### PR TITLE
fix: Emit appmap:create events

### DIFF
--- a/plugin-core/src/main/java/appland/files/AppMapAsyncFileListener.java
+++ b/plugin-core/src/main/java/appland/files/AppMapAsyncFileListener.java
@@ -12,8 +12,6 @@ import java.util.stream.Collectors;
 
 /**
  * Async file listener to notify about changes to .appmap.json files.
- * We don't react to changes from a file system refresh.
- * {@link  VirtualFileManagerLister} is taking care of refresh events.
  */
 @SuppressWarnings("UnstableApiUsage")
 public class AppMapAsyncFileListener implements AsyncFileListener {
@@ -40,10 +38,6 @@ public class AppMapAsyncFileListener implements AsyncFileListener {
     }
 
     private static boolean isAppMapFileChange(@NotNull VFileEvent event) {
-        if (event.isFromRefresh()) {
-            return false;
-        }
-
         // only treat renames as valid property changes
         if (event instanceof VFilePropertyChangeEvent) {
             if (!((VFilePropertyChangeEvent) event).isRename()) {

--- a/plugin-core/src/main/java/appland/telemetry/AppMapRecordListener.java
+++ b/plugin-core/src/main/java/appland/telemetry/AppMapRecordListener.java
@@ -12,7 +12,7 @@ public class AppMapRecordListener implements AppMapFileChangeListener {
 
     @Override
     public void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes) {
-        if (!changeTypes.contains(AppMapFileEventType.Create) || !changeTypes.contains(AppMapFileEventType.Modify)) {
+        if (!changeTypes.contains(AppMapFileEventType.Create) && !changeTypes.contains(AppMapFileEventType.Modify)) {
             return;
         }
 


### PR DESCRIPTION
All the file events were coming through as refresh, so no notifications containing create/modify events would ever fire. `AppMapAsyncFileListener` had appeared to be unused due to this.