### PR TITLE
Fix support for large AppMaps on Windows

### DIFF
--- a/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
@@ -28,16 +28,18 @@ public interface AppLandCommandLineService extends Disposable {
      * Launches the AppLand CLI tools for the given directory.
      * It'll stop any running service, which is serving a subdirectory the given path.
      *
-     * @param directory Directory, where the service should be launched.
+     * @param directory                 Directory, where the service should be launched.
+     * @param waitForProcessTermination Wait for termination of processes, which are no longer needed. This is mostly useful for test cases.
      */
-    void start(@NotNull VirtualFile directory) throws ExecutionException;
+    void start(@NotNull VirtualFile directory, boolean waitForProcessTermination) throws ExecutionException;
 
     /**
      * Stops any running service, which is being executed for the given directory.
      *
-     * @param directory Directory path
+     * @param directory          Directory path
+     * @param waitForTermination Waits until the process has been terminated. This is mostly useful for test cases.
      */
-    void stop(@NotNull VirtualFile directory);
+    void stop(@NotNull VirtualFile directory, boolean waitForTermination);
 
     /**
      * Refreshes the processes for the currently open projects.
@@ -58,8 +60,10 @@ public interface AppLandCommandLineService extends Disposable {
 
     /**
      * Stop all processes.
+     *
+     * @param waitForTermination Wait for process termination. This is mostly useful for test cases.
      */
-    void stopAll();
+    void stopAll(boolean waitForTermination);
 
     /**
      * Creates the command line to install AppMap in the given directory.
@@ -82,7 +86,7 @@ public interface AppLandCommandLineService extends Disposable {
      * Creates the command line to prune an AppMap file.
      *
      * @param appMapFile The file to prune. It won't be modified by the command, but the pruned content will be sent to STDOUT. Only files on the local file system are supported.
-     * @param maxSize The maximum size of the pruned file, must be a value understood by the CLI, e.g. "10mb"
+     * @param maxSize    The maximum size of the pruned file, must be a value understood by the CLI, e.g. "10mb"
      * @return The command line or {@code null} if the CLI is unavailable
      */
     @Nullable GeneralCommandLine createPruneAppMapCommand(@NotNull VirtualFile appMapFile, @NotNull String maxSize);

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -8,7 +8,6 @@ import appland.settings.AppMapSettingsListener;
 import com.intellij.execution.CantRunException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.configurations.PtyCommandLine;
 import com.intellij.execution.process.KillableProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
@@ -42,7 +41,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
 
     public DefaultCommandLineService() {
         var connection = ApplicationManager.getApplication().getMessageBus().connect(this);
-        connection.subscribe(AppMapConfigFileListener.TOPIC, this::refreshForOpenProjectsInBackground);
+        connection.subscribe(AppMapConfigFileListener.TOPIC, (AppMapConfigFileListener) this::refreshForOpenProjectsInBackground);
         connection.subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsListener() {
             @Override
             public void enableFindingsChanged() {
@@ -376,17 +375,16 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         });
     }
 
-    private static @Nullable PtyCommandLine createAppMapCliCommand(@NotNull String... parameters) {
+    private static @Nullable GeneralCommandLine createAppMapCliCommand(@NotNull String... parameters) {
         var toolPath = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap);
         if (toolPath == null || Files.notExists(toolPath)) {
             LOG.debug("AppMap CLI executable not found: " + toolPath);
             return null;
         }
 
-        var cmd = new PtyCommandLine();
+        var cmd = new GeneralCommandLine();
         cmd.withExePath(toolPath.toString());
         cmd.withParameters(parameters);
-        cmd.withConsoleMode(true);
         cmd.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
 
         LOG.debug("AppMap CLI command line " + cmd.getCommandLineString());

--- a/plugin-core/src/main/java/appland/cli/RegisterContentRootsActivity.java
+++ b/plugin-core/src/main/java/appland/cli/RegisterContentRootsActivity.java
@@ -46,7 +46,7 @@ public class RegisterContentRootsActivity implements StartupActivity {
             for (var contentRoot : contentRoots) {
                 try {
                     if (!service.isRunning(contentRoot, false)) {
-                        service.start(contentRoot);
+                        service.start(contentRoot, false);
                     }
                 } catch (ExecutionException e) {
                     LOG.error("Error launch CLI tools for directory: " + contentRoot.getPath(), e);

--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -1,14 +1,27 @@
 package appland;
 
+import appland.cli.AppLandCommandLineService;
+import appland.settings.AppMapApplicationSettings;
+import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
 import org.jetbrains.annotations.NotNull;
+import org.junit.After;
 
 import java.util.Collections;
 
 public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4TestCase {
+    @After
+    public void shutdownAppMapProcesses() {
+        AppLandCommandLineService.getInstance().stopAll(true);
+
+        // reset to default settings
+        ApplicationManager.getApplication().getService(AppMapApplicationSettingsService.class).loadState(new AppMapApplicationSettings());
+    }
+
     /**
      * Creates a minimal version of AppMap JSON, which contains the metadata with a name.
      */

--- a/plugin-core/src/test/java/appland/actions/StopAppMapRecordingActionTest.java
+++ b/plugin-core/src/test/java/appland/actions/StopAppMapRecordingActionTest.java
@@ -3,6 +3,7 @@ package appland.actions;
 import appland.AppMapBaseTest;
 import appland.settings.AppMapProjectSettingsService;
 import com.intellij.openapi.application.WriteAction;
+import com.intellij.util.PathUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,13 +34,13 @@ public class StopAppMapRecordingActionTest extends AppMapBaseTest {
 
         var location = StopAppMapRecordingAction.findDefaultStorageLocation(getProject());
         assertNotNull(location);
-        assertEquals("/src/root/tmp-appMapAgent/appmap/remote", location.toString());
+        assertEquals("/src/root/tmp-appMapAgent/appmap/remote", PathUtil.toSystemIndependentName(location.toString()));
     }
 
     @Test
     public void findDefaultStorageLocationFallback() {
         var location = StopAppMapRecordingAction.findDefaultStorageLocation(getProject());
         assertNotNull(location);
-        assertEquals("/src/tmp/appmap/remote", location.toString());
+        assertEquals("/src/tmp/appmap/remote", PathUtil.toSystemIndependentName(location.toString()));
     }
 }

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -47,7 +47,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
     @After
     public void shutdownProcesses() {
-        AppLandCommandLineService.getInstance().stopAll();
+        AppLandCommandLineService.getInstance().stopAll(true);
         // reset to default settings
         ApplicationManager.getApplication().getService(AppMapApplicationSettingsService.class).loadState(new AppMapApplicationSettings());
     }
@@ -58,6 +58,8 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         var tempDir = tempFile.getParent();
 
         var nestedFile = myFixture.addFileToProject("parent/child/file.txt", "");
+        assertNotNull(nestedFile.getParent());
+
         var nestedDir = nestedFile.getParent().getVirtualFile();
         assertNotNull(nestedDir);
 
@@ -82,13 +84,11 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
         assertActiveRoots(tempDir);
 
-        service.stop(tempDir);
+        service.stop(tempDir, true);
         assertFalse(service.isRunning(tempDir, true));
         assertFalse(service.isRunning(tempDir, false));
         assertFalse(service.isRunning(nestedDir, true));
         assertFalse(service.isRunning(nestedDir, false));
-
-        service.stopAll();
     }
 
     @Test
@@ -106,8 +106,6 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         assertNotNull(tempDirNioPath);
         var appMapDirNioPath = tempDirNioPath.resolve("tmp/appmaps");
         assertTrue("Configured AppMap dir must be created: " + appMapDirNioPath, Files.isDirectory(appMapDirNioPath));
-
-        service.stopAll();
     }
 
     @Test
@@ -136,7 +134,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
         assertActiveRoots(dirA, dirB);
 
-        service.stopAll();
+        service.stopAll(true);
         assertFalse(service.isRunning(dirA, true));
         assertFalse(service.isRunning(dirB, true));
     }
@@ -159,8 +157,6 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         });
         assertTrue(condition.await(30, TimeUnit.SECONDS));
         assertActiveRoots(newRootA, newRootB);
