### PR TITLE
Prune large AppMaps using the CLI

### DIFF
--- a/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
@@ -77,4 +77,21 @@ public interface AppLandCommandLineService extends Disposable {
      * @return The command line or {@code null} if the CLI is unavailable
      */
     @Nullable GeneralCommandLine createGenerateOpenApiCommand(@NotNull VirtualFile projectRoot);
+
+    /**
+     * Creates the command line to prune an AppMap file.
+     *
+     * @param appMapFile The file to prune. It won't be modified by the command, but the pruned content will be sent to STDOUT. Only files on the local file system are supported.
+     * @param maxSize The maximum size of the pruned file, must be a value understood by the CLI, e.g. "10mb"
+     * @return The command line or {@code null} if the CLI is unavailable
+     */
+    @Nullable GeneralCommandLine createPruneAppMapCommand(@NotNull VirtualFile appMapFile, @NotNull String maxSize);
+
+    /**
+     * Creates the command line to provide stats about an AppMap file.
+     *
+     * @param appMapFile The AppMap file to load
+     * @return The command line or {@code null} if the CLI is unavailable
+     */
+    @Nullable GeneralCommandLine createAppMapStatsCommand(@NotNull VirtualFile appMapFile);
 }

--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -1,10 +1,17 @@
 package appland.files;
 
+import appland.cli.AppLandCommandLineService;
 import appland.utils.GsonUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.gson.JsonObject;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.ProcessOutput;
+import com.intellij.execution.util.ExecUtil;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
@@ -12,6 +19,7 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,13 +32,21 @@ import java.util.Collection;
 
 public final class AppMapFiles {
     private static final Logger LOG = Logger.getInstance("#appmap.files");
+
     public static final String APPMAP_YML = "appmap.yml";
+
+    // prune size parameter passed to the appmap CLI tool
+    public static final String APPMAP_CLI_MAX_PRUNE_SIZE = "10mb";
+    // Files larger than 200mb are considered giant and can't be pruned or opened
+    public static int SIZE_THRESHOLD_GIANT_BYTES = 200 * 1024 * 1024;
+    // Files larger than 10mb and smaller than 200mb are considered large and have to be pruned
+    public static int SIZE_THRESHOLD_LARGE_BYTES = 10 * 1024 * 1024;
 
     private AppMapFiles() {
     }
 
     public static boolean isAppMapConfigFileName(@NotNull String fileName) {
-        return FileUtil.fileNameEquals(fileName, AppMapFiles.APPMAP_YML);
+        return FileUtil.fileNameEquals(fileName, APPMAP_YML);
     }
 
     /**
@@ -38,7 +54,7 @@ public final class AppMapFiles {
      */
     @RequiresReadLock
     public static @NotNull Collection<VirtualFile> findAppMapConfigFiles(@NotNull Project project, @NotNull GlobalSearchScope scope) {
-        return FilenameIndex.getVirtualFilesByName(project, AppMapFiles.APPMAP_YML, false, scope);
+        return FilenameIndex.getVirtualFilesByName(project, APPMAP_YML, false, scope);
     }
 
     /**
@@ -139,5 +155,101 @@ public final class AppMapFiles {
         // name.appmap.json is mapped to name/appmap-findings.json
         var findingsPath = String.format("%s/appmap-findings.json", StringUtil.trimEnd(appMapFile.getName(), ".appmap.json"));
         return parent.findFileByRelativePath(findingsPath);
+    }
+
+    /**
+     * Load the content of the file.
+     *
+     * @param file File to load
+     * @return File content or {@code null} if an error ocurred
+     */
+    @RequiresReadLock
+    public static @Nullable String loadFileContent(@NotNull VirtualFile file) {
+        return ReadAction.compute(() -> {
+            var document = FileDocumentManager.getInstance().getDocument(file);
+            if (document == null) {
+                LOG.error("unable to retrieve document for file: " + file.getPath());
+                return null;
+            }
+
+            return document.getText();
+        });
+    }
+
+    /**
+     * Loads the AppMap file content and follows the same rules as VSCode:
+     * <ol>
+     * <li>size <= 10mb: load as-is</li>
+     * <li>size > 200mb: return empty content</li>
+     * <li>10mb < size <= 200mb: prune JSON using the AppMap CLI tool</li>
+     * </ol>
+     *
+     * @param file AppMap file to load
+     * @return The content of {@code null} if an error occurred loading the content
+     */
+    @RequiresBackgroundThread
+    public static @Nullable String loadAppMapFile(@NotNull VirtualFile file) {
+        return loadAppMapFile(file, SIZE_THRESHOLD_GIANT_BYTES, SIZE_THRESHOLD_LARGE_BYTES, APPMAP_CLI_MAX_PRUNE_SIZE);
+    }
+
+    /**
+     * Load AppMap with specific size threshold values.
+     *
+     * @param file                    File to load
+     * @param sizeThresholdGiantBytes Files above this size are considered "giant"
+     * @param sizeThresholdLargeBytes Files above this size are considered "large", unless they're "giant"
+     * @param appMapTargetSize        Target size specifier for the pruned AppMap file
+     * @return Content of the AppMap file, pruned when necessary. Either {@code null} in case of errors or valid JSON.
+     */
+    @RequiresBackgroundThread
+    static @Nullable String loadAppMapFile(@NotNull VirtualFile file,
+                                           int sizeThresholdGiantBytes,
+                                           int sizeThresholdLargeBytes,
+                                           @NotNull String appMapTargetSize) {
+        var fileLength = file.getLength();
+
+        if (fileLength > sizeThresholdGiantBytes) {
+            return "{}";
+        }
+
+        if (fileLength > sizeThresholdLargeBytes) {
+            var command = AppLandCommandLineService.getInstance().createPruneAppMapCommand(file, appMapTargetSize);
+            if (command != null) {
+                try {
+                    var processOutput = ExecUtil.execAndGetOutput(command);
+                    return getOutputOrLogStatus(command, processOutput);
+                } catch (ExecutionException e) {
+                    LOG.debug("error pruning AppMap: " + file.getPath(), e);
+                }
+            }
+            return null;
+        }
+
+        return loadFileContent(file);
+    }
+
+    @RequiresBackgroundThread
+    public static @Nullable String loadAppMapStats(@NotNull VirtualFile file) {
+        var command = AppLandCommandLineService.getInstance().createAppMapStatsCommand(file);
+        if (command == null) {
+            return null;
+        }
+
+        try {
+            var processOutput = ExecUtil.execAndGetOutput(command);
+            return getOutputOrLogStatus(command, processOutput);
+        } catch (ExecutionException e) {
+            LOG.debug("error retrieving AppMap file stats: " + file.getPath(), e);
+        }
+        return null;
+    }
+
+    private static @Nullable String getOutputOrLogStatus(@NotNull GeneralCommandLine command, @NotNull ProcessOutput processOutput) {
+        if (processOutput.getExitCode() == 0) {
+            return processOutput.getStdout();
+        }
+
+        LOG.debug("failed to execute command: " + command.getCommandLineString() + ", status: " + processOutput);
+        return null;
     }
 }

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -228,7 +228,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
 
         // send init message to webview to launch the JS application in a background thread
         isWebViewReady.set(true);
