### PR TITLE
feat: Implement "Generate OpenAPI"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ allprojects {
 
     val testOutput = configurations.create("testOutput")
     dependencies {
+        // for compatibility with IntelliJ Ultimate, IU-2021.3.3 doesn't include this for unknown reasons
+        compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+
         // http://wiremock.org, Apache 2 license
         testImplementation("com.github.tomakehurst:wiremock-jre8:2.33.1")
 

--- a/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
+++ b/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
@@ -132,11 +132,11 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
                             }
                         });
                     } else {
-                        // fixme show message for timeout or cancelled
-                        LOG.debug("Operation was cancelled or timed out");
+                        sendErrorTelemetry();
                     }
                 } catch (ExecutionException e) {
-                    throw new RuntimeException(e);
+                    LOG.debug("Error executing command: " + commandLine.getCommandLineString(), e);
+                    sendErrorTelemetry();
                 }
             }
         }.queue();
@@ -158,5 +158,9 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
                 return data.property("appmap.project.language", languageId);
             });
         });
+    }
+
+    private static void sendErrorTelemetry() {
+        TelemetryService.getInstance().sendEvent("open_api:failure");
     }
 }

--- a/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
+++ b/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
@@ -1,0 +1,141 @@
+package appland.actions;
+
+import appland.AppMapBundle;
+import appland.cli.AppLandCommandLineService;
+import appland.settings.AppMapProjectSettingsService;
+import appland.telemetry.TelemetryService;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.process.CapturingProcessHandler;
+import com.intellij.ide.actions.OpenInRightSplitAction;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.vcs.changes.ui.VirtualFileListCellRenderer;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.concurrency.annotations.RequiresEdt;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Generates an OpenAPI file using the CLI tool.
+ */
+public class GenerateOpenApiAction extends AnAction implements DumbAware {
+    private static final Logger LOG = Logger.getInstance(GenerateOpenApiAction.class);
+    private static final String APPMAP_OPENAPI_FILENAME = "appmap-openapi.yml";
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        createOpenApiFileInteractive(Objects.requireNonNull(e.getProject()), false);
+    }
+
+    /**
+     * Creates an OpenAPI file with user interaction.
+     * If no AppMap directory is available, then an error message will be displayed.
+     * If there's exactly one AppMap directory in the project, then no further user interaction happens.
+     * If there's more than one AppMap directory in the current project, then a popup will be shown to let the user choose one.
+     * <p>
+     * After the file was created, the result is shown in a new editor.
+     *
+     * @param project           The current project
+     * @param showInSplitEditor If the result file should be opened in a split editor
+     */
+    @RequiresEdt
+    public static void createOpenApiFileInteractive(@NotNull Project project, boolean showInSplitEditor) {
+        var commandLineService = AppLandCommandLineService.getInstance();
+        var roots = commandLineService.getActiveRoots();
+
+        if (roots.isEmpty()) {
+            Messages.showInfoMessage(project,
+                    AppMapBundle.get("action.appmap.generateOpenAPI.noRootMessage.text"),
+                    AppMapBundle.get("action.appmap.generateOpenAPI.noRootMessage.title"));
+        } else if (roots.size() == 1) {
+            createOpenApiFile(project, roots.get(0), showInSplitEditor);
+        } else {
+            //noinspection RedundantCast,unchecked
+            JBPopupFactory.getInstance()
+                    .createPopupChooserBuilder(roots)
+                    .setRenderer((ListCellRenderer<VirtualFile>) new VirtualFileListCellRenderer(project))
+                    .setTitle(AppMapBundle.get("action.appmap.generateOpenAPI.rootChooser.title"))
+                    .setMovable(false)
+                    .setResizable(false)
+                    .setRequestFocus(true)
+                    .setItemChosenCallback(root -> createOpenApiFile(project, root, showInSplitEditor))
+                    .createPopup()
+                    .showInFocusCenter();
+        }
+    }
+
+    @RequiresEdt
+    public static void createOpenApiFile(@NotNull Project project, @NotNull VirtualFile projectRoot, boolean showInSplitEditor) {
+        var commandLine = AppLandCommandLineService.getInstance().createGenerateOpenApiCommand(projectRoot);
+        if (commandLine == null) {
+            LOG.debug("Unable to create command line, e.g. because CLI tool is missing.");
+            return;
+        }
+
+        // run command in background and show the new result file in a new editor
+        new Task.Modal(project, AppMapBundle.get("action.appmap.generateOpenAPI.task.title"), true) {
+            private volatile VirtualFile openApiFile;
+
+            @Override
+            public void onSuccess() {
+                if (openApiFile != null) {
+                    var editorManager = FileEditorManager.getInstance(project);
+                    if (showInSplitEditor && editorManager.getSelectedEditor() != null) {
+                        OpenInRightSplitAction.Companion.openInRightSplit(project, openApiFile, null, true);
+                    } else {
+                        editorManager.openFile(openApiFile, true);
+                    }
+
+                    // send telemetry after successful operation
+                    // fixme(jansorg): add property "appmap.project.language"
+                    TelemetryService.getInstance().sendEvent("open_api:generate");
+                }
+            }
+
+            @Override
+            public void onFinished() {
+                AppMapProjectSettingsService.getState(project).setCreatedOpenAPI(project, true);
+            }
+
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                try {
+                    var handler = new CapturingProcessHandler(commandLine);
+                    var timeout = (int) TimeUnit.SECONDS.toMillis(30);
+                    var output = handler.runProcessWithProgressIndicator(indicator, timeout, true);
+                    if (output.getExitCode() == 0) {
+                        openApiFile = WriteAction.computeAndWait(() -> {
+                            try {
+                                var file = projectRoot.createChildData(this, APPMAP_OPENAPI_FILENAME);
+                                VfsUtil.saveText(file, output.getStdout());
+                                return file;
+                            } catch (IOException e) {
+                                LOG.error(e);
+                                return null;
+                            }
+                        });
+                    } else {
+                        // fixme show message for timeout or cancelled
+                        LOG.debug("Operation was cancelled or timed out");
+                    }
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }.queue();
+    }
+}

