### PR TITLE
Introduce listener to notify about Install Guide navigation

### DIFF
--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideListener.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideListener.java
@@ -1,0 +1,17 @@
+package appland.installGuide;
+
+import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Listener for Install Guide navigation events.
+ */
+public interface InstallGuideListener {
+    @Topic.ProjectLevel
+    Topic<InstallGuideListener> TOPIC = Topic.create("appmap.installGuide", InstallGuideListener.class);
+
+    /**
+     * @param page The installation guide page, which was executed/opened
+     */
+    void afterInstallGuidePageOpened(@NotNull InstallGuideViewPage page);
+}


### PR DESCRIPTION
Part of the changes for https://github.com/getappmap/appmap-intellij-plugin/issues/298

This adds a listener. We need to decouple the action after Install Guide navigation because the action needs Java support, which is an optional plugin and thus isn't available in the core part, where the install guide is implemented.