### PR TITLE
Reorder panels in the AppMap toolwindow

### DIFF
--- a/plugin-core/src/main/java/appland/toolwindow/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapWindowPanel.java
@@ -219,46 +219,63 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
         contentPanel.add(createRuntimeAnalysisPanel(project, parent));
         contentPanel.add(createInstallGuidePanel(project, parent));
         contentPanel.add(createCodeObjectsPanel(project, parent));
-        contentPanel.add(createDocumentationLinksPanel());
+        contentPanel.add(createDocumentationLinksPanel(project));
         return contentPanel;
     }
 
     @NotNull
     private static JPanel createInstallGuidePanel(@NotNull Project project, @NotNull Disposable parent) {
-        return new CollapsiblePanel(AppMapBundle.get("toolwindow.appmap.instructions"), false, new InstallGuidePanel(project, parent), false);
+        return new CollapsiblePanel(project,
+                AppMapBundle.get("toolwindow.appmap.instructions"),
+                "appmap.toolWindow.installGuide.collapsed",
+                false,
+                new InstallGuidePanel(project, parent));
     }
 
     @NotNull
     private static JPanel createRuntimeAnalysisPanel(@NotNull Project project, @NotNull Disposable parent) {
         var runtimeAnalysisPanel = new RuntimeAnalysisPanel(project, parent);
         runtimeAnalysisPanel.setMinimumSize(new JBDimension(0, 100));
-        return new CollapsiblePanel(AppMapBundle.get("toolwindow.appmap.runtimeAnalysis"), false, runtimeAnalysisPanel, true);
+        return new CollapsiblePanel(project,
+                AppMapBundle.get("toolwindow.appmap.runtimeAnalysis"),
+                "appmap.toolWindow.runtimeAnalysis.collapsed",
+                true,
+                runtimeAnalysisPanel);
     }
 
     @NotNull
     private static JPanel createCodeObjectsPanel(@NotNull Project project, @NotNull Disposable parentDisposable) {
         var codeObjectsPanel = new CodeObjectsPanel(project, parentDisposable);
         codeObjectsPanel.setMinimumSize(new JBDimension(0, 100));
-        return new CollapsiblePanel(AppMapBundle.get("toolWindow.appmap.codeObjects"), false, codeObjectsPanel, true);
+        return new CollapsiblePanel(project,
+                AppMapBundle.get("toolWindow.appmap.codeObjects"),
+                "appmap.toolWindow.codeObjects.collapsed",
+                true,
+                codeObjectsPanel);
     }
 
     @NotNull
