### PR TITLE
Locate source file in background thread inside a ReadAction

### DIFF
--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -1,6 +1,9 @@
 appmap.editor.name=AppMap
 appmap.editor.unavailableWarning=Interactive AppMap viewer is not available with the configured JDK. Please switch to the default JetBrains JDK for AppMap to work.
 
+appmap.editor.showSourceFileMissing.title=AppMap
+appmap.editor.showSourceFileMissing.text=File {0} could not be found.
+
 action.showRecentAppmap.text=AppMap: Open the Most Recently Modified AppMap
 action.showRecentAppmap.description=Locate and open the most recently modified AppMap inside of your project files.
 action.showRecentAppmap.notFoundErrorTitle=No AppMap Found


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/139
Needs #189 , because that PR refactors the code updated by this PR.

This PR fixes an exception, which occurred when a user clicked "Show source" inside an AppMap editor.