### PR TITLE
fix: only record top-level packages by default

### DIFF
--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -107,6 +107,7 @@ public final class AppMapJavaPackageConfig {
 
         for (var packageName : ReadAction.compute(() -> findTopLevelPackages(project, runConfigurationScope))) {
             config.append("- path: ").append(packageName).append('\n');
+            config.append("  shallow: true").append('\n');
         }
 
         return config.toString();


### PR DESCRIPTION
Set "shallow: true" in the generated config, to limit the number of method calls captured by default.