### PR TITLE
Download the latest AppMap Java agent at startup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ plugins {
 
 val pluginVersion = prop("pluginVersion")
 val lombokVersion = prop("lombokVersion")
-val appMapJvmAgentVersion = prop("appMapJvmAgent")
 
 group = "appland.appmap"
 version = pluginVersion
@@ -142,15 +141,11 @@ allprojects {
 }
 
 project(":") {
-    val appMapJavaAgent = configurations.create("appMapJavaAgent")
     dependencies {
         implementation(project(":plugin-core", "instrumentedJar"))
         implementation(project(":plugin-gradle", "instrumentedJar"))
         implementation(project(":plugin-java", "instrumentedJar"))
         implementation(project(":plugin-maven", "instrumentedJar"))
-
-        // to copy the appmap-java jar file into the plugin zip
-        appMapJavaAgent("com.appland:appmap-agent:$appMapJvmAgentVersion")
     }
 
     changelog {
@@ -163,7 +158,6 @@ project(":") {
             inputs.dir("${project.rootDir}/appland-install-guide")
             inputs.dir("${project.rootDir}/appland-findings")
             inputs.dir("${project.rootDir}/appland-signin")
-            inputs.files(appMapJavaAgent)
 
             destinationDir = project.buildDir
             from("${project.rootDir}/appland") {
@@ -185,15 +179,6 @@ project(":") {
                 into("appmap-assets/appland-signin")
                 include("index.html")
                 include("dist/**")
-            }
-            from(appMapJavaAgent) {
-                into("appmap-assets/appmap-agents")
-                rename {
-                    when (it.startsWith("appmap-agent-")) {
-                        true -> "appmap-agent.jar"
-                        false -> name
-                    }
-                }
             }
 
             processResources {

--- a/plugin-core/src/main/java/appland/AppMapPlugin.java
+++ b/plugin-core/src/main/java/appland/AppMapPlugin.java
@@ -40,10 +40,6 @@ public final class AppMapPlugin {
         return getPluginPath().resolve("appland-signin").resolve("index.html");
     }
 
-    public static Path getJavaAgentPath() {
-        return getPluginPath().resolve("appmap-agents").resolve("appmap-agent.jar");
-    }
-
     @NotNull
     public static PluginDescriptor getDescriptor() {
         var plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -175,3 +175,6 @@ codeObjects.navigation.locatingFiles=Locating AppMaps....
 codeObjects.chooseAppMap=Choose AppMap File
 codeObjects.requestTopLevel.label=HTTP server requests
 codeObjects.queryTopLevel.label=Queries
+
+javaAgent.download.title=Downloading AppMap Java agent...
+javaAgent.run.missingJar=Unable to execute because the AppMap Java agent file is unavailable

--- a/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
@@ -1,6 +1,7 @@
 package appland.execution;
 
-import appland.AppMapPlugin;
+import appland.AppMapBundle;
+import appland.javaAgent.AppMapJavaAgentDownloadService;
 import com.intellij.execution.CantRunException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,13 +20,18 @@ public class AppMapJvmCommandLinePatcher {
             throw new CantRunException("Unable to find an appmap.yml file");
         }
 
+        var agentJarPath = AppMapJavaAgentDownloadService.getInstance().getJavaAgentPathIfExists();
+        if (agentJarPath == null) {
+            throw new CantRunException(AppMapBundle.get("javaAgent.run.missingJar"));
+        }
+
         var jvmParams = new LinkedList<String>();
         //jvmParams.add("-Dappmap.debug");
         jvmParams.add("-Dappmap.config.file=" + appMapConfig);
         if (appMapOutputDirectory != null) {
             jvmParams.add("-Dappmap.output.directory=" + appMapOutputDirectory);
         }
-        jvmParams.add("-javaagent:" + AppMapPlugin.getJavaAgentPath());
+        jvmParams.add("-javaagent:" + agentJarPath);
         return jvmParams;
     }
 }

--- a/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadActivity.java
+++ b/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadActivity.java
@@ -1,0 +1,25 @@
+package appland.javaAgent;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AppMapJavaAgentDownloadActivity implements StartupActivity.Background {
+    private static final Logger LOG = Logger.getInstance(AppMapJavaAgentDownloadActivity.class);
+    private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
+
+    @Override
+    public void runActivity(@NotNull Project project) {
+        if (ACTIVE.compareAndSet(false, true)) {
+            try {
+                LOG.debug("Downloading AppMap Java agent");
+                AppMapJavaAgentDownloadService.getInstance().downloadJavaAgent(project);
+            } catch (Exception e) {
+                LOG.warn("Failed to download AppMap Java agent", e);
+            }
+        }
+    }
+}

--- a/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
+++ b/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
@@ -80,18 +80,18 @@ public final class AppMapJavaAgentDownloadService {
             return false;
         }
 
-        // e.g. appmap-1.7.2.downloading
-        var lockFilePath = assetDownloadPath.resolveSibling(latestAsset.getFileName().replace(".jar", ".downloading"));
+        // e.g. appmap-1.7.2.jar.downloading
+        var lockFilePath = assetDownloadPath.resolveSibling(latestAsset.getFileName() + ".downloading");
         assert !assetDownloadPath.equals(lockFilePath);
 
         if (!guardWithLockFile(lockFilePath, () -> downloadAgentJarFile(indicator, latestAsset, assetDownloadPath))) {
             return false;
         }
 
-        // create a symbolic link pointing to "appmap.jar"
+        // create a relative symbolic appmap.jar pointing to the downloaded JAR file
         try {
             Files.deleteIfExists(agentFilePath);
-            Files.createSymbolicLink(agentFilePath, assetDownloadPath);
+            Files.createSymbolicLink(agentFilePath, agentFilePath.getParent().relativize(assetDownloadPath));
         } catch (IOException e) {
             // copy the downloaded file to "agent.jar" as a fallback,
             // e.g. on system where symbolic links are unsupported
@@ -161,7 +161,7 @@ public final class AppMapJavaAgentDownloadService {
      * @return The path of the directory, where the AppMap Java agent should be stored (~/.appmap/lib/java).
      */
     @Nullable Path getOrCreateAgentDir() {
-        var agentDirPath = Paths.get(System.getProperty("user.dir")).resolve(Paths.get("appmap", "lib", "java"));
+        var agentDirPath = Paths.get(System.getProperty("user.dir")).resolve(Paths.get(".appmap", "lib", "java"));
         try {
             Files.createDirectories(agentDirPath);
             return agentDirPath;

--- a/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
+++ b/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
@@ -1,0 +1,173 @@
+package appland.javaAgent;
+
+import appland.AppMapBundle;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.PerformInBackgroundOption;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.ThrowableRunnable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Application service to manage the download of the AppMap Java agent.
+ */
+public final class AppMapJavaAgentDownloadService {
+    private static final Logger LOG = Logger.getInstance(AppMapJavaAgentDownloadService.class);
+    private static final String AGENT_LINK_FILENAME = "appmap.jar";
+
+    public static AppMapJavaAgentDownloadService getInstance() {
+        return ApplicationManager.getApplication().getService(AppMapJavaAgentDownloadService.class);
+    }
+
+    /**
+     * @return Local path to the downloaded Java agent file.
+     * {@code null} is returned if the agent has not been downloaded yet.
+     */
+    public @Nullable Path getJavaAgentPathIfExists() {
+        var jarFilePath = getJavaAgentPath();
+        return jarFilePath == null || Files.notExists(jarFilePath) ? null : jarFilePath;
+    }
+
+    @SuppressWarnings("DialogTitleCapitalization")
+    public void downloadJavaAgent(@NotNull Project project) {
+        var title = AppMapBundle.get("javaAgent.download.title");
+        new Task.Backgroundable(project, title, false, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                try {
+                    downloadJavaAgentSync(indicator);
+                } catch (IOException e) {
+                    LOG.warn("failed to download AppMap Java agent", e);
+                }
+            }
+        }.queue();
+    }
+
+    public boolean downloadJavaAgentSync(@NotNull ProgressIndicator indicator) throws IOException {
+        var agentFilePath = getJavaAgentPath();
+        if (agentFilePath == null) {
+            LOG.warn("unable to locate target file path for AppMap Java agent");
+            return false;
+        }
+
+        var latestAsset = GitHubRelease.getLatestRelease(indicator, "getappmap", "appmap-java")
+                .stream()
+                .filter(asset -> "application/java-archive".equals(asset.getContentType()))
+                .findFirst()
+                .orElse(null);
+
+        if (latestAsset == null) {
+            LOG.warn("JAR assets not found in latest GitHub release of getappmap/appmap-java");
+            return false;
+        }
+
+        // e.g. ~/.appmap/lib/java/appmap-1.7.2.jar
+        var assetDownloadPath = agentFilePath.resolveSibling(latestAsset.getFileName());
+
+        // don't download if the asset file does already exist
+        if (Files.exists(assetDownloadPath)) {
+            return false;
+        }
+
+        // e.g. appmap-1.7.2.downloading
+        var lockFilePath = assetDownloadPath.resolveSibling(latestAsset.getFileName().replace(".jar", ".downloading"));
+        assert !assetDownloadPath.equals(lockFilePath);
+
+        if (!guardWithLockFile(lockFilePath, () -> downloadAgentJarFile(indicator, latestAsset, assetDownloadPath))) {
+            return false;
+        }
+
+        // create a symbolic link pointing to "appmap.jar"
+        try {
+            Files.deleteIfExists(agentFilePath);
+            Files.createSymbolicLink(agentFilePath, assetDownloadPath);
+        } catch (IOException e) {
+            // copy the downloaded file to "agent.jar" as a fallback,
+            // e.g. on system where symbolic links are unsupported
+            Files.copy(assetDownloadPath, agentFilePath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Guards the operation of the runnable with a lock file.
+     * If the lock file does already exist and is less than 5 minutes old, then the runnable is NOT executed.
+     * Otherwise, the lock file is either created or updated before the runnable is executed.
+     *
+     * @param lockFilePath Target path of the lock file
+     * @param runnable     The operation to guard with the lock file
+     * @return {@code true} if the runnable was executed
+     * @throws IOException Thrown if the runnable failed to execute
+     */
+    private boolean guardWithLockFile(@NotNull Path lockFilePath,
+                                      @NotNull ThrowableRunnable<IOException> runnable) throws IOException {
+        if (Files.exists(lockFilePath)) {
+            var fiveMinutesAgo = Instant.now().minus(5, ChronoUnit.MINUTES);
+            if (!Files.getLastModifiedTime(lockFilePath).toInstant().isBefore(fiveMinutesAgo)) {
+                return false;
+            }
+
+            Files.setLastModifiedTime(lockFilePath, FileTime.from(Instant.now()));
+        } else {
+            Files.createFile(lockFilePath);
+        }
+
+        try {
+            runnable.run();
+        } finally {
+            Files.deleteIfExists(lockFilePath);
+        }
+        return true;
+    }
+
+    /**
+     * Downloads the GitHub asset and stores it at the given path.
+     *
+     * @param indicator         Progress indicator
+     * @param agentReleaseAsset Asset to download
+     * @param assetDownloadPath Target path, where the download is stored on disk
+     * @throws IOException Thrown if the download failed to complete
+     */
+    private static void downloadAgentJarFile(@NotNull ProgressIndicator indicator,
+                                             @NotNull GitHubReleaseAsset agentReleaseAsset,
+                                             @NotNull Path assetDownloadPath) throws IOException {
+        try {
+            agentReleaseAsset.download(indicator, assetDownloadPath);
+        } catch (IOException e) {
+            // remove partial download and throw IOException
+            Files.deleteIfExists(assetDownloadPath);
+            throw new IOException("Failed to download agent JAR: " + agentReleaseAsset.getDownloadUrl(), e);
+        }
+    }
+
+    private @Nullable Path getJavaAgentPath() {
+        var agentDir = getOrCreateAgentDir();
+        return agentDir == null ? null : agentDir.resolve(AGENT_LINK_FILENAME);
+    }
+
+    /**
+     * @return The path of the directory, where the AppMap Java agent should be stored (~/.appmap/lib/java).
+     */
+    @Nullable Path getOrCreateAgentDir() {
+        var agentDirPath = Paths.get(System.getProperty("user.dir")).resolve(Paths.get("appmap", "lib", "java"));
+        try {
+            Files.createDirectories(agentDirPath);
+            return agentDirPath;
+        } catch (IOException e) {
+            LOG.warn("error creating AppMap agent directory: " + agentDirPath, e);
+            return null;
+        }
+    }
+}

--- a/plugin-java/src/main/java/appland/javaAgent/GitHubReleaseAsset.java
+++ b/plugin-java/src/main/java/appland/javaAgent/GitHubReleaseAsset.java
@@ -1,0 +1,43 @@
+package appland.javaAgent;
+
+import appland.utils.GsonUtils;
+import com.google.gson.annotations.SerializedName;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.util.io.HttpRequests;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+final class GitHubRelease {
+    @SuppressWarnings("SameParameterValue")
+    static List<GitHubReleaseAsset> getLatestRelease(@NotNull ProgressIndicator progressIndicator,
+                                                     @NotNull String repoOwner,
+                                                     @NotNull String repoName) throws IOException {
+        var url = String.format("https://api.github.com/repos/%s/%s/releases/latest", repoOwner, repoName);
+        var response = HttpRequests.request(url).readString(progressIndicator);
+        return List.of(GsonUtils.GSON.fromJson(response, GitHubReleaseResponse.class).getAssets());
+    }
+}
+
+@Value
+class GitHubReleaseResponse {
+    @SerializedName("assets")
+    GitHubReleaseAsset[] assets;
+}
+
+@Value
+class GitHubReleaseAsset {
+    @SerializedName("name")
+    String fileName;
+    @SerializedName("content_type")
+    String contentType;
+    @SerializedName("browser_download_url")
+    String downloadUrl;
+
+    void download(@NotNull ProgressIndicator progressIndicator, @NotNull Path targetFilePath) throws IOException {
+        HttpRequests.request(this.downloadUrl).saveToFile(targetFilePath, progressIndicator);
+    }
+}

--- a/plugin-java/src/main/resources/META-INF/appmap-java.xml
+++ b/plugin-java/src/main/resources/META-INF/appmap-java.xml
@@ -1,5 +1,8 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="appland.javaAgent.AppMapJavaAgentDownloadService"/>
+        <postStartupActivity implementation="appland.javaAgent.AppMapJavaAgentDownloadActivity"/>
+
         <programRunner implementation="appland.execution.AppMapJavaAgentRunner"/>
         <java.programPatcher implementation="appland.execution.AppMapJavaProgramPatcher"/>
     </extensions>

--- a/plugin-java/src/test/java/appland/execution/AppMapJavaAgentRunnerTest.java
+++ b/plugin-java/src/test/java/appland/execution/AppMapJavaAgentRunnerTest.java
@@ -1,7 +1,7 @@
 package appland.execution;
 
 import appland.AppLandTestExecutionPolicy;
-import appland.AppMapPlugin;
+import appland.javaAgent.AppMapJavaAgentDownloadService;
 import com.intellij.execution.ProgramRunnerUtil;
 import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.execution.application.ApplicationConfiguration;
@@ -60,7 +60,12 @@ public class AppMapJavaAgentRunnerTest extends BaseAppMapJavaTest {
         var descriptor = runConfigDescriptor.get();
         assertNotNull(descriptor);
 
-        var cmdline = descriptor.getProcessHandler().toString();
-        assertTrue("The JVM command must be patched with the AppMap agent", cmdline.contains(AppMapPlugin.getJavaAgentPath().toString()));
+        var processHandler = descriptor.getProcessHandler();
+        assertNotNull(processHandler);
+        var cmdline = processHandler.toString();
+
+        var agentJarPath = AppMapJavaAgentDownloadService.getInstance().getJavaAgentPathIfExists();
+        assertNotNull(agentJarPath);
+        assertTrue("The JVM command must be patched with the AppMap agent", cmdline.contains(agentJarPath.toString()));
     }
 }

--- a/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
+++ b/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
@@ -1,9 +1,11 @@
 package appland.execution;
 
 import appland.cli.AppLandCommandLineService;
+import appland.javaAgent.AppMapJavaAgentDownloadService;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.util.Disposer;
@@ -14,6 +16,14 @@ public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
     @Override
     protected void setUp() throws Exception {
         EdtTestUtil.runInEdtAndWait(super::setUp);
+
+        try {
+            if (AppMapJavaAgentDownloadService.getInstance().getJavaAgentPathIfExists() == null) {
+                AppMapJavaAgentDownloadService.getInstance().downloadJavaAgentSync(new EmptyProgressIndicator());
+            }
+        } catch (Exception e) {
+            addSuppressedException(e);
+        }
     }
 
     @Override

--- a/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
+++ b/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
@@ -43,6 +43,16 @@ public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
     }
 
     @Test
+    public void agentDirPath(){
+        var service = AppMapJavaAgentDownloadService.getInstance();
+        var agentDir = service.getOrCreateAgentDir();
+        assertNotNull(agentDir);
+
+        var expectedParent = Paths.get(System.getProperty("user.dir")).resolve(".appmap");
+        assertTrue("Agent dir must be under ~/.agent", agentDir.startsWith(expectedParent));
+    }
+
+    @Test
     public void multipleDownloadRequests() throws IOException {
         var service = AppMapJavaAgentDownloadService.getInstance();
         assertNull("JAR file must not exist in a clean temp directory", service.getJavaAgentPathIfExists());
@@ -70,7 +80,7 @@ public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
         var agentDir = service.getOrCreateAgentDir();
         assertTrue("Agent target directory must exist", agentDir != null && Files.isDirectory(agentDir));
 
-        var lockFilePath = agentDir.resolve(jarAsset.getFileName().replace(".jar", ".downloading"));
+        var lockFilePath = agentDir.resolve(jarAsset.getFileName() + ".downloading");
         assertFalse(Files.exists(lockFilePath));
         Files.createFile(lockFilePath);
 

--- a/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
+++ b/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
@@ -1,0 +1,82 @@
+package appland.javaAgent;
+
+import appland.AppMapBaseTest;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.NioFiles;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
+    @Rule
+    public final TestRule systemPropertyUpdate = (statement, description) -> new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            var oldUserHome = System.getProperty("user.dir");
+            try {
+                var path = Paths.get(myFixture.getTempDirFixture().getTempDirPath()).resolve("appmap-agent");
+                NioFiles.deleteRecursively(path);
+
+                System.setProperty("user.dir", path.toString());
+                statement.evaluate();
+            } finally {
+                System.setProperty("user.dir", oldUserHome);
+            }
+        }
+    };
+
+    @Override
+    protected TempDirTestFixture createTempDirTestFixture() {
+        // create temp files on disk
+        return new TempDirTestFixtureImpl();
+    }
+
+    @Test
+    public void multipleDownloadRequests() throws IOException {
+        var service = AppMapJavaAgentDownloadService.getInstance();
+        assertNull("JAR file must not exist in a clean temp directory", service.getJavaAgentPathIfExists());
+
+        assertTrue("First attempt must download the file", service.downloadJavaAgentSync(new EmptyProgressIndicator()));
+        assertNotNull("JAR file must exist after a download", service.getJavaAgentPathIfExists());
+        if (SystemInfo.isUnix) {
+            assertTrue("agent.jar must be a symbolic link", Files.isSymbolicLink(service.getJavaAgentPathIfExists()));
+        }
+
+        assertFalse("Second attempt must skip the download", service.downloadJavaAgentSync(new EmptyProgressIndicator()));
+        assertNotNull("JAR file must still exist after a skipped download", service.getJavaAgentPathIfExists());
+    }
+
+    @Test
+    public void lockFileGuard() throws IOException {
+        var service = AppMapJavaAgentDownloadService.getInstance();
+
+        var jarAsset = GitHubRelease.getLatestRelease(new EmptyProgressIndicator(), "getappmap", "appmap-java")
+                .stream()
+                .filter(asset -> asset.getFileName().endsWith(".jar"))
+                .findFirst().orElse(null);
+        assertNotNull(jarAsset);
+
+        var agentDir = service.getOrCreateAgentDir();
+        assertTrue("Agent target directory must exist", agentDir != null && Files.isDirectory(agentDir));
+
+        var lockFilePath = agentDir.resolve(jarAsset.getFileName().replace(".jar", ".downloading"));
+        assertFalse(Files.exists(lockFilePath));
+        Files.createFile(lockFilePath);
+
+        assertFalse("Agent must not be downloaded if a new lock file exists", service.downloadJavaAgentSync(new EmptyProgressIndicator()));
+
+        Files.setLastModifiedTime(lockFilePath, FileTime.from(Instant.now().minus(6, ChronoUnit.MINUTES)));
+        assertTrue("Agent must be downloaded if an old lock file exists", service.downloadJavaAgentSync(new EmptyProgressIndicator()));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/287

With this PR, the Java agent JAR file is downloaded at startup.
The download is only made if the current IDE provides Java support (i.e. IntelliJ IDEA Ultimate or Community). The agent file is only needed for Java-based run configurations. Limiting the download to Java projects is unreliable IMHO, because projects can contain mixed of any kind of language and Java support may be added after a project is opened.

This follows the implementation of VSCode, as outlined by @ahtrotta :
> 1. If the latest JAR file version already exists on disk, then do nothing and return.
> 2. Look for a file in the target directory called appmap-X.X.X.jar.downloading. If this file already exists, and it's less than 5 minutes old, return and do nothing - because another VSCode instance is already performing the update.
> 3. Touch/create the lock file appmap-X.X.X.downloading. Set mtime to now if it already exists.
> 4. Download the new JAR file.
> 5. Delete the lock file.
> 6. Symlink or copy the downloaded JAR file to appmap.jar