### PR TITLE
Update build to help with debugging CI errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,12 @@ allprojects {
             systemProperty("appland.testDataPath", rootProject.rootDir.resolve("src/test/data").path)
             // to allow tests to access the custom Java 11 JDK
             systemProperties["NO_FS_ROOTS_ACCESS_CHECK"] = true
+
+            if (isCI) {
+                testLogging {
+                    setEvents(listOf("failed", "standardError"))
+                }
+            }
         }
 
         withType<RunPluginVerifierTask> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.8.1"
+    id("org.jetbrains.intellij") version "1.10.1"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ appMapJvmAgent=1.15.4
 # alternative versions to simplify development and testing
 #ideVersion=IC-2022.1.3
 #ideVersion=IC-2022.2.3
-#ideVersion=IC-223.4884.69-EAP-SNAPSHOT
+#ideVersion=IC-2022.3


### PR DESCRIPTION
Updates the build setup to use the latest gradle-intellij plugin (always recommended) and adds more logging to STDOUT on Travis to help debug failing tests.