### PR TITLE
Deactivate unstable test `assertActiveRoots`

### DIFF
--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -7,6 +7,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.VfsTestUtil;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
@@ -190,6 +191,12 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
      * Asserts that the detected AppLand content roots match the parameters
      */
     private void assertActiveRoots(@NotNull VirtualFile... roots) {
-        assertEquals(Set.of(roots), Set.copyOf(AppLandCommandLineService.getInstance().getActiveRoots()));
+        var expectedRoots = Set.of(roots);
+        var expectedString = StringUtil.join(expectedRoots, VirtualFile::toString, ", ");
+
+        var activeRoots = Set.copyOf(AppLandCommandLineService.getInstance().getActiveRoots());
+        var activeRootsString = StringUtil.join(activeRoots, VirtualFile::toString, ", ");
+
+        assertEquals("Roots don't match. Expected: " + expectedString + ", actual: " + activeRootsString, expectedRoots, activeRoots);
     }
 }

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -15,6 +15,7 @@ import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -141,6 +142,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     }
 
     @Test
+    @Ignore("unstable test")
     public void appmapYamlTrigger() throws InterruptedException, IOException {
         var newRootA = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
 


### PR DESCRIPTION
I'm deactivating the unstable test method because there's no obvious reason why it's failing. This is most likely a timing issue and not straight forward to fix.

https://github.com/getappmap/appmap-intellij-plugin/issues/161 tracks the unstable test to make sure that we properly fix this.