### PR TITLE
Properly handle reload of finding files to avoid an empty list of findings in the UI

### DIFF
--- a/plugin-core/src/test/java/appland/problemsView/FindingsManagerTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/FindingsManagerTest.java
@@ -42,7 +42,7 @@ public class FindingsManagerTest extends AppMapBaseTest {
         var problematicFile = root.findFileByRelativePath("app/controllers/microposts_controller.rb");
         assertNotNull(problematicFile);
 
-        manager.reloadAsync().get(30, TimeUnit.SECONDS);
+        manager.reloadAsync().blockingGet(30, TimeUnit.SECONDS);
 
         assertEquals(1, manager.getProblemFileCount());
         assertEquals(1, manager.getProblemCount());

--- a/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
@@ -107,6 +107,6 @@ public class RuntimeAnalysisModelTest extends AppMapBaseTest {
         ScannerFilesAsyncListener.disableForTests(() -> {
             return WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject(directoryPath, "root"));
         });
-        FindingsManager.getInstance(getProject()).reloadAsync().get(30, TimeUnit.SECONDS);
+        FindingsManager.getInstance(getProject()).reloadAsync().blockingGet(30, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/270
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/182

The reload of finding files uses a cancellable ReadAction, which means that it could be executed multiple times.
The code, which was executed multiple times, had side effects, which could break the UI.
This PR removes the side effects and consistently applies the results collected by the ReadAction to the UI.

Most likely, this is also a fix for https://github.com/getappmap/appmap-intellij-plugin/issues/270, which may be caused by a disposed project.