-    private static JPanel createDocumentationLinksPanel() {
-        return new CollapsiblePanel(AppMapBundle.get("toolWindow.appmap.documentation"), false, new AppMapContentPanel(true) {
-            @Override
-            protected void setupPanel() {
-                /* can be generated from vscode links with:
-                 * $ curl -L https://github.com/getappmap/vscode-appland/raw/master/src/tree/links.ts |
-                 *   sed -n '/label:/ {s/.*: /add(new UrlLabel(/; s/,\n/, /; N; s/\n *link: / /; s/,$/\)\);/; y/'"'"'/"/; p }'
-                 */
-                add(new UrlLabel("Quickstart", "https://appmap.io/docs/quickstart"));
-                add(new UrlLabel("AppMap overview", "https://appmap.io/docs/appmap-overview"));
-                add(new UrlLabel("How to use AppMap diagrams", "https://appmap.io/docs/how-to-use-appmap-diagrams"));
-                add(new UrlLabel("Sequence diagrams", "https://appmap.io/docs/diagrams/sequence-diagrams.html"));
-                add(new UrlLabel("Reference", "https://appmap.io/docs/reference"));
-                add(new UrlLabel("Recording methods", "https://appmap.io/docs/recording-methods"));
-                add(new UrlLabel("Community", "https://appmap.io/docs/community"));
-            }
-        }, false);
+    private static JPanel createDocumentationLinksPanel(@NotNull Project project) {
+        return new CollapsiblePanel(
+                project,
+                AppMapBundle.get("toolWindow.appmap.documentation"),
+                "appmap.toolWindow.documentation.collapsed",
+                true,
+                new AppMapContentPanel(true) {
+                    @Override
+                    protected void setupPanel() {
+                        /* can be generated from vscode links with:
+                         * $ curl -L https://github.com/getappmap/vscode-appland/raw/master/src/tree/links.ts |
+                         *   sed -n '/label:/ {s/.*: /add(new UrlLabel(/; s/,\n/, /; N; s/\n *link: / /; s/,$/\)\);/; y/'"'"'/"/; p }'
+                         */
+                        add(new UrlLabel("Quickstart", "https://appmap.io/docs/quickstart"));
+                        add(new UrlLabel("AppMap overview", "https://appmap.io/docs/appmap-overview"));
+                        add(new UrlLabel("How to use AppMap diagrams", "https://appmap.io/docs/how-to-use-appmap-diagrams"));
+                        add(new UrlLabel("Sequence diagrams", "https://appmap.io/docs/diagrams/sequence-diagrams.html"));
+                        add(new UrlLabel("Reference", "https://appmap.io/docs/reference"));
+                        add(new UrlLabel("Recording methods", "https://appmap.io/docs/recording-methods"));
+                        add(new UrlLabel("Community", "https://appmap.io/docs/community"));
+                    }
+                });
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapWindowPanel.java
@@ -225,7 +225,7 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
 
     @NotNull
     private static JPanel createInstallGuidePanel(@NotNull Project project, @NotNull Disposable parent) {
-        return new CollapsiblePanel(AppMapBundle.get("toolwindow.appmap.quickstart"), false, new InstallGuidePanel(project, parent), false);
+        return new CollapsiblePanel(AppMapBundle.get("toolwindow.appmap.instructions"), false, new InstallGuidePanel(project, parent), false);
     }
 
     @NotNull

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapWindowPanel.java
@@ -213,27 +213,36 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
                     var d = getDividerWidth();
                     if (height > d) {
                         var maxSize1 = first.getMaximumSize();
+                        var maxHeight1 = maxSize1 != null && maxSize1.getHeight() < Integer.MAX_VALUE
+                                ? maxSize1.getHeight()
+                                : null;
                         var maxSize2 = second.getMaximumSize();
+                        var maxHeight2 = maxSize2 != null && maxSize2.getHeight() < Integer.MAX_VALUE
+                                ? maxSize2.getHeight()
+                                : null;
+                        var height1Invalid = maxHeight1 != null && first.getHeight() > maxHeight1;
+                        var height2Invalid = maxHeight2 != null && second.getHeight() > maxHeight2;
 
-                        int iSize1;
-                        int iSize2;
-                        if (maxSize1 != null && first.getHeight() > maxSize1.height) {
-                            // limit height of 1st component to its max height
-                            iSize1 = (int) Math.round(maxSize1.getHeight());
-                            iSize2 = height - iSize1 - d;
-                        } else if (maxSize2 != null && second.getHeight() > maxSize2.height) {
+                        int height1;
+                        int height2;
+                        if (maxHeight1 != null && maxHeight2 != null || height1Invalid) {
+                            // distribute available space to 2nd component,
+                            // because we don't want to show a large "AppMaps" panel without content
+                            height1 = (int) Math.round(maxHeight1);
+                            height2 = height - height1 - d;
+                        } else if (height2Invalid) {
                             // limit height of 2nd component to its max height
-                            iSize2 = (int) Math.round(maxSize2.getHeight());
-                            iSize1 = height - iSize2 - d;
+                            height2 = (int) Math.round(maxHeight2);
+                            height1 = height - height2 - d;
                         } else {
                             // no update needed
                             return;
                         }
 
                         int width = getWidth();
-                        var firstRect = new Rectangle(0, 0, width, iSize1);
-                        var dividerRect = new Rectangle(0, iSize1, width, d);
-                        var secondRect = new Rectangle(0, iSize1 + d, width, iSize2);
+                        var firstRect = new Rectangle(0, 0, width, height1);
+                        var dividerRect = new Rectangle(0, height1, width, d);
+                        var secondRect = new Rectangle(0, height1 + d, width, height2);
 
                         myDivider.setVisible(true);
 

--- a/plugin-core/src/main/java/appland/toolwindow/CollapsiblePanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/CollapsiblePanel.java
@@ -40,20 +40,21 @@ public class CollapsiblePanel extends JPanel {
         try {
             var maxSize = getMaximumSize();
             var maxWidth = maxSize != null ? maxSize.width : Integer.MAX_VALUE;
-            var maxHeight = maxSize != null ? maxSize.height : Integer.MAX_VALUE;
-            var verticalInsets = content.getHeight() + getInsets().top + getInsets().bottom;
+            var verticalInsets = getInsets().top + getInsets().bottom;
 
             if (!collapse) {
                 add(content, BorderLayout.CENTER);
-                maxHeight = growVertically
+
+                var maxHeight = growVertically
                         ? Integer.MAX_VALUE
-                        : title.getHeight() + verticalInsets;
+                        : title.getHeight() + content.getHeight() + verticalInsets;
+                setMaximumSize(new Dimension(maxWidth, maxHeight));
             } else if (isInitialized) {
                 remove(content);
-                maxHeight = title.getHeight() + verticalInsets;
-            }
 
-            setMaximumSize(new Dimension(maxWidth, maxHeight));
+                var maxHeight = title.getHeight() + verticalInsets;
+                setMaximumSize(new Dimension(maxWidth, maxHeight));
+            }
 
             isCollapsed = collapse;
             title.setCollapsed(isCollapsed);

--- a/plugin-core/src/main/java/appland/toolwindow/CollapsiblePanelTitle.java
+++ b/plugin-core/src/main/java/appland/toolwindow/CollapsiblePanelTitle.java
@@ -20,8 +20,8 @@ class CollapsiblePanelTitle extends JPanel {
     private static final KeyStroke KEY_ENTER = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
     private static final KeyStroke KEY_SPACE = KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0);
     private final JBLabel label;
-    private final Icon expandIcon = UIUtil.getTreeCollapsedIcon();
-    private final Icon collapseIcon = UIUtil.getTreeExpandedIcon();
+    private final Icon expandIcon = UIUtil.getTreeExpandedIcon();
+    private final Icon collapseIcon = UIUtil.getTreeCollapsedIcon();
 
     private final List<Runnable> labelActionListeners = new LinkedList<>();
 

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -69,7 +69,7 @@ toolwindow.appmap.filterEmptyText=Filter AppMaps by name
 toolWindow.appmap.codeObjects=Code Objects
 toolWindow.appmap.documentation=Documentation
 toolwindow.appmap.runtimeAnalysis=Runtime Analysis
-toolwindow.appmap.quickstart=Quickstart
+toolwindow.appmap.instructions=Instructions
 
 toolwindow.jcefUnsupported.emptyText=Your IDE does not support JCEF HTML webviews.
 toolwindow.jcefUnsupported.emptyText2=Please change the Boot Java Runtime to the newest version

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -66,8 +66,9 @@ toolwindow.appmap.emptyText.line1=All the AppMaps that are present
 toolwindow.appmap.emptyText.line2=in this project will be listed here.
 toolwindow.appmap.installAgentEmptyText=Open instructions
 toolwindow.appmap.filterEmptyText=Filter AppMaps by name
-toolWindow.appmap.codeObjects=Code Objects
-toolWindow.appmap.documentation=Documentation
+toolwindow.appmap.appMaps=AppMaps
+toolwindow.appmap.codeObjects=Code Objects
+toolwindow.appmap.documentation=Documentation
 toolwindow.appmap.runtimeAnalysis=Runtime Analysis
 toolwindow.appmap.instructions=Instructions
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/326

Reorders the panels inside the AppMap toolwindow:
1. Instructions
2. AppMaps
3. Runtime Analysis
4. Code Objects
5. Documentation links

It also fixes the height of the nested components and the distribution of available space if there are collapsed components.
There's still a 1px splitter to change the height of the AppMap panel.

It also updates the icons for the collapsed/expanded state. Previously, the expanded icon was used for the collapsed state.

Reviewing commit-by-commit should work well.

Initial view:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/6f0ed4d1-8d58-4840-a680-0e8fa0fee88c)
