### PR TITLE
Improve "Stop remote recording" action

### DIFF
--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -1,17 +1,19 @@
 package appland.actions;
 
+import appland.AppMapBundle;
 import appland.Icons;
 import appland.notifications.AppMapNotifications;
 import appland.remote.RemoteRecordingService;
 import appland.remote.RemoteRecordingStatusService;
 import appland.remote.StopRemoteRecordingDialog;
-import appland.settings.AppMapProjectSettings;
+import appland.remote.StopRemoteRecordingForm;
 import appland.settings.AppMapProjectSettingsService;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
@@ -27,10 +29,11 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static appland.AppMapBundle.get;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class StopAppMapRecordingAction extends AnAction implements DumbAware {
+    private static final Logger LOG = Logger.getInstance(StopAppMapRecordingAction.class);
+
     public StopAppMapRecordingAction() {
         super(Icons.STOP_RECORDING_ACTION);
     }
@@ -55,27 +58,48 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
         var project = e.getProject();
         assert project != null;
 
-        var state = AppMapProjectSettingsService.getState(project);
-        var form = StopRemoteRecordingDialog.show(project,
-                findDefaultStorageLocation(project, state),
-                RemoteRecordingStatusService.getInstance(project).getActiveRecordingURL(),
-                state.getRecentRemoteRecordingURLs()
-        );
-        if (form == null) {
-            // user cancelled the form
-            return;
-        }
+        new Task.Modal(project, AppMapBundle.get("action.stopAppMapRemoteRecording.locationProgress.title"), true) {
+            private final AtomicReference<String> location = new AtomicReference<>();
 
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                if (project.isDisposed()) {
+                    return;
+                }
+
+                indicator.setText(AppMapBundle.get("action.stopAppMapRemoteRecording.locationProgress.progressTitle"));
+                location.set(findDefaultStorageLocation(project));
+            }
+
+            @Override
+            public void onSuccess() {
+                if (project.isDisposed()) {
+                    return;
+                }
+
+                var form = StopRemoteRecordingDialog.show(project,
+                        location.get(),
+                        RemoteRecordingStatusService.getInstance(project).getActiveRecordingURL(),
+                        AppMapProjectSettingsService.getState(project).getRecentRemoteRecordingURLs());
+                if (form != null) {
+                    stopAndSaveRemoteRecording(project, form);
+                }
+            }
+        }.queue();
+    }
+
+    private static void stopAndSaveRemoteRecording(@NotNull Project project, @NotNull StopRemoteRecordingForm form) {
         var storageDirectoryPath = form.getDirectoryLocation();
-        state.setRecentAppMapStorageLocation(storageDirectoryPath);
+        AppMapProjectSettingsService.getState(project).setRecentAppMapStorageLocation(storageDirectoryPath);
 
-        new Task.Backgroundable(project, get("action.stopAppMapRemoteRecording.progressTitle"), false) {
+        new Task.Backgroundable(project, AppMapBundle.get("action.stopAppMapRemoteRecording.progressTitle"), false) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 Path nioStoragePath;
                 try {
                     nioStoragePath = Paths.get(storageDirectoryPath);
-                } catch (InvalidPathException exception) {
+                } catch (InvalidPathException e) {
+                    LOG.debug("Invalid storage location", e);
                     showStopRecordingFailedError(project, form.getURL());
                     return;
                 }
@@ -101,8 +125,9 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
     /**
      * try to find a reasonable default for the storage location
      */
-    private static @Nullable String findDefaultStorageLocation(@NotNull Project project,
-                                                               @NotNull AppMapProjectSettings state) {
+    private static @Nullable String findDefaultStorageLocation(@NotNull Project project) {
+        var state = AppMapProjectSettingsService.getState(project);
+
         var storageLocation = state.getRecentAppMapStorageLocation();
         if (StringUtil.isEmpty(storageLocation)) {
             var projectDir = ProjectUtil.guessProjectDir(project);
@@ -116,8 +141,8 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
 
     private static void showStopRecordingFailedError(@NotNull Project project, @NotNull String url) {
         AppMapNotifications.showExpandedRecordingNotification(project,
-                get("notification.recordingStopFailed.title"),
-                get("notification.recordingStopFailed.content", url),
+                AppMapBundle.get("notification.recordingStopFailed.title"),
+                AppMapBundle.get("notification.recordingStopFailed.content", url),
                 NotificationType.ERROR, true, false, true);
     }
 }

--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -78,21 +78,22 @@ public final class AppMapFiles {
      *
      * @param appMapFile The path to the file
      * @param name       The new name
+     * @param charset    Charset of the AppMap file
      * @return {@code true} if the operation was successful
      */
-    public static boolean updateMetadata(@NotNull Path appMapFile, @NotNull String name) {
+    public static boolean updateMetadata(@NotNull Path appMapFile, @NotNull String name, @NotNull Charset charset) {
         try {
-            var json = GsonUtils.GSON.fromJson(Files.newBufferedReader(appMapFile, StandardCharsets.UTF_8), JsonObject.class);
+            var json = GsonUtils.GSON.fromJson(Files.newBufferedReader(appMapFile, charset), JsonObject.class);
             if (!json.has("metadata")) {
                 json.add("metadata", new JsonObject());
             }
             var metadata = json.getAsJsonObject("metadata");
             metadata.addProperty("name", name);
 
-            Files.write(appMapFile, GsonUtils.GSON.toJson(json).getBytes(StandardCharsets.UTF_8));
+            Files.write(appMapFile, GsonUtils.GSON.toJson(json).getBytes(charset));
             return true;
         } catch (IOException e) {
-            LOG.debug("error while updating AppMap metadata", e);
+            LOG.debug("error while updating AppMap metadata of " + appMapFile, e);
             return false;
         }
     }

--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -60,23 +60,23 @@ public final class AppMapFiles {
     }
 
     /**
-     * @param dir          Parent dir
-     * @param metadataName Descriptive name, used to calculate the filename
-     * @return A filename for a new appmap stored inside of dir.
+     * @param parentDirectoryPath Parent dir
+     * @param metadataName        Descriptive name, used to calculate the filename
+     * @return A filename for a new AppMap stored inside of dir.
      */
-    public static Path appMapFilename(@NotNull Path dir, @NotNull String metadataName) {
-        var filename = metadataName.replaceAll("[^a-zA-Z0-9]", "_");
+    public static @NotNull Path appMapFilename(@NotNull Path parentDirectoryPath, @NotNull String metadataName) {
         if (metadataName.isEmpty()) {
             throw new IllegalArgumentException("AppMap filename must not be empty");
         }
 
+        var filename = metadataName.replaceAll("[^a-zA-Z0-9]", "_");
         var candidate = String.format("%s.appmap.json", filename);
         var i = 1;
-        while (Files.exists(dir.resolve(candidate))) {
+        while (Files.exists(parentDirectoryPath.resolve(candidate))) {
             candidate = String.format("%s(%d).appmap.json", filename, i);
             i++;
         }
-        return dir.resolve(candidate);
+        return parentDirectoryPath.resolve(candidate);
     }
 
     /**

--- a/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
+++ b/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
@@ -71,9 +72,9 @@ public class DefaultRemoteRecordingService implements RemoteRecordingService {
             // throws a HttpStatusException for response status >= 400
             request.saveToFile(appMapFile, ProgressManager.getGlobalProgressIndicator());
 
-            // update metadata
-            var updated = AppMapFiles.updateMetadata(appMapFile, name);
-            return updated ? appMapFile : null;
+            AppMapFiles.updateMetadata(appMapFile, name, StandardCharsets.UTF_8);
+
+            return appMapFile;
         } catch (Exception e) {
             LOG.debug("exception retrieving AppMap data from remote server " + appMapServerUrl, e);
 

--- a/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
+++ b/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
@@ -60,7 +60,7 @@ public class DefaultRemoteRecordingService implements RemoteRecordingService {
         assert ProgressManager.getInstance().hasProgressIndicator();
 
         var appMapFile = AppMapFiles.appMapFilename(storageDirectoryPath, name);
-        LOG.debug("Stopping AppMap recording for base URL: " + baseURL + ", storing at %s", appMapFile);
+        LOG.debug(String.format("Stopping AppMap recording for base URL: %s, storing at %s", baseURL, appMapFile));
 
         var request = setupRequest(HttpRequests.delete(url(baseURL, URL_SUFFIX), HttpRequests.JSON_CONTENT_TYPE));
         try {

--- a/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
+++ b/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
@@ -59,10 +59,11 @@ public class DefaultRemoteRecordingService implements RemoteRecordingService {
         assertIsNotEDT();
         assert ProgressManager.getInstance().hasProgressIndicator();
 
+        var appMapServerUrl = url(baseURL, URL_SUFFIX);
         var appMapFile = AppMapFiles.appMapFilename(storageDirectoryPath, name);
-        LOG.debug(String.format("Stopping AppMap recording for base URL: %s, storing at %s", baseURL, appMapFile));
+        LOG.debug(String.format("Stopping AppMap recording for URL %s, storing at %s", appMapServerUrl, appMapFile));
 
-        var request = setupRequest(HttpRequests.delete(url(baseURL, URL_SUFFIX), HttpRequests.JSON_CONTENT_TYPE));
+        var request = setupRequest(HttpRequests.delete(appMapServerUrl, HttpRequests.JSON_CONTENT_TYPE));
         try {
             // stream to file on disk, it creates the necessary parent directories.
             // throws a HttpStatusException for response status >= 400

--- a/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
+++ b/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
@@ -55,16 +55,16 @@ public class DefaultRemoteRecordingService implements RemoteRecordingService {
     }
 
     @Override
-    public @Nullable Path stopRecording(@NotNull String baseURL, @NotNull Path parentDirPath, @NotNull String name) {
+    public @Nullable Path stopRecording(@NotNull String baseURL, @NotNull Path storageDirectoryPath, @NotNull String name) {
         assertIsNotEDT();
         assert ProgressManager.getInstance().hasProgressIndicator();
 
-        var appMapFile = AppMapFiles.appMapFilename(parentDirPath, name);
+        var appMapFile = AppMapFiles.appMapFilename(storageDirectoryPath, name);
         LOG.debug("Stopping AppMap recording for base URL: " + baseURL + ", storing at %s", appMapFile);
 
         var request = setupRequest(HttpRequests.delete(url(baseURL, URL_SUFFIX), HttpRequests.JSON_CONTENT_TYPE));
         try {
-            // stream to file on disk,
+            // stream to file on disk, it creates the necessary parent directories.
             // throws a HttpStatusException for response status >= 400
             request.saveToFile(appMapFile, ProgressManager.getGlobalProgressIndicator());
 

--- a/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
+++ b/plugin-core/src/main/java/appland/remote/DefaultRemoteRecordingService.java
@@ -13,6 +13,8 @@ import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
@@ -73,7 +75,14 @@ public class DefaultRemoteRecordingService implements RemoteRecordingService {
             var updated = AppMapFiles.updateMetadata(appMapFile, name);
             return updated ? appMapFile : null;
         } catch (Exception e) {
-            LOG.debug("exception retrieving recording status", e);
+            LOG.debug("exception retrieving AppMap data from remote server " + appMapServerUrl, e);
+
+            try {
+                // delete the AppMap file, because it may only contain some response data
+                Files.deleteIfExists(appMapFile);
+            } catch (IOException ex) {
+                // ignore
+            }
             return null;
         }
     }

--- a/plugin-core/src/main/java/appland/remote/RemoteRecordingService.java
+++ b/plugin-core/src/main/java/appland/remote/RemoteRecordingService.java
@@ -35,11 +35,10 @@ public interface RemoteRecordingService {
     /**
      * Stops AppMap remote recording
      *
-     * @param baseURL       The URL where the AppMap remote agent is installed.
-     * @param parentDirPath Path to the parent directory, where the AppMap is saved
-     * @param name          The name of the AppMap, as in "metadata.name" of the AppMap's JSON. It's also used for the filename
+     * @param baseURL              The URL where the AppMap remote agent is installed.
+     * @param storageDirectoryPath Path to the parent directory, where the AppMap is saved. The directory does not have to exist when this method is called.
+     * @param name                 The name of the AppMap, as in "metadata.name" of the AppMap's JSON. It's also used for the filename.
      * @return The path to the new file, if the operation was successful. {@code null} is returned if the operation failed.
      */
-    @Nullable
-    Path stopRecording(@NotNull String baseURL, @NotNull Path parentDirPath, @NotNull String name);
+    @Nullable Path stopRecording(@NotNull String baseURL, @NotNull Path storageDirectoryPath, @NotNull String name);
 }

--- a/plugin-core/src/main/java/appland/remote/StopRemoteRecordingDialog.java
+++ b/plugin-core/src/main/java/appland/remote/StopRemoteRecordingDialog.java
@@ -66,8 +66,12 @@ public class StopRemoteRecordingDialog extends DialogWrapper {
         }
 
         try {
-            if (!Files.isDirectory(Paths.get(form.getDirectoryLocation()))) {
-                return new ValidationInfo(AppMapBundle.get("dirPathValidation.notDir"), form.getDirectoryLocationInput());
+            var locationPath = Paths.get(form.getDirectoryLocation());
+            // if the directory does not yet exist, then we ignore it because the save implementation will create it
+            if (Files.exists(locationPath)) {
+                if (!Files.isDirectory(locationPath)) {
+                    return new ValidationInfo(AppMapBundle.get("dirPathValidation.notDir"), form.getDirectoryLocationInput());
+                }
             }
         } catch (Exception e) {
             return new ValidationInfo(AppMapBundle.get("dirPathValidation.invalidPath"), form.getDirectoryLocationInput());

--- a/plugin-core/src/main/java/appland/remote/StopRemoteRecordingForm.java
+++ b/plugin-core/src/main/java/appland/remote/StopRemoteRecordingForm.java
@@ -4,10 +4,12 @@ import appland.AppMapBundle;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.TextFieldWithHistory;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.SystemDependent;
 
 import javax.swing.*;
@@ -22,16 +24,23 @@ public class StopRemoteRecordingForm {
     private JBLabel appMapLocation;
     private TextFieldWithBrowseButton directoryLocationInput;
 
-    public StopRemoteRecordingForm(@NotNull Project project, @NotNull List<String> recentURLs, @NotNull String lastLocation) {
+    public StopRemoteRecordingForm(@NotNull Project project,
+                                   @Nullable String defaultStorageLocation,
+                                   @Nullable String activeRecordingUrl,
+                                   @NotNull List<String> recentRecordingUrls) {
         urlLabel.setText(AppMapBundle.get("appMapRemoteRecording.urlLabel"));
         appMapNameLabel.setText(AppMapBundle.get("appMapRemoteRecording.appMapNameLabel"));
         appMapLocation.setText(AppMapBundle.get("appMapRemoteRecording.locationLabel"));
-        urlComboBox.setHistory(recentURLs);
+
+        urlComboBox.setHistory(recentRecordingUrls);
+        if (StringUtil.isNotEmpty(activeRecordingUrl)) {
+            urlComboBox.setText(activeRecordingUrl);
+        }
 
         directoryLocationInput.addBrowseFolderListener(AppMapBundle.get("action.stopAppMapRemoteRecording.fileChooserTitle"),
                 null, project, new FileChooserDescriptor(false, true, false, false, false, false));
-        if (!lastLocation.isBlank()) {
-            directoryLocationInput.setText(lastLocation);
+        if (StringUtil.isNotEmpty(defaultStorageLocation)) {
+            directoryLocationInput.setText(defaultStorageLocation);
         }
     }
 

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -48,6 +48,8 @@ action.stopAppMapRemoteRecording.dialogTitle=Stop Remote Recording
 action.stopAppMapRemoteRecording.stopButton=Stop Recording
 action.stopAppMapRemoteRecording.fileChooserTitle=Choose AppMap Location
 action.stopAppMapRemoteRecording.progressTitle=Stopping recording...
+action.stopAppMapRemoteRecording.locationProgress.title=Stop Remote Recording
+action.stopAppMapRemoteRecording.locationProgress.progressTitle=Locating AppMap storage location...
 
 errorReporter.actionText=Report on GitHub
 
@@ -146,3 +148,4 @@ webview.findingDetails.locationNotFound.message=The source file could not be fou
 webview.findingDetails.appMapNotFound.title=AppMap Not Found
 webview.findingDetails.appMapNotFound.message=The AppMap file could not be found.
 toolwindow.appmap.runtimeAnalysis=Runtime Analysis
+

--- a/plugin-core/src/test/java/appland/actions/StopAppMapRecordingActionTest.java
+++ b/plugin-core/src/test/java/appland/actions/StopAppMapRecordingActionTest.java
@@ -1,0 +1,45 @@
+package appland.actions;
+
+import appland.AppMapBaseTest;
+import appland.settings.AppMapProjectSettingsService;
+import com.intellij.openapi.application.WriteAction;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+public class StopAppMapRecordingActionTest extends AppMapBaseTest {
+    @Before
+    @After
+    public void resetSettings() {
+        AppMapProjectSettingsService.getState(getProject()).setRecentAppMapStorageLocation("");
+    }
+
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
+    @Test
+    public void findDefaultStorageLocationSettings() {
+        AppMapProjectSettingsService.getState(getProject()).setRecentAppMapStorageLocation("/project/user/appMapDir");
+        assertEquals(Paths.get("/project/user/appMapDir"), StopAppMapRecordingAction.findDefaultStorageLocation(getProject()));
+    }
+
+    @Test
+    public void findDefaultStorageLocationConfig() {
+        edt(() -> WriteAction.run(() -> myFixture.copyDirectoryToProject("projects/empty-appMapDir", "root")));
+
+        var location = StopAppMapRecordingAction.findDefaultStorageLocation(getProject());
+        assertNotNull(location);
+        assertEquals("/src/root/tmp-appMapAgent/appmap/remote", location.toString());
+    }
+
+    @Test
+    public void findDefaultStorageLocationFallback() {
+        var location = StopAppMapRecordingAction.findDefaultStorageLocation(getProject());
+        assertNotNull(location);
+        assertEquals("/src/tmp/appmap/remote", location.toString());
+    }
+}

--- a/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
+++ b/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
@@ -23,7 +23,7 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
         var file = FileUtilRt.createTempFile("appmap-test", ".appmap.json").toPath();
         Files.write(file, "{}".getBytes(StandardCharsets.UTF_8));
 
-        var success = AppMapFiles.updateMetadata(file, "updated AppMap name");
+        var success = AppMapFiles.updateMetadata(file, "updated AppMap name", StandardCharsets.UTF_8);
         assertTrue(success);
         assertEquals("{\"metadata\":{\"name\":\"updated AppMap name\"}}", Files.readString(file));
     }
@@ -33,7 +33,7 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
         var file = FileUtilRt.createTempFile("appmap-test", ".appmap.json").toPath();
         Files.write(file, "{\"metadata\": {\"name\":\"old AppMap name\"}}".getBytes(StandardCharsets.UTF_8));
 
-        var success = AppMapFiles.updateMetadata(file, "updated AppMap name");
+        var success = AppMapFiles.updateMetadata(file, "updated AppMap name", StandardCharsets.UTF_8);
         assertTrue(success);
         assertEquals("{\"metadata\":{\"name\":\"updated AppMap name\"}}", Files.readString(file));
     }

--- a/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
+++ b/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
@@ -37,4 +37,22 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
         assertTrue(success);
         assertEquals("{\"metadata\":{\"name\":\"updated AppMap name\"}}", Files.readString(file));
     }
+
+    @Test
+    public void readAppMapDir() {
+        var configFile = myFixture.copyFileToProject("appmap-config/appmap.yml");
+        assertEquals("tmp/appmap", AppMapFiles.readAppMapDirConfigValue(configFile));
+    }
+
+    @Test
+    public void readAppMapDirEmptyValue() {
+        var configFile = myFixture.copyFileToProject("appmap-config/appmap-empty-dir.yml");
+        assertNull(AppMapFiles.readAppMapDirConfigValue(configFile));
+    }
+
+    @Test
+    public void readAppMapDirMissingValue() {
+        var configFile = myFixture.copyFileToProject("appmap-config/appmap-no-dir.yml");
+        assertNull(AppMapFiles.readAppMapDirConfigValue(configFile));
+    }
 }

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -12,7 +12,6 @@ import com.intellij.psi.JavaDirectoryService;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiPackage;
-import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.GlobalSearchScopesCore;
 import com.intellij.util.EmptyConsumer;
@@ -89,8 +88,8 @@ public final class AppMapJavaPackageConfig {
     private static @Nullable VirtualFile findAppMapConfig(@NotNull Project project,
                                                           @NotNull GlobalSearchScope runProfileScope) {
         return ReadAction.compute(() -> {
-            var files = FilenameIndex.getFilesByName(project, AppMapFiles.APPMAP_YML, runProfileScope);
-            return files.length == 1 ? files[0].getVirtualFile() : null;
+            var files = AppMapFiles.findAppMapConfigFiles(project, runProfileScope);
+            return files.size() == 1 ? files.iterator().next() : null;
         });
     }
 

--- a/src/test/data/appmap-config/appmap-empty-dir.yml
+++ b/src/test/data/appmap-config/appmap-empty-dir.yml
@@ -1,0 +1,12 @@
+name: sample_app_6th_ed
+packages:
+    -   path: app
+    -   path: lib
+language: ruby
+appmap_dir:
+test_recording:
+    test_commands:
+        -   env:
+                APPMAP: 'true'
+                DISABLE_SPRING: 'true'
+            command: bundle exec rails test

--- a/src/test/data/projects/empty-appMapDir/appmap.yml
+++ b/src/test/data/projects/empty-appMapDir/appmap.yml
@@ -1,0 +1,13 @@
+name: spring-petclinic-appMapDir
+appmap_dir: tmp-appMapAgent/appmap
+packages:
+- path: db.h2
+- path: db.hsqldb
+- path: db.mysql
+- path: db.postgres
+- path: messages
+- path: org.springframework.samples.petclinic
+- path: static.resources.css
+- path: static.resources.fonts
+- path: static.resources.images
+- path: templates


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/146
Best reviewed commit by commit.

You can test this by doing a remote recording, e.g. via `Tools > AppLand > ...`. The stop action should pick up the right location the first time it's invoked in a project.

- Cleanup of the code and fix a few minor issues of "stop remote recording". The code needed some care...
- Refactoring to allow fetching the default storage location in the background
- Don't terminate early in "Stop remote recording" if the update of the AppMap name failed (e.g. due to an unknown or invalid encoding of the retrieved AppMap)
- Update the default location of recorded AppMap

The location is now calculated like this:
1. The last used location of "Stop AppMap recording". I retained the old logic, but this can be removed, if necessary
2. The location configured in the project's `appmap.yml` file. If there's more than one `appmap.yml` then the config files are ignores. There's no context to decide which config file to use. Append `remote` to the configured path.
3. Use `projectBaseDir/temp/appmap/remote` as fallback

Questions:
- Should the stop action remember and restore the last used location or should it always pick up the location from appmap.yml first?