### PR TITLE
Simplify JCEF webview message handling

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/SimpleWebviewMessageHandler.java
+++ b/plugin-core/src/main/java/appland/webviews/SimpleWebviewMessageHandler.java
@@ -1,0 +1,29 @@
+package appland.webviews;
+
+import com.google.gson.JsonObject;
+import com.intellij.ui.jcef.JBCefJSQuery;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Simplified message handler, which returns "success" by default and an error response when an exception occurred.
+ */
+public interface SimpleWebviewMessageHandler extends WebviewMessageHandler {
+    /**
+     * @return {@code true} if the message was handled, {@code false} if the message was not handled.
+     * @throws Exception If an error occurred while handling the message
+     */
+    boolean handleMessage(@NotNull String messageId, @Nullable JsonObject message) throws Exception;
+
+    @Override
+    default @Nullable JBCefJSQuery.Response handleWebviewMessage(@NotNull String messageId, @Nullable JsonObject message) {
+        try {
+            if (handleMessage(messageId, message)) {
+                return new JBCefJSQuery.Response("success");
+            }
+            return null;
+        } catch (Exception e) {
+            return new JBCefJSQuery.Response("failure", 1, e.getMessage());
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Base class for editors based on a JCEF webview.
  * It implements most of the shared functionality and allows to customize link handling, message handling and more.
  */
-public abstract class WebviewEditor<T> extends UserDataHolderBase implements FileEditor, WebviewMessageHandler {
+public abstract class WebviewEditor<T> extends UserDataHolderBase implements FileEditor, SimpleWebviewMessageHandler {
     private static final Logger LOG = Logger.getInstance(WebviewEditor.class);
 
     protected final @NotNull Project project;

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.ui.jcef.JBCefJSQuery;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,18 +47,18 @@ public class FindingDetailsEditor extends WebviewEditor<Void> {
     }
 
     @Override
-    public @Nullable JBCefJSQuery.Response handleWebviewMessage(@NotNull String messageId, @Nullable JsonObject message) {
+    public boolean handleMessage(@NotNull String messageId, @Nullable JsonObject message) throws Exception {
         switch (messageId) {
             case "open-findings-overview":
                 ApplicationManager.getApplication().invokeLater(() -> {
                     FindingsOverviewEditorProvider.openEditor(project);
                 }, ModalityState.defaultModalityState());
-                return new JBCefJSQuery.Response("success");
+                return true;
 
             case "open-in-source-code":
                 assert message != null;
                 openEditorForLocation(gson.fromJson(message.getAsJsonObject("location"), ResolvedStackLocation.class));
-                return new JBCefJSQuery.Response("success");
+                return true;
 
             case "open-map":
                 // file path to the AppMap is at uri > path
@@ -69,10 +68,10 @@ public class FindingDetailsEditor extends WebviewEditor<Void> {
                     var fragment = GsonUtils.getPath(message, "uri", "fragment");
                     openAppMapUri(path.getAsString(), fragment != null ? fragment.getAsString() : "{}");
                 }
-                return new JBCefJSQuery.Response("success");
+                return true;
 
             default:
-                return null;
+                return false;
         }
     }
 

--- a/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.ui.jcef.JBCefJSQuery;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -88,21 +87,21 @@ public class FindingsOverviewEditor extends WebviewEditor<List<ScannerFinding>> 
     }
 
     @Override
-    public @Nullable JBCefJSQuery.Response handleWebviewMessage(@NotNull String messageId, @Nullable JsonObject message) {
+    public boolean handleMessage(@NotNull String messageId, @Nullable JsonObject message) {
         switch (messageId) {
             case "open-problems-tab":
                 ApplicationManager.getApplication().invokeLater(() -> FindingsViewTab.activateFindingsTab(project));
-                return new JBCefJSQuery.Response("success");
+                return true;
 
             case "open-finding-info":
                 // locate finding by hash, then open it in a new AppMap webview
                 if (message != null && message.has("hash")) {
                     openFindingsByHash(message.getAsJsonPrimitive("hash").getAsString());
                 }
-                return new JBCefJSQuery.Response("processed " + messageId);
+                return true;
 
             default:
-                return null;
+                return false;
         }
     }
 


### PR DESCRIPTION
Preliminary work for https://github.com/getappmap/appmap-intellij-plugin/issues/246

Fixes the responses to webview messages. Previously, the AppMap webview editor implementation skipped responses,, but we should always send it if the message was handled.