### PR TITLE
Update bundled java-agent to the most recent version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ ideVersionVerifier=IC-2021.3.3,IC-231.8109.90
 
 lombokVersion=1.18.24
 
-appMapJvmAgent=1.15.4
+appMapJvmAgent=1.17.2
 
 # alternative versions to simplify development and testing
 ideVersion=IC-2021.3.3


### PR DESCRIPTION
This updates the bundled java-agent JAR to 1.17.2 of https://github.com/getappmap/appmap-java.
The previously bundled version was 1.15.4.