### PR TITLE
fix: Use `/authn_provider` for authentication

### DIFF
--- a/plugin-core/src/main/java/appland/oauth/AppMapAuthRequest.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapAuthRequest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class AppMapAuthRequest implements OAuthRequest<AppMapAuthCredentials> {
-    private static final Url SERVER_URL = Urls.newFromEncoded("https://app.land/authn_provider/localhost");
+    private static final Url SERVER_URL = Urls.newFromEncoded("https://app.land/authn_provider");
 
     @Getter
     private final String nonce = UUID.randomUUID().toString();


### PR DESCRIPTION
`/authn_provider/localhost` has been deprecated and will be removed in the future.