### PR TITLE
Cleanup handling of non-blocking ReadAction

### DIFF
--- a/plugin-core/src/main/java/appland/problemsView/listener/ScannerFilesAsyncListener.java
+++ b/plugin-core/src/main/java/appland/problemsView/listener/ScannerFilesAsyncListener.java
@@ -3,8 +3,8 @@ package appland.problemsView.listener;
 import appland.index.AppMapFindingsUtil;
 import appland.problemsView.FindingsManager;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.ThrowableComputable;
@@ -123,10 +123,12 @@ public class ScannerFilesAsyncListener implements AsyncFileListener {
                         continue;
                     }
 
-                    // we need to run in smart mode because the findings manager uses the index to find relative files
-                    ReadAction.nonBlocking(() -> processChangesAsync(project, toAdd, toRemove, toRefresh, directories))
-                            .inSmartMode(project)
-                            .submit(executor);
+                    executor.submit(() -> {
+                        // we need to run in smart mode because the findings manager uses the index to find relative files
+                        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
+                            processChangesAsync(project, toAdd, toRemove, toRefresh, directories);
+                        });
+                    });
                 }
             }
         };

--- a/plugin-core/src/test/java/appland/problemsView/FindingsManagerTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/FindingsManagerTest.java
@@ -7,9 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class FindingsManagerTest extends AppMapBaseTest {
     @Before
@@ -32,17 +30,18 @@ public class FindingsManagerTest extends AppMapBaseTest {
     }
 
     @Test
-    public void findingsVSCodeSystem() throws ExecutionException, InterruptedException, TimeoutException {
+    public void findingsVSCodeSystem() throws Exception {
         var manager = FindingsManager.getInstance(getProject());
+
+        var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
         var root = myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");
+        assertTrue(condition.await(30, TimeUnit.SECONDS));
 
         var findingsFile = root.findChild("appmap-findings.json");
         assertNotNull(findingsFile);
 
         var problematicFile = root.findFileByRelativePath("app/controllers/microposts_controller.rb");
         assertNotNull(problematicFile);
-
-        manager.reloadAsync().blockingGet(30, TimeUnit.SECONDS);
 
         assertEquals(1, manager.getProblemFileCount());
         assertEquals(1, manager.getProblemCount());

--- a/plugin-core/src/test/java/appland/problemsView/TestFindingsManager.java
+++ b/plugin-core/src/test/java/appland/problemsView/TestFindingsManager.java
@@ -1,7 +1,11 @@
 package appland.problemsView;
 
+import appland.problemsView.listener.ScannerFindingsListener;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CountDownLatch;
 
 public class TestFindingsManager extends FindingsManager {
     public TestFindingsManager(@NotNull Project project) {
@@ -10,5 +14,21 @@ public class TestFindingsManager extends FindingsManager {
 
     public static void reset(@NotNull Project project) {
         FindingsManager.getInstance(project).reset();
+    }
+
+    public static @NotNull CountDownLatch createFindingsCondition(@NotNull Project project, @NotNull Disposable disposable) {
+        var latch = new CountDownLatch(1);
+        project.getMessageBus().connect(disposable).subscribe(ScannerFindingsListener.TOPIC, new ScannerFindingsListener() {
+            @Override
+            public void afterFindingsReloaded() {
+                latch.countDown();
+            }
+
+            @Override
+            public void afterFindingsChanged() {
+                latch.countDown();
+            }
+        });
+        return latch;
     }
 }

--- a/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
@@ -2,11 +2,9 @@ package appland.toolwindow.runtimeAnalysis;
 
 import appland.AppMapBaseTest;
 import appland.problemsView.FindingsManager;
-import appland.problemsView.listener.ScannerFilesAsyncListener;
+import appland.problemsView.TestFindingsManager;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.project.DumbUtilImpl;
-import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assume;
@@ -104,9 +102,8 @@ public class RuntimeAnalysisModelTest extends AppMapBaseTest {
     }
 
     private void loadFindingsDirectory(@NotNull String directoryPath) throws Exception {
-        ScannerFilesAsyncListener.disableForTests(() -> {
-            return WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject(directoryPath, "root"));
-        });
-        FindingsManager.getInstance(getProject()).reloadAsync().blockingGet(30, TimeUnit.SECONDS);
+        var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
+        WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject(directoryPath, "root"));
+        assertTrue(condition.await(30, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
Removing the use of `ReadAction.nonBlocking` in `ScannerFilesAsyncListner`, because a non-blocking action may be executed multiple times and this call has side-effects. We're now using a blocking ReadAction in smart mode instead. Such side-effects could cause too few or too many findings.

https://github.com/getappmap/appmap-intellij-plugin/pull/303/commits/5dbe753a05e7e962e5ef894f025c90fba83702c9 cleans up the non-blocking ReadAction of `FindingsManager.reloadAsync()`. It removes the return value (a `Promise`) in favor of the message bus. The return value was complicating our setup and didn't work well with the cancellation of the non-blocking ReadAction (via `.coalesceBy(getClass(), project)`). This should hopefully make our tests more stable. Tests were sometimes failing on my local system, most likely caused by differing CPU load.
As far as I understand, `thenAsync`, was the culprit of the callback on the Event Dispatch Thread. I've removed it in favor of `onSuccess`, which follows the usage in the JetBrains platform code.
