### PR TITLE
Don't reload AppMap webview if it's not fully initialized yet

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
@@ -270,6 +270,11 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
                     return;
                 }
 
+                if (!isWebViewReady()) {
+                    LOG.debug("AppMap file was modified before webview was fully initialized");
+                    return;
+                }
+
                 LOG.debug("AppMap file was modified, fromSave: " + event.isFromSave() + ", fromRefresh: " + event.isFromRefresh());
                 if (isSelected.get()) {
                     // load immediately if focused


### PR DESCRIPTION
I noticed this problem while working on changes to "Stop AppMap recording".
The stop action updates the metadata, which triggers file change listeners.
The AppMap webview editor is created after making those changes, but the file change listeners were (sometimes?) dispatched after the editor was already opened.
This PR avoids to load the content twice, which would especially reduce memory usage and time top open for large recordings.