### PR TITLE
Experimental REST endpoint to open an AppMap file

### DIFF
--- a/src/main/java/appland/rest/ApplandHttpRequestHandler.java
+++ b/src/main/java/appland/rest/ApplandHttpRequestHandler.java
@@ -1,0 +1,76 @@
+package appland.rest;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.ide.RestService;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Provides a custom REST handler at http://localhost:63343/api/appland
+ * If 63343 is already taken, then try the next few ports, e.g. 63344.
+ */
+public class ApplandHttpRequestHandler extends RestService {
+    @NotNull
+    @Override
+    protected String getServiceName() {
+        return "appland";
+    }
+
+    @Nullable
+    @Override
+    public String execute(@NotNull QueryStringDecoder urlDecoder,
+                          @NotNull FullHttpRequest request,
+                          @NotNull ChannelHandlerContext channelHandlerContext) throws IOException {
+
+        var uriParam = urlDecoder.parameters().get("uri");
+        if (uriParam == null || uriParam.size() != 1) {
+            sendStatus(HttpResponseStatus.BAD_REQUEST, false, channelHandlerContext.channel());
+            return Companion.parameterMissedErrorMessage("uri");
+        }
+
+        var uri = uriParam.get(0);
+        if (StringUtil.isEmptyOrSpaces(uri)) {
+            sendStatus(HttpResponseStatus.BAD_REQUEST, false, channelHandlerContext.channel());
+            return Companion.parameterMissedErrorMessage("uri");
+        }
+
+/*        var stateParam = urlDecoder.parameters().get("state");
+        if (stateParam == null || stateParam.size() != 1) {
+            sendStatus(HttpResponseStatus.BAD_REQUEST, false, channelHandlerContext.channel());
+            return Companion.parameterMissedErrorMessage("state");
+        }*/
+
+        var systemIndependentPath = FileUtil.toSystemIndependentName(FileUtil.expandUserHome(uri));
+        var file = Paths.get(FileUtil.toSystemDependentName(systemIndependentPath));
+        var vFile = LocalFileSystem.getInstance().findFileByNioFile(file);
+        if (vFile == null) {
+            sendStatus(HttpResponseStatus.NOT_FOUND, false, channelHandlerContext.channel());
+            return null;
+        }
+
+        var project = getLastFocusedOrOpenedProject();
+        if (project == null) {
+            project = ProjectManager.getInstance().getDefaultProject();
+        }
+
+        var openFileRequest = new OpenFileDescriptor(project, vFile);
+        ApplicationManager.getApplication().invokeLater(() -> {
+            openFileRequest.navigate(true);
+        });
+
+        sendOk(request, channelHandlerContext);
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,8 @@
                              instance="appland.settings.AppMapProjectConfigurable"/>
 
         <errorHandler implementation="appland.GitHubErrorHandler"/>
+
+        <httpRequestHandler implementation="appland.rest.ApplandHttpRequestHandler"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Please note, that this is still in an experimental state.

Example URL:
http://localhost:63342/api/appland?uri=/Users/user/dir/file.appmap
http://localhost:63343/api/appland?uri=/Users/user/dir/file.appmap
Try a few more ports if the above isn't working for you

Existing URL handler of JetBrains IDEs for testing:
http://localhost:63342/api/about
http://localhost:63343/api/about

ToDo:
- [ ] Restrict to *.appmap files and the corresponding internal file type
- [ ] Restrict to requests with a state query parameter (?)
- [ ] If possible, restrict to a strict set of referrers, e.g. http://localhost and https://app.land/
- [ ] Support relative file paths, locate them in the current project (?)
- [ ] Validate the state query parameter and pass it to the AppLand app, which is launched for the opened file.
- [ ] Test and implement support for Windows. It's currently unclear which file paths AppLand would send on Windows