### PR TITLE
Warn about missing support for JCEF webviews 

### DIFF
--- a/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import com.intellij.ui.content.ContentFactory;
+import com.intellij.ui.jcef.JBCefApp;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -54,9 +55,8 @@ public class AppMapToolWindowFactory implements ToolWindowFactory, DumbAware {
             }
         });
 
-        assert panel instanceof JPanel;
         var content = ContentFactory.SERVICE.getInstance().createContent(null, null, false);
-        content.setComponent((JPanel) panel);
+        content.setComponent(panel);
         toolWindow.getContentManager().addContent(content);
 
         if (toolWindow.isVisible()) {
@@ -64,11 +64,15 @@ public class AppMapToolWindowFactory implements ToolWindowFactory, DumbAware {
         }
     }
 
-    @NotNull
-    private AppMapToolWindowContent createContentPanel(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    @SuppressWarnings("unchecked")
+    private <T extends JPanel & AppMapToolWindowContent> @NotNull T createContentPanel(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        if (!JBCefApp.isSupported()) {
+            return (T) new JcefUnsupportedPanel();
+        }
+
         return AppMapApplicationSettingsService.getInstance().isAuthenticated()
-                ? new AppMapWindowPanel(project, toolWindow.getDisposable())
-                : new SignInViewPanel(toolWindow.getDisposable());
+                ? (T) new AppMapWindowPanel(project, toolWindow.getDisposable())
+                : (T) new SignInViewPanel(toolWindow.getDisposable());
     }
 }
 

--- a/plugin-core/src/main/java/appland/toolwindow/JcefUnsupportedPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/JcefUnsupportedPanel.java
@@ -1,0 +1,30 @@
+package appland.toolwindow;
+
+import appland.AppMapBundle;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.components.JBPanelWithEmptyText;
+
+final class JcefUnsupportedPanel extends JBPanelWithEmptyText implements AppMapToolWindowContent {
+    @SuppressWarnings("DialogTitleCapitalization")
+    public JcefUnsupportedPanel() {
+        getEmptyText().setText(AppMapBundle.get("toolwindow.jcefUnsupported.emptyText"), SimpleTextAttributes.ERROR_ATTRIBUTES);
+        getEmptyText().appendLine(AppMapBundle.get("toolwindow.jcefUnsupported.emptyText2"));
+        getEmptyText().appendLine(AppMapBundle.get("toolwindow.jcefUnsupported.emptyText3"));
+        getEmptyText().appendLine(AppMapBundle.get("toolwindow.jcefUnsupported.linkTitle"), SimpleTextAttributes.LINK_ATTRIBUTES, e -> {
+            BrowserUtil.browse(AppMapBundle.get("toolwindow.jcefUnsupported.linkUrl"));
+        });
+    }
+
+    @Override
+    public void onToolWindowShown() {
+    }
+
+    @Override
+    public void onToolWindowHidden() {
+    }
+
+    @Override
+    public void dispose() {
+    }
+}

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -70,6 +70,12 @@ toolWindow.appmap.documentation=Documentation
 toolwindow.appmap.runtimeAnalysis=Runtime Analysis
 toolwindow.appmap.quickstart=Quickstart
 
+toolwindow.jcefUnsupported.emptyText=Your IDE does not support JCEF HTML webviews.
+toolwindow.jcefUnsupported.emptyText2=Please change the Boot Java Runtime to the newest version
+toolwindow.jcefUnsupported.emptyText3=that includes JCEF by following this guide:
+toolwindow.jcefUnsupported.linkTitle=Instructions
+toolwindow.jcefUnsupported.linkUrl=https://intellij-support.jetbrains.com/hc/en-us/articles/206544879
+
 urlValidation.protocolMissing=Please define the protocol (https:// or http://).
 urlValidation.hostMissing=Please enter a host name.
 urlValidation.parsingFailed=Please enter a valid URL, e.g. https://example.com


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/266

This PR displays a panel with an error message instead of attempting to use a JCEF webview on IDEs, where it's unsupported. For example, Android Studio does not support it by default.

I'd be glad for thoughts on the error message and if we should link to a webpage with further details on this or not.

![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/169698b1-18b1-4d80-83a7-79b2c4428ee4)
