### PR TITLE
Use new AppMap scopes where possible

### DIFF
--- a/plugin-core/src/main/java/appland/actions/OpenRecentAppMapAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenRecentAppMapAction.java
@@ -1,6 +1,7 @@
 package appland.actions;
 
 import appland.AppMapBundle;
+import appland.index.AppMapSearchScopes;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -8,13 +9,12 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.ProjectScope;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Locates the most recently modified .appmap.json file in the project and opens it.
  * This needs an index and thus can't run when DumbMode is active.
- *
+ * <p>
  * If two files have the same modification timestamp, then the returned file is randomly chosen,
  * depending on the order in the index.
  */
@@ -23,7 +23,7 @@ public class OpenRecentAppMapAction extends AnAction {
 
     static VirtualFile findMostRecentlyModifiedAppMap(com.intellij.openapi.project.Project project) {
         LOG.debug("Query .appmap.json files...");
-        var files = FilenameIndex.getAllFilesByExt(project, "appmap.json", ProjectScope.getProjectScope(project));
+        var files = FilenameIndex.getAllFilesByExt(project, "appmap.json", AppMapSearchScopes.appMapsWithExcluded(project));
         LOG.debug("Found .appmap.json files: " + files.size());
 
         return files.stream().max((a, b) -> {

--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -4,6 +4,7 @@ import appland.AppMapBundle;
 import appland.Icons;
 import appland.files.AppMapFiles;
 import appland.files.AppMapVfsUtils;
+import appland.index.AppMapSearchScopes;
 import appland.notifications.AppMapNotifications;
 import appland.remote.RemoteRecordingService;
 import appland.remote.RemoteRecordingStatusService;
@@ -124,7 +125,8 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
 
     @RequiresBackgroundThread
     private static @Nullable Path findConfiguredStorageLocation(@NotNull Project project) {
-        var configFiles = ReadAction.compute(() -> AppMapFiles.findAppMapConfigFiles(project, GlobalSearchScope.allScope(project)));
+        var scope = AppMapSearchScopes.projectFilesWithExcluded(project);
+        var configFiles = ReadAction.compute(() -> AppMapFiles.findAppMapConfigFiles(project, scope));
         if (configFiles.size() == 1) {
             var configFile = configFiles.iterator().next();
             if (configFile.isInLocalFileSystem()) {

--- a/plugin-core/src/main/java/appland/files/FileLookup.java
+++ b/plugin-core/src/main/java/appland/files/FileLookup.java
@@ -1,5 +1,6 @@
 package appland.files;
 
+import appland.index.AppMapSearchScopes;
 import com.google.common.collect.Lists;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
@@ -9,7 +10,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.ProjectScope;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,7 +51,7 @@ public class FileLookup {
             return null;
         }
 
-        for (var candidate : FilenameIndex.getVirtualFilesByName(project, filename(relativePath), true, ProjectScope.getAllScope(project))) {
+        for (var candidate : FilenameIndex.getVirtualFilesByName(project, filename(relativePath), true, AppMapSearchScopes.projectFilesWithExcluded(project))) {
             var parent = candidate.getParent();
             for (String expectedParentName : parentsReversed(relativePath)) {
                 if (parent == null || !FileUtil.namesEqual(expectedParentName, parent.getName())) {

--- a/plugin-core/src/main/java/appland/index/AppMapMetadataIndex.java
+++ b/plugin-core/src/main/java/appland/index/AppMapMetadataIndex.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.search.ProjectScope;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.intellij.util.indexing.ID;
 import com.intellij.util.indexing.SingleEntryFileBasedIndexExtension;
@@ -93,7 +92,7 @@ public class AppMapMetadataIndex extends SingleEntryFileBasedIndexExtension<AppM
 
         var lowercaseNameFilter = nameFilter == null ? null : nameFilter.toLowerCase();
         var result = new ArrayList<AppMapMetadata>();
-        processAppMaps(project, ProjectScope.getEverythingScope(project), (file, value) -> {
+        processAppMaps(project, AppMapSearchScopes.appMapsWithExcluded(project), (file, value) -> {
             if (nameFilter == null || value.getName().toLowerCase().contains(lowercaseNameFilter)) {
                 result.add(value);
             }

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -1,6 +1,7 @@
 package appland.execution;
 
 import appland.files.AppMapFiles;
+import appland.index.AppMapSearchScopes;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.SearchScopeProvidingRunProfile;
 import com.intellij.openapi.application.ReadAction;
@@ -50,7 +51,7 @@ public final class AppMapJavaPackageConfig {
                 ? ((SearchScopeProvidingRunProfile) runProfile).getSearchScope()
                 : null;
         if (runProfileScope == null) {
-            runProfileScope = GlobalSearchScope.everythingScope(project);
+            runProfileScope = AppMapSearchScopes.projectFilesWithExcluded(project);
         }
         var runProfileAndWorkingDir = workingDir == null
                 ? runProfileScope


### PR DESCRIPTION
#275 added methods to declare AppMap search scopes. `main` was changed in the meantime and this PR updates the recently added scopes to use the new AppMap scopes instead.