--- a/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
+++ b/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
@@ -108,7 +108,7 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
 
             @Override
             public void onFinished() {
-                AppMapProjectSettingsService.getState(project).setCreatedOpenAPI(project, true);
+                AppMapProjectSettingsService.getState(project).setCreatedOpenAPI(true);
             }
 
             @Override

--- a/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
@@ -69,4 +69,12 @@ public interface AppLandCommandLineService extends Disposable {
      * @return The command line or {@code null} if the CLI is unavailable
      */
     @Nullable GeneralCommandLine createInstallCommand(@NotNull Path path, @NotNull String language);
+
+    /**
+     * Creates the command line to generate an OpenAPI file for a given workspace directory.
+     *
+     * @param projectRoot Project path
+     * @return The command line or {@code null} if the CLI is unavailable
+     */
+    @Nullable GeneralCommandLine createGenerateOpenApiCommand(@NotNull VirtualFile projectRoot);
 }

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -165,6 +165,30 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         return cmd;
     }
 
+    @Override
+    public @Nullable GeneralCommandLine createGenerateOpenApiCommand(@NotNull VirtualFile projectRoot) {
+        var toolPath = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap);
+        if (toolPath == null || Files.notExists(toolPath)) {
+            LOG.debug("CLI executable not found: " + toolPath);
+            return null;
+        }
+
+        var localPath = projectRoot.getFileSystem().getNioPath(projectRoot);
+        if (localPath == null) {
+            LOG.debug("Project root is not on the local filesystem", projectRoot);
+            return null;
+        }
+
+        var cmd = new PtyCommandLine();
+        cmd.withExePath(toolPath.toString());
+        cmd.withParameters("openapi", "--appmap-dir", localPath.toString());
+        cmd.withConsoleMode(false);
+        cmd.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
+
+        LOG.debug("AppMap OpenAPI command line " + cmd.getCommandLineString());
+        return cmd;
+    }
+
     private void stopLocked(@NotNull CliProcesses value) {
         try {
             shutdownInBackground(value.indexer);

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -274,9 +274,9 @@ public class InstallGuideEditor extends UserDataHolderBase implements FileEditor
 
                             ApplicationManager.getApplication().invokeLater(() -> {
                                 if (appMapRoot != null) {
-                                    GenerateOpenApiAction.createOpenApiFile(project, appMapRoot, true);
+                                    GenerateOpenApiAction.createOpenApiFile(project, appMapRoot, false);
                                 } else {
-                                    GenerateOpenApiAction.createOpenApiFileInteractive(project, true);
+                                    GenerateOpenApiAction.createOpenApiFileInteractive(project, false);
                                 }
                             }, ModalityState.defaultModalityState());
                             break;

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -2,6 +2,7 @@ package appland.installGuide;
 
 import appland.AppMapBundle;
 import appland.AppMapPlugin;
+import appland.actions.GenerateOpenApiAction;
 import appland.cli.AppLandCommandLineService;
 import appland.index.AppMapMetadata;
 import appland.index.IndexedFileListenerUtil;
@@ -33,6 +34,7 @@ import com.intellij.ide.actions.runAnything.execution.RunAnythingRunProfile;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.impl.AsyncDataContext;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorLocation;
@@ -41,6 +43,7 @@ import com.intellij.openapi.fileEditor.FileEditorState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.UserDataHolderBase;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.terminal.TerminalExecutionConsole;
@@ -263,6 +266,22 @@ public class InstallGuideEditor extends UserDataHolderBase implements FileEditor
                             break;
                         }
 
+                        case "generate-openapi": {
+                            var projectPath = json.has("projectPath") ? json.getAsJsonPrimitive("projectPath").getAsString() : null;
+                            var appMapRoot = StringUtil.isNotEmpty(projectPath)
+                                    ? LocalFileSystem.getInstance().findFileByNioFile(Paths.get(projectPath))
+                                    : null;
+
+                            ApplicationManager.getApplication().invokeLater(() -> {
+                                if (appMapRoot != null) {
+                                    GenerateOpenApiAction.createOpenApiFile(project, appMapRoot, true);
+                                } else {
+                                    GenerateOpenApiAction.createOpenApiFileInteractive(project, true);
+                                }
+                            }, ModalityState.defaultModalityState());
+                            break;
+                        }
+
                         default:
                             LOG.warn("Unhandled message type: " + type);
                     }
