### PR TITLE
Use correct path for user home directory

### DIFF
--- a/plugin-core/src/main/java/appland/utils/SystemProperties.java
+++ b/plugin-core/src/main/java/appland/utils/SystemProperties.java
@@ -1,0 +1,24 @@
+package appland.utils;
+
+import com.intellij.util.ThrowableRunnable;
+import org.jetbrains.annotations.NotNull;
+
+public class SystemProperties {
+    public static final String USER_HOME = "user.home";
+
+    public static @NotNull String getUserHome() {
+        return System.getProperty(USER_HOME);
+    }
+
+    public static <T extends Throwable> void withPropertyValue(@NotNull String propertyName,
+                                                               @NotNull String value,
+                                                               @NotNull ThrowableRunnable<T> block) throws T {
+        var oldValue = System.getProperty(propertyName);
+        try {
+            System.setProperty(propertyName, value);
+            block.run();
+        } finally {
+            System.setProperty(propertyName, oldValue);
+        }
+    }
+}

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -152,7 +152,7 @@ appMapExecutor.startAction=Start with AppMap
 appMapExecutor.startActionConfigName=Start {0} with AppMap
 appMapExecutor.jdkNotSupportedWithLink=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry. <a href="">Configure</a>
 appMapExecutor.jdkNotSupported=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry.
-appMapExecutor.executionError.message=Unable to execute the run configuration: {0}.b
+appMapExecutor.executionError.message=Unable to execute the run configuration: {0}.
 
 annotator.quickFixFamily=AppMap
 annotator.openQuickFix.name=Open in AppMap file

--- a/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
+++ b/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
@@ -1,6 +1,7 @@
 package appland.javaAgent;
 
 import appland.AppMapBundle;
+import appland.utils.SystemProperties;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.PerformInBackgroundOption;
@@ -161,7 +162,7 @@ public final class AppMapJavaAgentDownloadService {
      * @return The path of the directory, where the AppMap Java agent should be stored (~/.appmap/lib/java).
      */
     @Nullable Path getOrCreateAgentDir() {
-        var agentDirPath = Paths.get(System.getProperty("user.dir")).resolve(Paths.get(".appmap", "lib", "java"));
+        var agentDirPath = Paths.get(SystemProperties.getUserHome()).resolve(Paths.get(".appmap", "lib", "java"));
         try {
             Files.createDirectories(agentDirPath);
             return agentDirPath;

--- a/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
+++ b/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
@@ -1,6 +1,7 @@
 package appland.javaAgent;
 
 import appland.AppMapBaseTest;
+import appland.utils.SystemProperties;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.NioFiles;
@@ -23,16 +24,9 @@ public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
     public final TestRule systemPropertyUpdate = (statement, description) -> new Statement() {
         @Override
         public void evaluate() throws Throwable {
-            var oldUserHome = System.getProperty("user.dir");
-            try {
-                var path = Paths.get(myFixture.getTempDirFixture().getTempDirPath()).resolve("appmap-agent");
-                NioFiles.deleteRecursively(path);
-
-                System.setProperty("user.dir", path.toString());
-                statement.evaluate();
-            } finally {
-                System.setProperty("user.dir", oldUserHome);
-            }
+            var path = Paths.get(myFixture.getTempDirFixture().getTempDirPath()).resolve("appmap-agent");
+            NioFiles.deleteRecursively(path);
+            SystemProperties.withPropertyValue(SystemProperties.USER_HOME, path.toString(), statement::evaluate);
         }
     };
 
@@ -43,12 +37,12 @@ public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
     }
 
     @Test
-    public void agentDirPath(){
+    public void agentDirPath() {
         var service = AppMapJavaAgentDownloadService.getInstance();
         var agentDir = service.getOrCreateAgentDir();
         assertNotNull(agentDir);
 
-        var expectedParent = Paths.get(System.getProperty("user.dir")).resolve(".appmap");
+        var expectedParent = Paths.get(SystemProperties.getUserHome()).resolve(".appmap");
         assertTrue("Agent dir must be under ~/.agent", agentDir.startsWith(expectedParent));
     }
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/316

The user home dir is contained in system property `user.home`, not `user.dir`.
This PR keeps the property name in a single place to prevent incorrect use.
Previously, it only appeared to be working, because the working directory (`user.dir`) was often set to the user home directory.