-        new Task.Backgroundable(project, AppMapBundle.get("webview.loading"), false, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+        new Task.Backgroundable(project, getLoadingProgressTitle(), false, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 var initData = createInitData();
@@ -238,6 +238,10 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
                 afterInit(initData);
             }
         }.queue();
+    }
+
+    protected @NotNull String getLoadingProgressTitle() {
+        return AppMapBundle.get("webview.loading");
     }
 
     @NotNull

--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
@@ -11,9 +11,11 @@ import appland.problemsView.ResolvedStackLocation;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.telemetry.TelemetryService;
 import appland.upload.AppMapUploader;
+import appland.utils.GsonUtils;
 import appland.webviews.WebviewEditor;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.actions.OpenInRightSplitAction;
@@ -21,7 +23,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorState;
 import com.intellij.openapi.fileEditor.FileEditorStateLevel;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
@@ -57,7 +58,7 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
     // keeps track if the file was modified and not yet loaded into the AppMap application
     private final AtomicBoolean isModified = new AtomicBoolean(false);
 
-    public AppMapFileEditor(Project project, VirtualFile file) {
+    public AppMapFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
         super(project, file);
         setupVfsListener(file);
     }
@@ -70,20 +71,9 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
                 .create();
     }
 
-    /**
-     * @return The JSON object to pass to the AppMap webview as "data" property.
-     */
     @Override
     protected @Nullable JsonObject createInitData() {
-        var fileContent = ReadAction.compute(() -> {
-            var document = FileDocumentManager.getInstance().getDocument(file);
-            if (document == null) {
-                LOG.error("unable to retrieve document for file: " + file.getPath());
-                return null;
-            }
-
-            return document.getText();
-        });
+        var fileContent = AppMapFiles.loadAppMapFile(file);
 
         // return early in case of error
         if (fileContent == null) {
@@ -93,6 +83,15 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
         try {
             // parse JSON outside the ReadAction
             var appMapJson = gson.fromJson(fileContent, JsonObject.class);
+
+            // retrieve stats from CLI and attach to the parsed AppMap
+            try {
+                var appMapStats = AppMapFiles.loadAppMapStats(file);
+                var stats = GsonUtils.singlePropertyObject("functions", gson.fromJson(appMapStats, JsonArray.class));
+                appMapJson.add("stats", stats);
+            } catch (Exception e) {
+                LOG.debug("error parsing AppMap stats", e);
+            }
 
             // attach findings, which belong to this AppMap, as property "findings" (same as in VSCode)
             var findingsFile = ReadAction.compute(() -> AppMapFiles.findRelatedFindingsFile(file));
@@ -248,6 +247,11 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
             default:
                 return null;
         }
+    }
+
+    @Override
+    protected @NotNull String getLoadingProgressTitle() {
+        return AppMapBundle.get("appmap.editor.loadingFile");
     }
 
     /**

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -1,5 +1,6 @@
 appmap.editor.name=AppMap
 appmap.editor.unavailableWarning=Interactive AppMap viewer is not available with the configured JDK. Please switch to the default JetBrains JDK for AppMap to work.
+appmap.editor.loadingFile=Loading AppMap...
 
 appmap.editor.showSourceFileMissing.title=AppMap
 appmap.editor.showSourceFileMissing.text=File {0} could not be found.

--- a/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
+++ b/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
@@ -1,7 +1,15 @@
 package appland.files;
 
+import appland.cli.AppLandCommandLineService;
+import appland.utils.GsonUtils;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.util.ExecUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -9,6 +17,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
+    @Override
+    protected TempDirTestFixture createTempDirTestFixture() {
+        return new TempDirTestFixtureImpl();
+    }
+
     @Test
     public void files() {
         var file = myFixture.configureByText("a.json", "");
@@ -54,5 +67,37 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
     public void readAppMapDirMissingValue() {
         var configFile = myFixture.copyFileToProject("appmap-config/appmap-no-dir.yml");
         assertNull(AppMapFiles.readAppMapDirConfigValue(configFile));
+    }
+
+    @Test
+    public void pruneLargeAppMapFile() {
+        // file with a size of roughly 2.5mb
+        var appMap = myFixture.copyFileToProject("appmap/misago_threads_tests_test_threadslists_AllThreadsListTests_test_noscript_pagination.appmap.json");
+        var prunedContent = AppMapFiles.loadAppMapFile(appMap, 10 * 1024 * 1024, 2 * 1024 * 1024, "1mb");
+        assertNotNull(prunedContent);
+
+        var jsonPruned = GsonUtils.GSON.fromJson(prunedContent, JsonObject.class);
+        assertNotNull(jsonPruned);
+        assertTrue("Pruned data must contain property pruneFilter", jsonPruned.has("pruneFilter"));
+    }
+
+    @Test
+    public void pruneGiantAppMapFile() {
+        // file with a size of roughly 2.5mb
+        var appMap = myFixture.copyFileToProject("appmap/misago_threads_tests_test_threadslists_AllThreadsListTests_test_noscript_pagination.appmap.json");
+        var prunedContent = AppMapFiles.loadAppMapFile(appMap, 2 * 1024 * 1024, 2 * 1024 * 1024, "1mb");
+        assertEquals("Empty JSON must be returned for a giant AppMap ", "{}", prunedContent);
+    }
+
+    @Test
+    public void statsJson() throws ExecutionException {
+        var appMap = myFixture.copyFileToProject("appmap/misago_threads_tests_test_threadslists_AllThreadsListTests_test_noscript_pagination.appmap.json");
+        var command = AppLandCommandLineService.getInstance().createAppMapStatsCommand(appMap);
+        assertNotNull(command);
+
+        var statsArray = GsonUtils.GSON.fromJson(ExecUtil.execAndGetOutput(command).getStdout(), JsonArray.class);
+        assertNotNull("Stats JSON must be valid, STDERR must be excluded from captured output", statsArray);
+
+        assertTrue("stats must not be empty", statsArray.size() > 0);
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/244

This is best tested with a project containing large and giant AppMaps.

- Executes the AppMap CLI to purge large AppMaps
- Always adds the "stats" property (loaded via AppMap CLI) to the JSON passed to the AppMap webview
- Adds tests to test the CLI with the prune and stats commands