### PR TITLE
chore: using JDK 17 is supported now by the agent, no need to setup JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,6 @@ before_install:
 - chmod +x gradlew
 
 install:
-    - curl -s get.sdkman.io | bash
-    - source "$HOME/.sdkman/bin/sdkman-init.sh"
-    - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-    - source "/home/travis/.sdkman/bin/sdkman-init.sh"
-    - sdk install java 11.0.2-open
-    - export APP_MAP_JDK="$(sdk home java 11.0.2-open)"
     - ./gradlew build verifyPlugin
 
 before_deploy:


### PR DESCRIPTION
We referenced JDK 11.0.2 in our Travis setup, but this version is not available anymore and broke CI.
The agent added support for JDK 17, so we don't need this workaround anymore.