### PR TITLE
Use better default of storage location of "Stop AppMap recording"

### DIFF
--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -150,7 +150,7 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
      */
     @RequiresBackgroundThread
     private static @Nullable Path findConfiguredStorageLocation(@NotNull Project project) {
-        return ReadAction.compute(() -> AppMapFiles.findAppMapConfigFiles(project, AppMapSearchScopes.appMapsWithExcluded(project))
+        return ReadAction.compute(() -> AppMapFiles.findAppMapConfigFiles(project, AppMapSearchScopes.projectFilesWithExcluded(project))
                 .stream()
                 .map(StopAppMapRecordingAction::findAppMapDirectory)
                 .filter(Objects::nonNull)

--- a/plugin-core/src/main/java/appland/remote/StopRemoteRecordingDialog.java
+++ b/plugin-core/src/main/java/appland/remote/StopRemoteRecordingDialog.java
@@ -9,8 +9,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -20,30 +18,27 @@ public class StopRemoteRecordingDialog extends DialogWrapper {
     private final StopRemoteRecordingForm form;
 
     protected StopRemoteRecordingDialog(@NotNull Project project,
-                                        @Nullable String defaultStorageLocation,
                                         @Nullable String activeRecordingUrl,
                                         @NotNull List<String> recentRecordingUrls) {
         super(project);
 
-        form = new StopRemoteRecordingForm(project, defaultStorageLocation, activeRecordingUrl, recentRecordingUrls);
+        form = new StopRemoteRecordingForm(activeRecordingUrl, recentRecordingUrls);
         init();
     }
 
     /**
      * Show the dialog and return the entered URL.
      *
-     * @param project                The current project
-     * @param defaultStorageLocation Default value for the "storage location" input
-     * @param activeRecordingUrl     Default for the "Remote URL" input
-     * @param recentRecordingUrls    Values for the "Remote URL" dropdown
+     * @param project             The current project
+     * @param activeRecordingUrl  Default for the "Remote URL" input
+     * @param recentRecordingUrls Values for the "Remote URL" dropdown
      * @return The URL of {@code null} if the dialog was cancelled.
      */
     @Nullable
     public static StopRemoteRecordingForm show(@NotNull Project project,
-                                               @Nullable String defaultStorageLocation,
                                                @Nullable String activeRecordingUrl,
                                                @NotNull List<String> recentRecordingUrls) {
-        var dialog = new StopRemoteRecordingDialog(project, defaultStorageLocation, activeRecordingUrl, recentRecordingUrls);
+        var dialog = new StopRemoteRecordingDialog(project, activeRecordingUrl, recentRecordingUrls);
         dialog.init();
         dialog.setTitle(AppMapBundle.get("action.stopAppMapRemoteRecording.dialogTitle"));
         dialog.setOKButtonText(AppMapBundle.get("action.stopAppMapRemoteRecording.stopButton"));
@@ -59,22 +54,6 @@ public class StopRemoteRecordingDialog extends DialogWrapper {
 
         if (form.getName().isBlank()) {
             return new ValidationInfo(AppMapBundle.get("nameValidation.empty"), form.getAppMapNameInput());
-        }
-
-        if (form.getDirectoryLocation().isBlank()) {
-            return new ValidationInfo(AppMapBundle.get("dirPathValidation.empty"), form.getDirectoryLocationInput());
-        }
-
-        try {
-            var locationPath = Paths.get(form.getDirectoryLocation());
-            // if the directory does not yet exist, then we ignore it because the save implementation will create it
-            if (Files.exists(locationPath)) {
-                if (!Files.isDirectory(locationPath)) {
-                    return new ValidationInfo(AppMapBundle.get("dirPathValidation.notDir"), form.getDirectoryLocationInput());
-                }
-            }
-        } catch (Exception e) {
-            return new ValidationInfo(AppMapBundle.get("dirPathValidation.invalidPath"), form.getDirectoryLocationInput());
         }
 
         return null;

--- a/plugin-core/src/main/java/appland/remote/StopRemoteRecordingForm.form
+++ b/plugin-core/src/main/java/appland/remote/StopRemoteRecordingForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="appland.remote.StopRemoteRecordingForm">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="1125" height="381"/>
@@ -12,7 +12,7 @@
     <children>
       <vspacer id="92188">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="24a3a" class="com.intellij.ui.components.JBLabel" binding="urlLabel">
@@ -47,20 +47,6 @@
           <labelFor value="5c25f"/>
           <text value="AppMap Name:"/>
         </properties>
-      </component>
-      <component id="18efa" class="com.intellij.ui.components.JBLabel" binding="appMapLocation">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Storage Location:"/>
-        </properties>
-      </component>
-      <component id="e712d" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="directoryLocationInput">
-        <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
       </component>
     </children>
   </grid>

--- a/plugin-core/src/main/java/appland/remote/StopRemoteRecordingForm.java
+++ b/plugin-core/src/main/java/appland/remote/StopRemoteRecordingForm.java
@@ -1,16 +1,12 @@
 package appland.remote;
 
 import appland.AppMapBundle;
-import com.intellij.openapi.fileChooser.FileChooserDescriptor;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.TextFieldWithHistory;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.SystemDependent;
 
 import javax.swing.*;
 import java.util.List;
@@ -21,26 +17,14 @@ public class StopRemoteRecordingForm {
     private JBLabel urlLabel;
     private JBTextField appMapName;
     private JBLabel appMapNameLabel;
-    private JBLabel appMapLocation;
-    private TextFieldWithBrowseButton directoryLocationInput;
 
-    public StopRemoteRecordingForm(@NotNull Project project,
-                                   @Nullable String defaultStorageLocation,
-                                   @Nullable String activeRecordingUrl,
-                                   @NotNull List<String> recentRecordingUrls) {
+    public StopRemoteRecordingForm(@Nullable String activeRecordingUrl, @NotNull List<String> recentRecordingUrls) {
         urlLabel.setText(AppMapBundle.get("appMapRemoteRecording.urlLabel"));
         appMapNameLabel.setText(AppMapBundle.get("appMapRemoteRecording.appMapNameLabel"));
-        appMapLocation.setText(AppMapBundle.get("appMapRemoteRecording.locationLabel"));
 
         urlComboBox.setHistory(recentRecordingUrls);
         if (StringUtil.isNotEmpty(activeRecordingUrl)) {
             urlComboBox.setText(activeRecordingUrl);
-        }
-
-        directoryLocationInput.addBrowseFolderListener(AppMapBundle.get("action.stopAppMapRemoteRecording.fileChooserTitle"),
-                null, project, new FileChooserDescriptor(false, true, false, false, false, false));
-        if (StringUtil.isNotEmpty(defaultStorageLocation)) {
-            directoryLocationInput.setText(defaultStorageLocation);
         }
     }
 
@@ -58,21 +42,11 @@ public class StopRemoteRecordingForm {
         return this.appMapName.getText();
     }
 
-    @NotNull
-    @SystemDependent
-    public String getDirectoryLocation() {
-        return this.directoryLocationInput.getText();
-    }
-
     public JBTextField getAppMapNameInput() {
         return appMapName;
     }
 
     public TextFieldWithHistory getUrlComboBox() {
         return urlComboBox;
-    }
-
-    public TextFieldWithBrowseButton getDirectoryLocationInput() {
-        return directoryLocationInput;
     }
 }

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
@@ -17,7 +17,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class AppMapProjectSettings {
     private @Nullable List<String> recentRemoteRecordingURLs;
     private @Nullable String activeRecordingURL;
-    private @Nullable String recentAppMapStorageLocation;
     private @Nullable String cloudServerUrl;
     private boolean confirmAppMapUpload = true;
     private boolean openedAppMapEditor = false;
@@ -35,20 +34,10 @@ public class AppMapProjectSettings {
     public AppMapProjectSettings(@NotNull AppMapProjectSettings settings) {
         this.recentRemoteRecordingURLs = settings.recentRemoteRecordingURLs == null ? null : Lists.newLinkedList(settings.recentRemoteRecordingURLs);
         this.activeRecordingURL = settings.activeRecordingURL;
-        this.recentAppMapStorageLocation = settings.recentAppMapStorageLocation;
         this.cloudServerUrl = settings.cloudServerUrl;
         this.confirmAppMapUpload = settings.confirmAppMapUpload;
         this.openedAppMapEditor = settings.openedAppMapEditor;
         this.createdOpenAPI = settings.createdOpenAPI;
-    }
-
-    @NotNull
-    public synchronized String getRecentAppMapStorageLocation() {
-        return recentAppMapStorageLocation == null ? "" : recentAppMapStorageLocation;
-    }
-
-    public synchronized void setRecentAppMapStorageLocation(@NotNull String recentAppMapStorageLocation) {
-        this.recentAppMapStorageLocation = recentAppMapStorageLocation;
     }
 
     @NotNull


### PR DESCRIPTION
closes https://github.com/getappmap/appmap-intellij-plugin/issues/289

- Drop the file path input from the dialog of the "Stop Remote Recording" action
- Default to `target/appmap` instead of `tmp/appmap`

The storage location of "Stop Remote Recording" now looks into appmap.yml and then defaults to  `target/appmap` if no `appmap_dir` setting was found.