@@ -321,12 +340,9 @@ public class InstallGuideEditor extends UserDataHolderBase implements FileEditor
         // this contains all necessary data for the components, calculated under progress
         var projects = findProjects();
 
-        var disabledPages = new JsonArray();
-        disabledPages.add("openapi");
-
         var json = createBasePropertiesMessage("init");
         json.add("projects", gson.toJsonTree(projects));
-        json.add("disabledPages", disabledPages);
+        json.add("disabledPages", new JsonArray());
         return json;
     }
 

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideViewPage.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideViewPage.java
@@ -1,7 +1,6 @@
 package appland.installGuide;
 
 import appland.AppMapBundle;
-import appland.settings.AppMapApplicationSettingsService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
@@ -11,6 +10,7 @@ public enum InstallGuideViewPage {
     InstallAgent("project-picker"),
     RecordAppMaps("record-appmaps"),
     OpenAppMaps("open-appmaps"),
+    GenerateOpenAPI("openapi"),
     RuntimeAnalysis("investigate-findings");
 
     // value used by the JS application as "page" values
@@ -25,6 +25,8 @@ public enum InstallGuideViewPage {
                 return AppMapBundle.get("installGuide.pageRecordAppMaps.title");
             case OpenAppMaps:
                 return AppMapBundle.get("installGuide.pageOpenAppMaps.title");
+            case GenerateOpenAPI:
+                return AppMapBundle.get("installGuide.pageGenerateOpenAPI.title");
             case RuntimeAnalysis:
                 return AppMapBundle.get("installGuide.pageRuntimeAnalysis.title");
             default:

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
@@ -1,8 +1,8 @@
 package appland.settings;
 
 import com.google.common.collect.Lists;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import com.intellij.openapi.application.ApplicationManager;
+import lombok.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,19 +12,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 @EqualsAndHashCode
 @ToString
+@Getter(onMethod_ = {@Synchronized})
+@Setter(onMethod_ = {@Synchronized})
 public class AppMapProjectSettings {
-    @Nullable
-    private List<String> recentRemoteRecordingURLs;
-    @Nullable
-    private String activeRecordingURL;
-    @Nullable
-    private String recentAppMapStorageLocation;
-    @Nullable
-    private String cloudServerUrl;
+    private @Nullable List<String> recentRemoteRecordingURLs;
+    private @Nullable String activeRecordingURL;
+    private @Nullable String recentAppMapStorageLocation;
+    private @Nullable String cloudServerUrl;
     private boolean confirmAppMapUpload = true;
     private boolean openedAppMapEditor = false;
     private boolean createdOpenAPI = false;
 
+    @SuppressWarnings("unused")
     public AppMapProjectSettings() {
     }
 
@@ -74,45 +73,20 @@ public class AppMapProjectSettings {
         this.recentRemoteRecordingURLs.add(0, url);
     }
 
-    @Nullable
-    public synchronized String getActiveRecordingURL() {
-        return activeRecordingURL;
+    public void setCreatedOpenAPI(boolean createdOpenAPI) {
+        boolean changed;
+        synchronized (this) {
+            changed = this.createdOpenAPI != createdOpenAPI;
+            this.createdOpenAPI = createdOpenAPI;
+        }
+
+        if (changed) {
+            settingsPublisher().createOpenApiChanged();
+        }
     }
 
-    public synchronized void setActiveRecordingURL(@Nullable String activeRecordingURL) {
-        this.activeRecordingURL = activeRecordingURL;
-    }
-
-    public synchronized boolean getConfirmAppMapUpload() {
-        return confirmAppMapUpload;
-    }
-
-    public synchronized void setConfirmAppMapUpload(boolean confirmAppMapUpload) {
-        this.confirmAppMapUpload = confirmAppMapUpload;
-    }
-
-    @Nullable
-    public synchronized String getCloudServerUrl() {
-        return cloudServerUrl;
-    }
-
-    public synchronized void setCloudServerUrl(@Nullable String cloudServerUrl) {
-        this.cloudServerUrl = cloudServerUrl;
-    }
-
-    public synchronized boolean isOpenedAppMapEditor() {
-        return openedAppMapEditor;
-    }
-
-    public synchronized void setOpenedAppMapEditor(boolean openedAppMapEditor) {
-        this.openedAppMapEditor = openedAppMapEditor;
-    }
-
-    public synchronized boolean isCreatedOpenAPI() {
-        return createdOpenAPI;
-    }
-
-    public synchronized void setCreatedOpenAPI(boolean createdOpenAPI) {
-        this.createdOpenAPI = createdOpenAPI;
+    @NotNull
+    private AppMapSettingsListener settingsPublisher() {
+        return ApplicationManager.getApplication().getMessageBus().syncPublisher(AppMapSettingsListener.TOPIC);
     }
 }

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
@@ -23,6 +23,7 @@ public class AppMapProjectSettings {
     private String cloudServerUrl;
     private boolean confirmAppMapUpload = true;
     private boolean openedAppMapEditor = false;
+    private boolean createdOpenAPI = false;
 
     public AppMapProjectSettings() {
     }
@@ -39,6 +40,7 @@ public class AppMapProjectSettings {
         this.cloudServerUrl = settings.cloudServerUrl;
         this.confirmAppMapUpload = settings.confirmAppMapUpload;
         this.openedAppMapEditor = settings.openedAppMapEditor;
+        this.createdOpenAPI = settings.createdOpenAPI;
     }
 
     @NotNull
@@ -104,5 +106,13 @@ public class AppMapProjectSettings {
 
     public synchronized void setOpenedAppMapEditor(boolean openedAppMapEditor) {
         this.openedAppMapEditor = openedAppMapEditor;
+    }
+
+    public synchronized boolean isCreatedOpenAPI() {
+        return createdOpenAPI;
+    }
+
+    public synchronized void setCreatedOpenAPI(boolean createdOpenAPI) {
+        this.createdOpenAPI = createdOpenAPI;
     }
 }

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettingsForm.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettingsForm.java
@@ -27,7 +27,7 @@ class AppMapProjectSettingsForm {
     void loadSettingsFrom(@NotNull AppMapProjectSettings settings,
                           @NotNull AppMapApplicationSettings applicationSettings) {
         serverName.setText(settings.getCloudServerUrl());
-        confirmUpload.setSelected(settings.getConfirmAppMapUpload());
+        confirmUpload.setSelected(settings.isConfirmAppMapUpload());
 
         enableFindings.setSelected(applicationSettings.isEnableFindings());
         enableTelemetry.setSelected(applicationSettings.isEnableTelemetry());

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -4,7 +4,6 @@ import com.intellij.util.messages.Topic;
 
 public interface AppMapSettingsListener {
     @Topic.AppLevel
-    @Topic.ProjectLevel
     Topic<AppMapSettingsListener> TOPIC = Topic.create("AppMap settings change", AppMapSettingsListener.class);
 
     default void apiKeyChanged() {

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -4,11 +4,15 @@ import com.intellij.util.messages.Topic;
 
 public interface AppMapSettingsListener {
     @Topic.AppLevel
+    @Topic.ProjectLevel
     Topic<AppMapSettingsListener> TOPIC = Topic.create("AppMap settings change", AppMapSettingsListener.class);
 
     default void apiKeyChanged() {
     }
 
     default void enableFindingsChanged() {
+    }
+
+    default void createOpenApiChanged() {
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
@@ -128,6 +128,7 @@ public class InstallGuidePanel extends JPanel implements Disposable {
                             updateGenerateOpenApiLabel(project, label);
                         }
                     });
+                    break;
 
                 case RuntimeAnalysis:
                     project.getMessageBus().connect(parent).subscribe(ScannerFindingsListener.TOPIC, new ScannerFindingsListener() {

--- a/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
@@ -121,6 +121,14 @@ public class InstallGuidePanel extends JPanel implements Disposable {
                     });
                     break;
 
+                case GenerateOpenAPI:
+                    connection.subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsListener() {
+                        @Override
+                        public void createOpenApiChanged() {
+                            updateGenerateOpenApiLabel(project, label);
+                        }
+                    });
+
                 case RuntimeAnalysis:
                     project.getMessageBus().connect(parent).subscribe(ScannerFindingsListener.TOPIC, new ScannerFindingsListener() {
                         @Override
@@ -150,6 +158,10 @@ public class InstallGuidePanel extends JPanel implements Disposable {
 
             case OpenAppMaps:
                 updateOpenAppMapsLabel(project, label);
+                break;
+
+            case GenerateOpenAPI:
+                updateGenerateOpenApiLabel(project, label);
                 break;
 
             case RuntimeAnalysis:
@@ -196,6 +208,12 @@ public class InstallGuidePanel extends JPanel implements Disposable {
      */
     private static void updateOpenAppMapsLabel(@NotNull Project project, @NotNull StatusLabel label) {
         label.setStatus(AppMapProjectSettingsService.getState(project).isOpenedAppMapEditor()
+                ? InstallGuideStatus.Completed
+                : InstallGuideStatus.Incomplete);
+    }
+
+    private static void updateGenerateOpenApiLabel(@NotNull Project project, @NotNull StatusLabel label) {
+        label.setStatus(AppMapProjectSettingsService.getState(project).isCreatedOpenAPI()
                 ? InstallGuideStatus.Completed
                 : InstallGuideStatus.Incomplete);
     }

--- a/plugin-core/src/main/java/appland/upload/AppMapUploader.java
+++ b/plugin-core/src/main/java/appland/upload/AppMapUploader.java
@@ -45,7 +45,7 @@ public class AppMapUploader {
     public static void uploadAppMap(@NotNull Project project, @NotNull VirtualFile file, @NotNull Consumer<String> urlConsumer) {
         ApplicationManager.getApplication().assertIsDispatchThread();
 
-        if (AppMapProjectSettingsService.getState(project).getConfirmAppMapUpload()) {
+        if (AppMapProjectSettingsService.getState(project).isConfirmAppMapUpload()) {
             var reply = Messages.showOkCancelDialog(project,
                     AppMapBundle.get("upload.confirmation.message"),
                     AppMapBundle.get("upload.confirmation.title"),

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -113,6 +113,8 @@
         <action id="showRecentAppmap" class="appland.actions.OpenRecentAppMapAction"/>
         <action id="startAppMapRemoteRecording" class="appland.actions.StartAppMapRecordingAction"/>
         <action id="stopAppMapRemoteRecording" class="appland.actions.StopAppMapRecordingAction"/>
+
+        <action id="appmap.generateOpenAPI" class="appland.actions.GenerateOpenApiAction"/>
         <!--
         <action id="uploadAppMap" class="appland.actions.UploadAppMapAction"/>
         -->
@@ -126,6 +128,8 @@
             <separator/> -->
             <reference ref="startAppMapRemoteRecording"/>
             <reference ref="stopAppMapRemoteRecording"/>
+            <separator/>
+            <reference ref="appmap.generateOpenAPI"/>
             <separator/>
             <reference ref="appMapLogin"/>
             <reference ref="appMapLogout"/>

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -17,6 +17,13 @@ action.appMapLogin.description=Open a browser window to authenticate with the Ap
 action.appMapLogout.text=Sign Out From AppMap Server
 action.appMapLogout.description=Terminate your AppMap session.
 
+action.appmap.generateOpenAPI.text=Generate OpenAPI
+action.appmap.generateOpenAPI.description=Generates an OpenAPI file from the recorded AppMaps.
+action.appmap.generateOpenAPI.noRootMessage.title=No AppMaps Found
+action.appmap.generateOpenAPI.noRootMessage.text=No directory containing AppMaps found in your project. Please ensure that you have at least one valid appmap.yml file and AppMap files in your project.
+action.appmap.generateOpenAPI.task.title=Generating OpenAPI File...
+action.appmap.generateOpenAPI.rootChooser.title=Choose AppMap Directory
+
 group.appmapToolsMenu.text=AppMap
 group.appmapToolsMenu.title=AppMap Tools
 
@@ -92,6 +99,7 @@ installGuide.editor.title=Using AppMap
 installGuide.pageInstallAgent.title=Install AppMap Agent
 installGuide.pageRecordAppMaps.title=Record AppMaps
 installGuide.pageOpenAppMaps.title=Explore AppMaps
+installGuide.pageGenerateOpenAPI.title=Generate OpenAPI
 installGuide.pageRuntimeAnalysis.title=Runtime Analysis
 
 cliDownload.progress.title=Downloading {0}...

--- a/plugin-core/src/test/java/appland/upload/AppMapUploaderTest.java
+++ b/plugin-core/src/test/java/appland/upload/AppMapUploaderTest.java
@@ -26,7 +26,7 @@ public class AppMapUploaderTest extends AppMapBaseTest {
         var appmapFile = myFixture.configureByText("sample.appmap.json", "{\"version\": \"1.5.1\"}");
 
         var projectSettings = AppMapProjectSettingsService.getState(getProject());
-        var oldConfirmUpload = projectSettings.getConfirmAppMapUpload();
+        var oldConfirmUpload = projectSettings.isConfirmAppMapUpload();
         try {
             projectSettings.setCloudServerUrl(serverRule.baseUrl());
             projectSettings.setConfirmAppMapUpload(false);


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/163

Still missing:
- [x] Mark step as completed when the user invoked the "Create OpenAPI" action at least once
- [x] Properly pass "projectPath" from the webview to the Install Guide editor
- [x] Send telemetry
- [x] Open a split editor if executed from the webview
- [x] Update step "Generate OpenAPI" in tool window after an OpenAPI file was created
- [x] Add telemetry property for the project language, reuse language analyzers
- [x] Send error telemetry when "Generate OpenAPI" failed
- [x] Remove split editor
- [x] Review English messages