-
-        AppLandCommandLineService.getInstance().stopAll();
     }
 
     @Test
@@ -212,7 +208,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         });
 
         for (var contentRoot : contentRoots) {
-            AppLandCommandLineService.getInstance().start(contentRoot);
+            AppLandCommandLineService.getInstance().start(contentRoot, true);
         }
     }
 

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -1,7 +1,6 @@
 package appland.cli;
 
 import appland.AppMapBaseTest;
-import appland.settings.AppMapApplicationSettings;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.application.ApplicationManager;
@@ -15,7 +14,6 @@ import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -44,13 +42,6 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         RegisterContentRootsActivity.listenForContentRootChanges(getProject(), getTestRootDisposable());
         AppMapApplicationSettingsService.getInstance().setEnableFindings(true);
         AppMapApplicationSettingsService.getInstance().setApiKey("api-key");
-    }
-
-    @After
-    public void shutdownProcesses() {
-        AppLandCommandLineService.getInstance().stopAll(true);
-        // reset to default settings
-        ApplicationManager.getApplication().getService(AppMapApplicationSettingsService.class).loadState(new AppMapApplicationSettings());
     }
 
     @Test

--- a/plugin-core/src/test/java/appland/index/StreamingClassMapIteratorTest.java
+++ b/plugin-core/src/test/java/appland/index/StreamingClassMapIteratorTest.java
@@ -64,8 +64,8 @@ public class StreamingClassMapIteratorTest extends AppMapBaseTest {
         iterator.parse(classMapContent);
 
         // compare as sorted lists, because the VSCode data has a different sort order
-        var separator = SystemInfoRt.isWindows ? "\r\n" : "\n";
-        var sortedExpected = prepareSortedList(StringUtil.split(expectedOutputContent, separator));
+        // support both types of line separators because the Git data may have \n on Windows
+        var sortedExpected = prepareSortedList(List.of(expectedOutputContent.split("\r\n|\n")));
         var sortedActual = prepareSortedList(iterator.ids);
 
         assertEquals(sortedExpected, sortedActual);

--- a/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
+++ b/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
@@ -1,5 +1,6 @@
 package appland.execution;
 
+import appland.cli.AppLandCommandLineService;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil;
@@ -17,7 +18,13 @@ public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        EdtTestUtil.runInEdtAndWait(super::tearDown);
+        try {
+            AppLandCommandLineService.getInstance().stopAll(true);
+        } catch (Exception e) {
+            addSuppressedException(e);
+        } finally {
+            EdtTestUtil.runInEdtAndWait(super::tearDown);
+        }
     }
 
     @Override
@@ -41,7 +48,7 @@ public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
             return sdk;
         }
 
-        //noinspection UnstableApiUsage
+        //noinspection UnstableApiUsage,deprecation
         return JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
     }
 }


### PR DESCRIPTION
Fixes non-working handling of large AppMaps on Windows. The "stats" command was printing ANSI escape codes to STDOUT, which were breaking JSON parsing. This only happened on Windows, though. Running CI on Windows would have found this problem.

The other commits fix CI on Windows and should also fix the flaky CI with Travis. Background activity, which is often delayed on slow systems, was breaking the tests.