### PR TITLE
Improve lookup of existing appmap.yml files

### DIFF
--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -4,7 +4,6 @@ import appland.AppMapBundle;
 import appland.Icons;
 import appland.files.AppMapFiles;
 import appland.files.AppMapVfsUtils;
-import appland.index.AppMapSearchScopes;
 import appland.notifications.AppMapNotifications;
 import appland.remote.RemoteRecordingService;
 import appland.remote.RemoteRecordingStatusService;
@@ -150,7 +149,7 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
      */
     @RequiresBackgroundThread
     private static @Nullable Path findConfiguredStorageLocation(@NotNull Project project) {
-        return ReadAction.compute(() -> AppMapFiles.findAppMapConfigFiles(project, AppMapSearchScopes.projectFilesWithExcluded(project))
+        return ReadAction.compute(() -> AppMapFiles.findAppMapConfigFiles(project)
                 .stream()
                 .map(StopAppMapRecordingAction::findAppMapDirectory)
                 .filter(Objects::nonNull)

--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -1,6 +1,7 @@
 package appland.files;
 
 import appland.cli.AppLandCommandLineService;
+import appland.index.AppMapSearchScopes;
 import appland.utils.GsonUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -49,6 +50,15 @@ public final class AppMapFiles {
 
     public static boolean isAppMapConfigFileName(@NotNull String fileName) {
         return FileUtil.fileNameEquals(fileName, APPMAP_YML);
+    }
+
+    /**
+     * @return The appmap.yaml files available in the current project.
+     * appmap.yml files are not searched inside excluded folders, libraries or dependencies of the project.
+     */
+    @RequiresReadLock
+    public static @NotNull Collection<VirtualFile> findAppMapConfigFiles(@NotNull Project project) {
+        return findAppMapConfigFiles(project, AppMapSearchScopes.appMapConfigSearchScope(project));
     }
 
     /**

--- a/plugin-core/src/main/java/appland/index/AppMapNameIndex.java
+++ b/plugin-core/src/main/java/appland/index/AppMapNameIndex.java
@@ -2,7 +2,6 @@ package appland.index;
 
 import appland.utils.GsonUtils;
 import com.google.gson.annotations.SerializedName;
-import com.intellij.json.JsonFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -31,7 +30,7 @@ public class AppMapNameIndex extends AbstractAppMapMetadataFileIndex<String> {
      * @return The directories, based on this index, which contain AppMap metadata files.
      */
     public static @NotNull Set<VirtualFile> getAppMapMetadataDirectories(@NotNull Project project) {
-        var scope = GlobalSearchScope.getScopeRestrictedByFileTypes(AppMapSearchScopes.projectFilesWithExcluded(project), JsonFileType.INSTANCE);
+        var scope = AppMapSearchScopes.appMapsWithExcluded(project);
         var keys = new HashSet<Integer>();
         FileBasedIndex.getInstance().processAllKeys(INDEX_ID, Processors.cancelableCollectProcessor(keys), scope, null);
         if (keys.isEmpty()) {

--- a/plugin-core/src/main/java/appland/index/AppMapSearchScopes.java
+++ b/plugin-core/src/main/java/appland/index/AppMapSearchScopes.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.roots.FileIndexFacade;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.ProjectAwareVirtualFile;
+import com.intellij.psi.search.ProjectScope;
 import com.intellij.psi.search.ProjectScopeImpl;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,6 +29,9 @@ public final class AppMapSearchScopes {
         return GlobalSearchScope.getScopeRestrictedByFileTypes(projectFilesWithExcluded(project), JsonFileType.INSTANCE);
     }
 
+    public static @NotNull GlobalSearchScope appMapConfigSearchScope(@NotNull Project project) {
+        return ProjectScope.getContentScope(project);
+    }
     /**
      * Search scope, which contains all project files and also excluded files of the project.
      * This implementation is based on IntelliJ's {@link ProjectScopeImpl}.

--- a/plugin-core/src/main/java/appland/installGuide/projectData/DefaultProjectDataService.java
+++ b/plugin-core/src/main/java/appland/installGuide/projectData/DefaultProjectDataService.java
@@ -106,7 +106,7 @@ public class DefaultProjectDataService implements ProjectDataService {
         var sampleCodeObjects = findSampleCodeObjects(project);
 
         var projectSettings = AppMapProjectSettingsService.getState(project);
-        var appMapConfigs = AppMapFiles.findAppMapConfigFiles(project, AppMapSearchScopes.projectFilesWithExcluded(project));
+        var appMapConfigs = AppMapFiles.findAppMapConfigFiles(project);
         var investigatedFindings = projectSettings.isInvestigatedFindings();
 
         var isJavaProject = JavaLanguageAnalyzer.JAVA_LANGUAGE_TITLE.equals(analysis.getFeatures().getLang().title);

--- a/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
@@ -4,6 +4,8 @@ import appland.AppMapBaseTest;
 import com.intellij.openapi.application.WriteAction;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class AppMapSearchScopesTest extends AppMapBaseTest {
     @Test
     public void contentRoots() throws Exception {
@@ -27,5 +29,29 @@ public class AppMapSearchScopesTest extends AppMapBaseTest {
         } finally {
             WriteAction.run(() -> topLevelDir.delete(this));
         }
+    }
+
+    @Test
+    public void appMapConfigScope() throws IOException {
+        var scope = AppMapSearchScopes.appMapConfigSearchScope(getProject());
+
+        var topLevelConfig = myFixture.configureByText("appmap.yml", "content").getVirtualFile();
+        assertTrue(scope.contains(topLevelConfig));
+        assertTrue(scope.contains(topLevelConfig.getParent()));
+
+        var subLevelConfig = myFixture.addFileToProject("sub-dir/appmap.yml", "content").getVirtualFile();
+        assertTrue(scope.contains(subLevelConfig));
+
+        // appmap.yml must not be found in non-content folders, e.g. in excluded folders
+        var excludedDir = myFixture.getTempDirFixture().findOrCreateDir("appmap-excluded-dir");
+        var excludedConfig = WriteAction.computeAndWait(() -> excludedDir.createChildData(this, "appmap.yml"));
+        withExcludedFolder(excludedDir, () -> {
+            assertFalse(scope.contains(excludedDir));
+            assertFalse(scope.contains(excludedConfig));
+        });
+
+        // folders outside content roots must not be included
+        var topLevelDir = myFixture.getTempDirFixture().findOrCreateDir("../appmap-top-level");
+        assertFalse(scope.contains(topLevelDir));
     }
 }

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -137,7 +137,8 @@ public final class AppMapJavaPackageConfig {
     private static @Nullable VirtualFile findAppMapConfig(@NotNull Project project,
                                                           @NotNull GlobalSearchScope runProfileScope) {
         return ReadAction.compute(() -> {
-            var files = AppMapFiles.findAppMapConfigFiles(project, runProfileScope);
+            var scope = runProfileScope.intersectWith(AppMapSearchScopes.appMapConfigSearchScope(project));
+            var files = AppMapFiles.findAppMapConfigFiles(project, scope);
             return files.size() == 1 ? files.iterator().next() : null;
         });
     }


### PR DESCRIPTION
Part of the changes for https://github.com/getappmap/appmap-intellij-plugin/issues/298
We'll need to call the creation of appmap.yml from another method. This PR cleans up the scope handling to simplify the upcoming changes.
The scope to locate appmap.yml files is now defined in a single place.