### PR TITLE
Improve performance to look up AppMap files in the project

### DIFF
--- a/plugin-core/src/main/java/appland/index/AppMapSearchScopes.java
+++ b/plugin-core/src/main/java/appland/index/AppMapSearchScopes.java
@@ -1,0 +1,23 @@
+package appland.index;
+
+import com.intellij.json.JsonFileType;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.search.GlobalSearchScope;
+import org.jetbrains.annotations.NotNull;
+
+public final class AppMapSearchScopes {
+    private AppMapSearchScopes() {
+    }
+
+    public static @NotNull GlobalSearchScope projectFilesWithExcluded(@NotNull Project project) {
+        return new EverythingExceptLibrariesScope(project);
+    }
+
+    /**
+     * @param project Project
+     * @return Search scope, which contains all .appmap.json files of the project, included files inside excluded directories. The scope is also restricted by the JSON file type.
+     */
+    public static @NotNull GlobalSearchScope appMapsWithExcluded(@NotNull Project project) {
+        return GlobalSearchScope.getScopeRestrictedByFileTypes(projectFilesWithExcluded(project), JsonFileType.INSTANCE);
+    }
+}

--- a/plugin-core/src/main/java/appland/index/ClassMapTypeIndex.java
+++ b/plugin-core/src/main/java/appland/index/ClassMapTypeIndex.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileSet;
-import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.indexing.*;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.IOUtil;
@@ -119,7 +118,7 @@ public class ClassMapTypeIndex extends FileBasedIndexExtension<ClassMapItemType,
             return;
         }
 
-        var scope = GlobalSearchScope.getScopeRestrictedByFileTypes(new EverythingExceptLibrariesScope(project), JsonFileType.INSTANCE);
+        var scope = AppMapSearchScopes.appMapsWithExcluded(project);
         FileBasedIndex.getInstance().processValues(INDEX_ID, type, null, processor, scope);
     }
 

--- a/plugin-core/src/main/java/appland/index/EverythingExceptLibrariesScope.java
+++ b/plugin-core/src/main/java/appland/index/EverythingExceptLibrariesScope.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  * We're using everythingScope because it contains excluded files, which are needed for the AppMap index data,
  * but it's also including libraries, and more unrelated files.
  */
-class EverythingExceptLibrariesScope extends DelegatingGlobalSearchScope {
+final class EverythingExceptLibrariesScope extends DelegatingGlobalSearchScope {
     EverythingExceptLibrariesScope(@NotNull Project project) {
         super(GlobalSearchScope.everythingScope(project));
     }

--- a/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
@@ -1,6 +1,7 @@
 package appland.problemsView;
 
 import appland.index.AppMapFindingsUtil;
+import appland.index.AppMapSearchScopes;
 import appland.problemsView.listener.ScannerFindingsListener;
 import appland.problemsView.model.FindingsDomainCount;
 import appland.problemsView.model.FindingsFileData;
@@ -23,7 +24,6 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import org.jetbrains.annotations.NotNull;
@@ -353,8 +353,7 @@ public class FindingsManager implements ProblemsProvider {
 
     @RequiresReadLock
     private @NotNull Collection<VirtualFile> findFindingsFiles() {
-        // only "everything" seems to contain our appmap-findings.json files in excluded parent folders
-        var scope = GlobalSearchScope.everythingScope(project);
+        var scope = AppMapSearchScopes.projectFilesWithExcluded(project);
         return FilenameIndex.getVirtualFilesByName(project, AppMapFindingsUtil.FINDINGS_FILE_NAME, true, scope);
     }
 

--- a/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
@@ -4,6 +4,7 @@ import appland.config.AppMapConfigFileListener;
 import appland.files.AppMapFileChangeListener;
 import appland.files.AppMapFiles;
 import appland.index.AppMapMetadataIndex;
+import appland.index.AppMapSearchScopes;
 import appland.installGuide.InstallGuideViewPage;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.listener.ScannerFindingsListener;
@@ -21,7 +22,7 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.CommonProcessors;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -168,9 +169,9 @@ public class InstallGuidePanel extends AppMapContentPanel implements Disposable 
      */
     private static void updateInstallAgentLabel(@NotNull Project project, @NotNull StatusLabel label) {
         findIndexedStatus(project, label, () -> {
-            return FilenameIndex.processFilesByName(AppMapFiles.APPMAP_YML, false, file -> {
-                return false;
-            }, GlobalSearchScope.everythingScope(project), project);
+            var processor = CommonProcessors.alwaysFalse();
+            var scope = AppMapSearchScopes.projectFilesWithExcluded(project);
+            return FilenameIndex.processFilesByName(AppMapFiles.APPMAP_YML, false, processor, scope, project);
         });
     }
 
@@ -180,7 +181,7 @@ public class InstallGuidePanel extends AppMapContentPanel implements Disposable 
     private static void updateRecordAppMapsLabel(@NotNull Project project, @NotNull StatusLabel label) {
         findIndexedStatus(project, label, () -> {
             var found = new AtomicBoolean(false);
-            AppMapMetadataIndex.processAppMaps(project, GlobalSearchScope.everythingScope(project), (file, appmap) -> {
+            AppMapMetadataIndex.processAppMaps(project, AppMapSearchScopes.appMapsWithExcluded(project), (file, appmap) -> {
                 found.set(true);
                 return false;
             });


### PR DESCRIPTION
This is a (minor) performance improvement to locate AppMap files in a project. 
I noticed this problem while investigating some of the new exceptions.

The fix is to use our own, more limited scope instead of `GlobalSearchScope.everythingScope(project);`, which also includes library files. Libraries may add a lot of files, e.g. external JAR files in Java project.