### PR TITLE
Restrict runtime of the AppMap stats command with a timeout (20s)

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
@@ -84,8 +84,10 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
             // retrieve stats from CLI and attach to the parsed AppMap
             try {
                 var appMapStats = AppMapFiles.loadAppMapStats(file);
-                var stats = GsonUtils.singlePropertyObject("functions", gson.fromJson(appMapStats, JsonArray.class));
-                appMapJson.add("stats", stats);
+                if (appMapStats != null) {
+                    var stats = GsonUtils.singlePropertyObject("functions", gson.fromJson(appMapStats, JsonArray.class));
+                    appMapJson.add("stats", stats);
+                }
             } catch (Exception e) {
                 LOG.debug("error parsing AppMap stats", e);
             }


### PR DESCRIPTION
This is a possible remedy for https://github.com/getappmap/appmap-intellij-plugin/issues/259, where a haning IDE was reported. It won't fix the crashing IDE, though.

Loading an AppMap webview executes the stats command with the AppMap CLI tool. 
The execution was not limited and may prevent the successful loading of an editor webview. 
This PR adds a timeout of 20s to restrict the maximum runtime of the stats command. I expect that the stats command is much faster than 20s, but we should avoid a blocking editor, nevertheless.