### PR TITLE
Pre-release tweaks: upgrade the AppMap agent and specify an authentication source during login

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ ideVersionVerifier=IC-2021.3,IC-2022.1.3
 
 lombokVersion=1.18.24
 
-appMapJvmAgent=1.15.1
+appMapJvmAgent=1.15.2
 
 # alternative versions to simplify development and testing
 #ideVersion=IC-2022.1.3

--- a/plugin-core/src/main/java/appland/execution/AppMapJvmExecutor.java
+++ b/plugin-core/src/main/java/appland/execution/AppMapJvmExecutor.java
@@ -27,7 +27,7 @@ import javax.swing.*;
 public class AppMapJvmExecutor extends Executor {
     public static final String EXECUTOR_ID = "AppMap";
     // latest version of Java, which is supported by the AppMap JVM agent
-    private static final int LATEST_SUPPORTED_JAVA_VERSION = 11;
+    private static final int LATEST_SUPPORTED_JAVA_VERSION = 17;
 
     public static @NotNull Executor getInstance() {
         var executor = ExecutorRegistry.getInstance().getExecutorById(EXECUTOR_ID);

--- a/plugin-core/src/main/java/appland/oauth/AppMapAuthRequest.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapAuthRequest.java
@@ -22,7 +22,7 @@ public class AppMapAuthRequest implements OAuthRequest<AppMapAuthCredentials> {
     @Override
     public Url getAuthUrlWithParameters() {
         var callbackUrl = getAuthorizationCodeUrl().addParameters(Map.of("nonce", nonce)).toExternalForm();
-        return SERVER_URL.addParameters(Map.of("redirect_url", callbackUrl));
+        return SERVER_URL.addParameters(Map.of("redirect_url", callbackUrl, "source", "JetBrains"));
     }
 
     @NotNull


### PR DESCRIPTION
This change:
- Bumps the bundled AppMap agent version to latest
- Adds a parameter to the authentication request indicating the source of the authentication (`JetBrains`). This is used by the backend to determine the description of a users API key.