### PR TITLE
Set `appmap_dir` when creating an `appmap.yml` file

### DIFF
--- a/plugin-core/src/main/java/appland/config/AppMapConfigFile.java
+++ b/plugin-core/src/main/java/appland/config/AppMapConfigFile.java
@@ -1,21 +1,112 @@
 package appland.config;
 
+import appland.utils.YamlUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Represents a `appmap.yml` file.
+ * It's operating on the parsed YML and retains all original values when written to disk.
  */
 @Data
+@AllArgsConstructor
 public class AppMapConfigFile {
-    @Nullable final String appMapDir;
+    private static final Logger LOG = Logger.getInstance(AppMapConfigFile.class);
+    private static final String NAME_PROPERTY = "name";
+    private static final String APPMAP_DIR_PROPERTY = "appmap_dir";
+    private static final String PACKAGES_PROPERTY = "packages";
+
+    private final @NotNull ObjectNode yamlData;
+
+    public AppMapConfigFile() {
+        this(new ObjectNode(JsonNodeFactory.instance));
+    }
+
+    public @Nullable String getName() {
+        if (yamlData.hasNonNull(NAME_PROPERTY)) {
+            return yamlData.get(NAME_PROPERTY).asText();
+        }
+        return null;
+    }
+
+    public void setName(@Nullable String name) {
+        if (StringUtil.isEmpty(name)) {
+            yamlData.remove(NAME_PROPERTY);
+        } else {
+            yamlData.set(NAME_PROPERTY, new TextNode(name));
+        }
+    }
+
+    /**
+     * @return The value of the "appmap_dir" property of the AppMap configuration
+     */
+    public @Nullable String getAppMapDir() {
+        return yamlData.hasNonNull(APPMAP_DIR_PROPERTY)
+                ? yamlData.get(APPMAP_DIR_PROPERTY).asText()
+                : null;
+    }
+
+    /**
+     * Updates property "appmap_dir". It's removed if {@code null} is passed as new value.
+     */
+    public void setAppMapDir(@Nullable String appMapDir) {
+        if (appMapDir == null) {
+            yamlData.remove(APPMAP_DIR_PROPERTY);
+        } else {
+            yamlData.set(APPMAP_DIR_PROPERTY, new TextNode(appMapDir));
+        }
+    }
+
+    public @NotNull List<Package> getPackages() {
+        if (!yamlData.has(PACKAGES_PROPERTY)) {
+            return Collections.emptyList();
+        }
+
+        var yamlValue = yamlData.get(PACKAGES_PROPERTY);
+        if (!yamlValue.isArray()) {
+            LOG.debug("Property 'packages' must be an array");
+            return Collections.emptyList();
+        }
+
+        try {
+            return YamlUtils.YAML.readerForListOf(Package.class).readValue(yamlValue);
+        } catch (IOException e) {
+            LOG.debug("Error parsing appmap config packages", e);
+            return Collections.emptyList();
+        }
+    }
+
+    public void setPackages(@Nullable List<String> packages) {
+        if (packages == null || packages.isEmpty()) {
+            yamlData.remove(PACKAGES_PROPERTY);
+            return;
+        }
+
+        var packageNodes = packages.stream()
+                .map(Package::new)
+                .collect(Collectors.toList());
+        yamlData.set(PACKAGES_PROPERTY, YamlUtils.YAML.valueToTree(packageNodes));
+    }
+
+    public void writeTo(@NotNull Path filePath) throws IOException {
+        YamlUtils.YAML.writeValue(filePath.toFile(), yamlData);
+    }
 
     public static @Nullable AppMapConfigFile parseConfigFile(@Nullable VirtualFile configFile) {
         if (configFile == null) {
@@ -40,15 +131,24 @@ public class AppMapConfigFile {
         }
 
         try {
-            var lines = Files.readAllLines(configFile);
-            var appMapDir = lines.stream()
-                    .filter(line -> line.trim().startsWith("appmap_dir:"))
-                    .findFirst()
-                    .map(line -> StringUtil.trimStart(line.trim(), "appmap_dir:").trim());
-            return appMapDir.map(AppMapConfigFile::new).orElse(null);
-        } catch (IOException e) {
-            Logger.getInstance(AppMapConfigFile.class).debug("Error reading appmap.config file: " + configFile, e);
+            var yamlTree = YamlUtils.YAML.readTree(configFile.toFile());
+            if (!yamlTree.isObject()) {
+                LOG.debug("appmap.yml is not an object: " + configFile);
+                return null;
+            }
+
+            return new AppMapConfigFile((ObjectNode) yamlTree);
+        } catch (Exception e) {
+            LOG.debug("Error reading appmap configuration: " + configFile, e);
             return null;
         }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Package {
+        @JsonProperty("path")
+        @Nullable String path = null;
     }
 }

--- a/plugin-core/src/main/java/appland/utils/YamlUtils.java
+++ b/plugin-core/src/main/java/appland/utils/YamlUtils.java
@@ -1,0 +1,10 @@
+package appland.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+public class YamlUtils {
+    public static final ObjectMapper YAML = new YAMLMapper()
+            .configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false);
+}

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -152,6 +152,7 @@ appMapExecutor.startAction=Start with AppMap
 appMapExecutor.startActionConfigName=Start {0} with AppMap
 appMapExecutor.jdkNotSupportedWithLink=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry. <a href="">Configure</a>
 appMapExecutor.jdkNotSupported=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry.
+appMapExecutor.executionError.message=Unable to execute the run configuration: {0}.b
 
 annotator.quickFixFamily=AppMap
 annotator.openQuickFix.name=Open in AppMap file

--- a/plugin-core/src/test/java/appland/config/AppMapConfigFileTest.java
+++ b/plugin-core/src/test/java/appland/config/AppMapConfigFileTest.java
@@ -5,6 +5,10 @@ import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 public class AppMapConfigFileTest extends AppMapBaseTest {
     @Override
     protected TempDirTestFixture createTempDirTestFixture() {
@@ -16,7 +20,7 @@ public class AppMapConfigFileTest extends AppMapBaseTest {
         var appMapFile = myFixture.copyFileToProject("appmap-config/appmap.yml");
         var config = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
         assertNotNull(config);
-        assertEquals("tmp/appmap", config.appMapDir);
+        assertEquals("tmp/appmap", config.getAppMapDir());
 
         var vfsConfig = AppMapConfigFile.parseConfigFile(appMapFile);
         assertEquals(config, vfsConfig);
@@ -25,8 +29,14 @@ public class AppMapConfigFileTest extends AppMapBaseTest {
     @Test
     public void readConfigWithoutPath() {
         var appMapFile = myFixture.copyFileToProject("appmap-config/appmap-no-dir.yml");
-        assertNull(AppMapConfigFile.parseConfigFile(appMapFile));
-        assertNull(AppMapConfigFile.parseConfigFile(appMapFile.toNioPath()));
+
+        var fromVirtualFile = AppMapConfigFile.parseConfigFile(appMapFile);
+        assertNotNull(fromVirtualFile);
+        assertNull(fromVirtualFile.getAppMapDir());
+
+        var fromNioFile = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
+        assertNotNull(fromNioFile);
+        assertNull(fromNioFile.getAppMapDir());
     }
 
     @Test
@@ -34,5 +44,71 @@ public class AppMapConfigFileTest extends AppMapBaseTest {
         var appMapFile = myFixture.copyFileToProject("appmap-config/appmap-empty.yml");
         assertNull(AppMapConfigFile.parseConfigFile(appMapFile));
         assertNull(AppMapConfigFile.parseConfigFile(appMapFile.toNioPath()));
+    }
+
+    @Test
+    public void updateAppMapDirProperty() throws IOException {
+        var appMapFile = myFixture.copyFileToProject("appmap-config/appmap-no-dir.yml");
+        var config = AppMapConfigFile.parseConfigFile(appMapFile);
+        assertNotNull(config);
+        assertNull(config.getAppMapDir());
+
+        // set to text value
+        config.setAppMapDir("/updated/appmap/dir");
+        config.writeTo(appMapFile.toNioPath());
+
+        var updatedConfig = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
+        assertNotNull(updatedConfig);
+        assertEquals("/updated/appmap/dir", updatedConfig.getAppMapDir());
+
+        // reset to null
+        config.setAppMapDir(null);
+        config.writeTo(appMapFile.toNioPath());
+
+        updatedConfig = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
+        assertNotNull(updatedConfig);
+        assertNull(updatedConfig.getAppMapDir());
+    }
+
+    @Test
+    public void updatePackages() throws IOException {
+        var appMapFile = myFixture.copyFileToProject("appmap-config/appmap-packages.yml");
+        var config = AppMapConfigFile.parseConfigFile(appMapFile);
+        assertNotNull(config);
+
+        var packages = List.of(new AppMapConfigFile.Package("package/one"), new AppMapConfigFile.Package("package/two"));
+        assertEquals(packages, config.getPackages());
+
+        var updatedPackages = List.of(new AppMapConfigFile.Package("new_package/one"), new AppMapConfigFile.Package("new_package/two"));
+        config.setPackages(List.of("new_package/one", "new_package/two"));
+        assertEquals(updatedPackages, config.getPackages());
+
+        config.writeTo(appMapFile.toNioPath());
+        var updatedConfig = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
+        assertNotNull(updatedConfig);
+        assertEquals(updatedPackages, config.getPackages());
+
+        // reset packages to empty list
+        config.setPackages(Collections.emptyList());
+        config.writeTo(appMapFile.toNioPath());
+        updatedConfig = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
+        assertNotNull(updatedConfig);
+        assertEquals(Collections.emptyList(), updatedConfig.getPackages());
+
+        // reset packages to null
+        config.setPackages(null);
+        config.writeTo(appMapFile.toNioPath());
+        updatedConfig = AppMapConfigFile.parseConfigFile(appMapFile.toNioPath());
+        assertNotNull(updatedConfig);
+        assertEquals(Collections.emptyList(), updatedConfig.getPackages());
+    }
+
+    @Test
+    public void nameProperty() {
+        var config = new AppMapConfigFile();
+        assertNull(config.getName());
+
+        config.setName("my AppMap name");
+        assertEquals("my AppMap name", config.getName());
     }
 }

--- a/plugin-gradle/src/main/java/appland/execution/AppMapExternalSystemExtension.java
+++ b/plugin-gradle/src/main/java/appland/execution/AppMapExternalSystemExtension.java
@@ -1,8 +1,11 @@
 package appland.execution;
 
+import appland.AppMapBundle;
+import appland.notifications.AppMapNotifications;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.RunnerSettings;
 import com.intellij.execution.configurations.SimpleJavaParameters;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration;
 import com.intellij.openapi.externalSystem.service.execution.configuration.ExternalSystemRunConfigurationExtension;
@@ -10,9 +13,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 
-import java.nio.file.Path;
-
 public class AppMapExternalSystemExtension extends ExternalSystemRunConfigurationExtension {
+    private static final Logger LOG = Logger.getInstance(AppMapExternalSystemExtension.class);
+
     @Override
     public boolean isApplicableFor(@NotNull ExternalSystemRunConfiguration configuration) {
         return configuration instanceof GradleRunConfiguration;
@@ -24,21 +27,30 @@ public class AppMapExternalSystemExtension extends ExternalSystemRunConfiguratio
                                    @Nullable RunnerSettings runnerSettings,
                                    @NotNull Executor executor) {
         if (executor instanceof AppMapJvmExecutor) {
-            try {
-                var gradleRunConfig = (GradleRunConfiguration) configuration;
-                var project = gradleRunConfig.getProject();
-                var workingDir = ProgramParameterUtils.findWorkingDir(project, javaParameters);
-                var config = AppMapJavaPackageConfig.findOrCreateAppMapConfig(project, gradleRunConfig, workingDir);
+            var gradleRunConfig = (GradleRunConfiguration) configuration;
+            var project = gradleRunConfig.getProject();
 
-                Path outputDirectory = null;
-                if (workingDir != null) {
-                    outputDirectory = workingDir.toNioPath().resolve("build").resolve("appmap");
+            try {
+                var workingDir = ProgramParameterUtils.findWorkingDir(project, javaParameters);
+                if (workingDir == null) {
+                    throw new IllegalStateException("unable to locate working directory to store AppMap files");
                 }
 
-                var jvmParams = AppMapJvmCommandLinePatcher.createJvmParams(config, outputDirectory);
+                var appMapOutputDirectory = workingDir.toNioPath().resolve("build").resolve("appmap");
+                var config = AppMapJavaPackageConfig.createOrUpdateAppMapConfig(project,
+                        gradleRunConfig,
+                        workingDir,
+                        appMapOutputDirectory);
+
+                var jvmParams = AppMapJvmCommandLinePatcher.createJvmParams(config, appMapOutputDirectory);
                 javaParameters.getVMParametersList().addAll(jvmParams);
             } catch (Exception e) {
-                Logger.getInstance(AppMapExternalSystemExtension.class).error(e);
+                LOG.warn("Unable to execute run configuration", e);
+                AppMapNotifications.showExpiringRecordingNotification(project,
+                        null,
+                        AppMapBundle.get("appMapExecutor.executionError.message", e.getMessage()),
+                        NotificationType.ERROR,
+                        true);
             }
         }
     }

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -129,7 +129,7 @@ public final class AppMapJavaPackageConfig {
 
         return workingDir == null
                 ? runProfileScope
-                : runProfileScope.uniteWith(new GlobalSearchScopesCore.DirectoryScope(project, workingDir, false));
+                : runProfileScope.intersectWith(GlobalSearchScopesCore.directoriesScope(project, true, workingDir));
     }
 
     // executed under progress

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaProgramPatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaProgramPatcher.java
@@ -21,7 +21,7 @@ public class AppMapJavaProgramPatcher extends AbstractAppMapJavaProgramPatcher {
 
     @Override
     protected @Nullable Path findAppMapOutputDirectory(@NotNull RunProfile configuration,
-                                                       @Nullable VirtualFile workingDirectory) {
+                                                       @NotNull VirtualFile workingDirectory) {
         if (!(configuration instanceof ModuleBasedConfiguration)) {
             return null;
         }

--- a/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
@@ -13,7 +13,10 @@ import java.util.List;
 /**
  * Patching of a JVM commandline to add the AppMap agent to the execution of a Java program.
  */
-public class AppMapJvmCommandLinePatcher {
+public final class AppMapJvmCommandLinePatcher {
+    private AppMapJvmCommandLinePatcher() {
+    }
+
     @NotNull
     static List<String> createJvmParams(@Nullable Path appMapConfig, @Nullable Path appMapOutputDirectory) throws CantRunException {
         if (appMapConfig == null) {
@@ -26,7 +29,6 @@ public class AppMapJvmCommandLinePatcher {
         }
 
         var jvmParams = new LinkedList<String>();
-        //jvmParams.add("-Dappmap.debug");
         jvmParams.add("-Dappmap.config.file=" + appMapConfig);
         if (appMapOutputDirectory != null) {
             jvmParams.add("-Dappmap.output.directory=" + appMapOutputDirectory);

--- a/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
+++ b/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
@@ -19,10 +19,8 @@ public class AppMapMavenProgramPatcher extends AbstractAppMapJavaProgramPatcher 
 
     @Override
     protected @Nullable Path findAppMapOutputDirectory(@NotNull RunProfile configuration,
-                                                       @Nullable VirtualFile workingDirectory) {
-        return workingDirectory == null
-                ? null
-                : workingDirectory.toNioPath().resolve("target").resolve("appmap");
+                                                       @NotNull VirtualFile workingDirectory) {
+        return workingDirectory.toNioPath().resolve("target").resolve("appmap");
     }
 
     @Override

--- a/src/test/data/appmap-config/appmap-packages.yml
+++ b/src/test/data/appmap-config/appmap-packages.yml
@@ -1,0 +1,11 @@
+name: sample_app_6th_ed
+packages:
+  - path: package/one
+  - path: package/two
+language: ruby
+test_recording:
+  test_commands:
+    - env:
+        APPMAP: 'true'
+        DISABLE_SPRING: 'true'
+      command: bundle exec rails test


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/299

With this PR, property `appmap_dir` is added to a `appmap.yml` file before a run configuration is executed with "Execute with AppMap". Existing `appmap.yml` files, which don't have the property set, will be updated before the run configuration is executed.
If no path for the property was found, then it defaults to `tmp/appmap`.

Because the appmap.yml is always updated, the property is not passed to the Java agent.

Because there are now more possible exceptions before a run is executed, we're now displaying a notification instead of logging it as an error. Before, we were silently skipping some of the errors without telling the user about it.

- [x] Verify, that the `appmap_dir` path is below the working dir and does exist
- [x] Update existing `appmap.yml` file if it does not yet contain a `appmap_dir` property