### PR TITLE
Add missing ID to plugin.xml

### DIFF
--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -77,7 +77,8 @@
 
         <notificationGroup id="appmap.remoteRecording" displayType="BALLOON"
                            key="notification.remoteRecording.displayName"/>
-        <statusBarWidgetFactory implementation="appland.remote.RemoteRecordingStatusBarFactory"/>
+        <statusBarWidgetFactory id="appmap.recordingStatusFactory"
+                                implementation="appland.remote.RemoteRecordingStatusBarFactory"/>
 
         <notificationGroup id="appmap.telemetry" displayType="STICKY_BALLOON"
                            key="telemetry.permission.title"/>


### PR DESCRIPTION
The log of the IDE was complaining about the missing ID, which is apparently only in later versions of the platform.