### PR TITLE
Create appmap_dir of a appmap.yml file as system-independent path

### DIFF
--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiPackage;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.GlobalSearchScopesCore;
 import com.intellij.util.EmptyConsumer;
+import com.intellij.util.PathUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -152,12 +153,15 @@ public final class AppMapJavaPackageConfig {
      * @param appMapOutputPath Relative path value for the `appmap_dir` property, if available.
      *                         If this is {@code null} or empty, then the "build_dir" property will not be set.
      */
-    private static AppMapConfigFile generateAppMapConfig(@NotNull Project project,
-                                                         @Nullable GlobalSearchScope runConfigurationScope,
-                                                         @Nullable String appMapOutputPath) {
+    static AppMapConfigFile generateAppMapConfig(@NotNull Project project,
+                                                 @Nullable GlobalSearchScope runConfigurationScope,
+                                                 @Nullable String appMapOutputPath) {
+        // appmap_dir should be "dir/subdir" even on Windows
+        var agnosticOutputPath = PathUtil.toSystemIndependentName(appMapOutputPath);
+
         var config = new AppMapConfigFile();
         config.setName(project.getName());
-        config.setAppMapDir(appMapOutputPath);
+        config.setAppMapDir(agnosticOutputPath);
         config.setPackages(ReadAction.compute(() -> findTopLevelPackages(project, runConfigurationScope)));
         return config;
     }

--- a/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigTest.java
+++ b/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigTest.java
@@ -1,0 +1,14 @@
+package appland.execution;
+
+import appland.AppMapBaseTest;
+import appland.index.AppMapSearchScopes;
+import org.junit.Test;
+
+public class AppMapJavaPackageConfigTest extends AppMapBaseTest {
+    @Test
+    public void systemIndependentAppMapDir() {
+        var scope = AppMapSearchScopes.projectFilesWithExcluded(getProject());
+        var config = AppMapJavaPackageConfig.generateAppMapConfig(getProject(), scope, "tmp\\appmap");
+        assertEquals("tmp/appmap", config.getAppMapDir());
+    }
+}


### PR DESCRIPTION
It's now creating `appmap_dir: target/build` and not `appmap_dir: target\build` on Windows.