### PR TITLE
Execute the AppMap install command with a PTY

### DIFF
--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -3,6 +3,7 @@ package appland.cli;
 import appland.AppMapBaseTest;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.PtyCommandLine;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
@@ -20,6 +21,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -149,6 +151,12 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         });
         assertTrue(condition.await(30, TimeUnit.SECONDS));
         assertActiveRoots(newRootA, newRootB);
+    }
+
+    @Test
+    public void installCommandLineHasPty() {
+        var installCommand = AppLandCommandLineService.getInstance().createInstallCommand(Paths.get("/"), "java");
+        assertTrue("The install command must have PTY", installCommand instanceof PtyCommandLine);
     }
 
     @Test

--- a/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerTest.java
@@ -32,7 +32,7 @@ public class ScannerFilesAsyncListenerTest extends AppMapBaseTest {
         var condition = createFindingsCondition();
         // adding an appmap-findings.json file must trigger a refresh via the file watcher
         myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");
-        assertTrue(condition.await(30, TimeUnit.SECONDS));
+        assertTrue(condition.await(60, TimeUnit.SECONDS));
 
         assertFindings(1, 1);
     }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/288

The install command needs a PTY, e.g. to query for user input on the terminal.
This is a regression of https://github.com/getappmap/appmap-intellij-plugin/pull/248. The prune command did not work with a  PTY. This PR adds a test and fix to ensure that the install command is executed with a PTY terminal.