### PR TITLE
Don't show an empty list of findings after project is opened

### DIFF
--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -7,14 +7,25 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
+import org.junit.Before;
 
 import java.util.Collections;
 
 public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4TestCase {
+    @Before
+    public void cleanupTempFilesystem() {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            TempFileSystem.getInstance().cleanupForNextTest();
+        } else {
+            edt(() -> TempFileSystem.getInstance().cleanupForNextTest());
+        }
+    }
+
     @Override
     protected LightProjectDescriptor getProjectDescriptor() {
         // we're returning a new instance, because we don't want to share the project setup between light tests.


### PR DESCRIPTION
The reload of findings was breaking because of a threading issue. 
The non-blocking ReadAction cancels the operation after the results are calculated. We used to call `onSuccess()`, which unfortunately may happen after or during the cancellation is triggered. This could cause an empty or an incomplete list of findings at startup.
This fix is hopefully fixing this for good. Unfortunately, I don't know of a reliable way to test this with a unit test.