### PR TITLE
Don't execute JDK validation on the EDT

### DIFF
--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -150,6 +150,7 @@ telemetry.permission.deny=Opt out
 appMapExecutor.description=AppMap executor
 appMapExecutor.startAction=Start with AppMap
 appMapExecutor.startActionConfigName=Start {0} with AppMap
+appMapExecutor.verifyingJDK=Verifying JDK...
 appMapExecutor.jdkNotSupportedWithLink=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry. <a href="">Configure</a>
 appMapExecutor.jdkNotSupported=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry.
 appMapExecutor.executionError.message=Unable to execute the run configuration: {0}.

--- a/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaAgentRunner.java
+++ b/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaAgentRunner.java
@@ -1,5 +1,6 @@
 package appland.execution;
 
+import appland.AppMapBundle;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.JavaCommandLineState;
 import com.intellij.execution.configurations.JavaParameters;
@@ -8,8 +9,10 @@ import com.intellij.execution.configurations.RunnerSettings;
 import com.intellij.execution.impl.DefaultJavaProgramRunner;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.JavaProgramPatcher;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbService;
-import com.intellij.util.SlowOperations;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,25 +40,52 @@ public abstract class AbstractAppMapJavaAgentRunner extends DefaultJavaProgramRu
                       @NotNull RunProfile runProfile,
                       boolean beforeExecution) {
         try {
-            // invokes our AppMapJavaProgramPatcher, but inside a read action.
+            // Invokes our AppMapJavaProgramPatcher, but inside a read action.
+            // Don't wrap this in "JavaProgramPatcher.patchJavaCommandLineParamsUnderProgress",
+            // because com.intellij.execution.impl.DefaultJavaProgramRunner.doExecute
+            // is already using it when it's calling this patch method.
             JavaProgramPatcher.runCustomPatchers(javaParameters, AppMapJvmExecutor.getInstance(), runProfile);
         } catch (Exception e) {
             throw new RuntimeException("Failed to update JVM command line for AppMap", e);
         }
     }
 
-    private static void verifyJdk(@NotNull ExecutionEnvironment environment) throws ExecutionException {
+    /**
+     * Validates the JDK if there's one configured for the executed configuration.
+     * Because this method is executed on the EDT
+     * and because we need to throw a ExecutionException to cancel the execution of the run configuration,
+     * we have to execute a modal task.
+     *
+     * @param environment Current environment
+     * @throws ExecutionException Thrown if the JDK is invalid
+     */
+    private void verifyJdk(@NotNull ExecutionEnvironment environment) throws ExecutionException {
         var state = environment.getState();
-        if (state instanceof JavaCommandLineState && !DumbService.isDumb(environment.getProject())) {
-            SlowOperations.allowSlowOperations(() -> {
-                var javaParameters = ((JavaCommandLineState) state).getJavaParameters();
-                if (javaParameters != null) {
-                    var jdk = javaParameters.getJdk();
-                    if (jdk != null) {
-                        AppMapJvmExecutor.verifyJDK(environment.getProject(), jdk);
-                    }
-                }
-            });
+        if (!(state instanceof JavaCommandLineState) || DumbService.isDumb(environment.getProject())) {
+            return;
         }
+
+        var task = new Task.WithResult<Void, ExecutionException>(environment.getProject(), AppMapBundle.get("appMapExecutor.verifyingJDK"), false) {
+            @Override
+            protected Void compute(@NotNull ProgressIndicator indicator) throws ExecutionException {
+                var javaParameters = ((JavaCommandLineState) state).getJavaParameters();
+                if (javaParameters == null) {
+                    return null;
+                }
+
+                var jdk = javaParameters.getJdk();
+                if (jdk == null) {
+                    return null;
+                }
+
+                return ReadAction.compute(() -> {
+                    AppMapJvmExecutor.verifyJDK(environment.getProject(), jdk);
+                    return null;
+                });
+            }
+        };
+
+        task.queue();
+        task.getResult();
     }
 }


### PR DESCRIPTION
During development and using `gradle runIde` I noticed frequent exceptions and also dead-locks of the UI when I executed the sprint-petclinic application with our "Execute with AppMap" button.
I don't know of a reliable case, but it happened to me mostly when I clicked on the button right after launching the IDE.

The exception does not contain our `appmap` package in the stacktrace, so user reports of it would have been sent to JetBrains and not AppMap.