### PR TITLE
Fix `verifyPlugin`

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -54,7 +54,7 @@ plugins:
     - CHANGELOG.md
     - gradle.properties
 - - '@semantic-release/exec'
-  - publishCmd: ./gradlew clean build
+  - publishCmd: ./gradlew clean build verifyPlugin
 - - '@semantic-release/github'
   - assets:
     - build/distributions/intellij-appmap-*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - source "/home/travis/.sdkman/bin/sdkman-init.sh"
     - sdk install java 11.0.2-open
     - export APP_MAP_JDK="$(sdk home java 11.0.2-open)"
-    - ./gradlew build
+    - ./gradlew build verifyPlugin
 
 before_deploy:
 - |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,10 @@ allprojects {
             systemProperty("appmap.sandbox", "true")
         }
 
+        verifyPlugin {
+            onlyIf { this.project == rootProject }
+        }
+
         withType<PrepareSandboxTask> {
             dependsOn(":copyPluginAssets")
             from("${rootProject.buildDir}/appmap-assets") {


### PR DESCRIPTION
Reverts the commit which removed `verifyPlugin` and fixes the gradle setup to only execute `verifyPlugin` for the main module, which is published.