### PR TITLE
Sync and watch AppMap directories with 2023.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ ideVersion=IC-2021.3.3
 #ideVersion=IC-2022.2.3
 #ideVersion=IC-2022.3
 #ideVersion=IC-2023.1.1
-#ideVersion=IC-232.7754.73-EAP-SNAPSHOT
+#ideVersion=IC-2023.2
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=false

--- a/plugin-core/src/main/java/appland/execution/AppMapExecutionListener.java
+++ b/plugin-core/src/main/java/appland/execution/AppMapExecutionListener.java
@@ -8,7 +8,8 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Force a sync of the filesystem to make sure that newly added AppMaps are found.
+ * Force a sync of the filesystem after a AppMap run configuration terminated
+ * to make sure that newly added AppMaps are found.
  */
 public class AppMapExecutionListener implements ExecutionListener {
     private static final Logger LOG = Logger.getInstance(AppMapExecutionListener.class);

--- a/plugin-core/src/main/java/appland/execution/AppMapExecutionListener.java
+++ b/plugin-core/src/main/java/appland/execution/AppMapExecutionListener.java
@@ -1,0 +1,24 @@
+package appland.execution;
+
+import com.intellij.execution.ExecutionListener;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Force a sync of the filesystem to make sure that newly added AppMaps are found.
+ */
+public class AppMapExecutionListener implements ExecutionListener {
+    private static final Logger LOG = Logger.getInstance(AppMapExecutionListener.class);
+
+    @Override
+    public void processTerminated(@NotNull String executorId, @NotNull ExecutionEnvironment env, @NotNull ProcessHandler handler, int exitCode) {
+        if (executorId.equals(AppMapJvmExecutor.EXECUTOR_ID)) {
+            VirtualFileManager.getInstance().asyncRefresh(() -> {
+                LOG.debug("finished filesystem refresh after execution with AppMap");
+            });
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
+++ b/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
@@ -1,21 +1,16 @@
 package appland.index;
 
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.indexing.FileBasedIndexExtension;
 import com.intellij.util.indexing.roots.IndexableFilesContributor;
 import com.intellij.util.indexing.roots.IndexableFilesIterator;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Adds excluded "appmap" folders and excluded AppMap files for indexing.
@@ -38,28 +33,7 @@ public class AppMapIndexableFilesContributor implements IndexableFilesContributo
 
     @Override
     public @NotNull Predicate<VirtualFile> getOwnFilePredicate(@NotNull Project project) {
-        var appMapIndexFilenames = findIndexedFilenames();
-        return file -> {
-            // we have to include directories, because that controls if the sub-entries are processed
-            return file.isDirectory()
-                    || ClassMapUtil.isClassMap(file)
-                    || AppMapFindingsUtil.isFindingFile(file)
-                    || appMapIndexFilenames.contains(file.getName());
-        };
-    }
-
-    @NotNull
-    private static Set<String> findIndexedFilenames() {
-        try {
-            return FileBasedIndexExtension.EXTENSION_POINT_NAME.getExtensionList().stream()
-                    .filter(extension -> extension instanceof AbstractAppMapMetadataFileIndex<?>)
-                    .map(extension -> ((AbstractAppMapMetadataFileIndex<?>) extension).getIndexedFileName())
-                    .collect(Collectors.toSet());
-        } catch (ProcessCanceledException e) {
-            throw e;
-        } catch (Exception e) {
-            // catching any exception, because we must not break indexing
-            return Collections.emptySet();
-        }
+        // we have to include directories, because that controls if the sub-entries are processed
+        return file -> file.isDirectory() || IndexUtil.isIndexedFile(file);
     }
 }

--- a/plugin-core/src/main/java/appland/index/AppMapIndexedRootsSetContributor.java
+++ b/plugin-core/src/main/java/appland/index/AppMapIndexedRootsSetContributor.java
@@ -1,0 +1,28 @@
+package appland.index;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.indexing.IndexableSetContributor;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class AppMapIndexedRootsSetContributor extends IndexableSetContributor {
+    @Override
+    public @NonNls @NotNull String getDebugName() {
+        return "AppMap directories";
+    }
+
+    @Override
+    public @NotNull Set<VirtualFile> getAdditionalRootsToIndex() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public @NotNull Set<VirtualFile> getAdditionalProjectRootsToIndex(@NotNull Project project) {
+        // in 2023.2, getAdditionalProjectRootsToIndex is executed in a com.intellij.openapi.application.NonBlockingReadAction
+        return IndexUtil.findAppMapIndexDirectories(project);
+    }
+}

--- a/plugin-core/src/main/java/appland/index/AppMapWatchedRootsProvider.java
+++ b/plugin-core/src/main/java/appland/index/AppMapWatchedRootsProvider.java
@@ -1,0 +1,25 @@
+package appland.index;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.WatchedRootsProvider;
+import com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class AppMapWatchedRootsProvider implements WatchedRootsProvider {
+    @Override
+    public @NotNull Set<String> getRootsToWatch(@NotNull Project project) {
+        var paths = new HashSet<String>();
+        for (var directory : IndexUtil.findAppMapIndexDirectories(project)) {
+            if (directory instanceof VirtualDirectoryImpl) {
+                if (!((VirtualDirectoryImpl) directory).allChildrenLoaded()) {
+                    directory.getChildren();
+                }
+            }
+            paths.add(directory.getPath());
+        }
+        return paths;
+    }
+}

--- a/plugin-core/src/main/java/appland/index/IndexUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexUtil.java
@@ -1,16 +1,89 @@
 package appland.index;
 
+import appland.config.AppMapConfigFile;
+import appland.files.AppMapFiles;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import com.intellij.util.indexing.FileBasedIndex;
+import com.intellij.util.indexing.FileBasedIndexExtension;
 import com.intellij.util.indexing.ID;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 final class IndexUtil {
     // base version for our indexes, increase when the data structures or the parsing logic change
     static final int BASE_VERSION = 57;
+
+    // filenames covered by our own indexes
+    static final Set<String> indexedFilenames = Collections.unmodifiableSet(findIndexedFilenames());
+
+    /**
+     * @param project Current project
+     * @return Directories on the local filesystem, which contain indexable AppMap data.
+     * The directories will be used for watched roots and for index decisions of the IDE.
+     */
+    static Set<VirtualFile> findAppMapIndexDirectories(@NotNull Project project) {
+        ApplicationManager.getApplication().assertReadAccessAllowed();
+
+        var appMapDirs = VfsUtilCore.createCompactVirtualFileSet();
+        collectAppMapOutputDirectories(project, appMapDirs);
+        return appMapDirs;
+    }
+
+    private static void collectAppMapOutputDirectories(@NotNull Project project, @NotNull Set<VirtualFile> target) {
+        var configFiles = findConfigFilesByExcludedDirs(project);
+        for (var configFile : configFiles) {
+            var config = AppMapConfigFile.parseConfigFile(configFile);
+            if (config != null && config.getAppMapDir() != null) {
+                var appMapDir = VfsUtilCore.findRelativeFile(config.getAppMapDir(), configFile.getParent());
+                if (appMapDir != null && appMapDir.isValid() && appMapDir.isInLocalFileSystem()) {
+                    target.add(appMapDir);
+                }
+            }
+        }
+    }
+
+    /**
+     * Locate appmap.yml files without index access.
+     */
+    private static @NotNull Collection<VirtualFile> findConfigFilesByExcludedDirs(@NotNull Project project) {
+        var configFiles = VfsUtilCore.createCompactVirtualFileSet();
+        for (var module : ModuleManager.getInstance(project).getModules()) {
+            for (var root : ModuleRootManager.getInstance(module).getExcludeRoots()) {
+                // we're only checking two parents at most
+                var start = root;
+                for (var i = 0; i < 2 && start != null; i++) {
+                    var parent = start.getParent();
+                    if (parent != null && parent.isValid()) {
+                        var config = parent.findChild(AppMapFiles.APPMAP_YML);
+                        if (config != null) {
+                            configFiles.add(config);
+                            break;
+                        }
+                    }
+                    start = parent;
+                }
+            }
+        }
+        return configFiles;
+    }
+
+    static boolean isIndexedFile(@NotNull VirtualFile file) {
+        return ClassMapUtil.isClassMap(file)
+                || AppMapFindingsUtil.isFindingFile(file)
+                || indexedFilenames.contains(file.getName());
+    }
 
     @RequiresReadLock
     static <T> @Nullable T getSingleEntryAppMapData(@NotNull ID<Integer, T> indexId,
@@ -24,5 +97,20 @@ final class IndexUtil {
         }
 
         return FileBasedIndex.getInstance().getSingleEntryIndexData(indexId, indexedFile, project);
+    }
+
+    @NotNull
+    private static Set<String> findIndexedFilenames() {
+        try {
+            return FileBasedIndexExtension.EXTENSION_POINT_NAME.getExtensionList().stream()
+                    .filter(extension -> extension instanceof AbstractAppMapMetadataFileIndex<?>)
+                    .map(extension -> ((AbstractAppMapMetadataFileIndex<?>) extension).getIndexedFileName())
+                    .collect(Collectors.toSet());
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (Exception e) {
+            // catching any exception, because we must not break indexing
+            return Collections.emptySet();
+        }
     }
 }

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -29,6 +29,9 @@
 
         <listener topic="appland.cli.AppLandDownloadListener"
                   class="appland.cli.StartServicesAfterDownloadListener"/>
+
+        <listener topic="com.intellij.execution.ExecutionListener"
+                  class="appland.execution.AppMapExecutionListener"/>
     </projectListeners>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -58,8 +58,13 @@
         <fileBasedIndex implementation="appland.index.AppMapServerRequestCountIndex"/>
         <fileBasedIndex implementation="appland.index.AppMapSqlQueriesCountIndex"/>
         <fileBasedIndex implementation="appland.index.ClassMapTypeIndex"/>
+
+        <roots.watchedRootsProvider implementation="appland.index.AppMapWatchedRootsProvider"/>
+        <!-- For 2023.1 and earlier -->
         <!--suppress PluginXmlValidity -->
         <indexableFilesContributor implementation="appland.index.AppMapIndexableFilesContributor"/>
+        <!-- For 2023.2 and later -->
+        <indexedRootsProvider implementation="appland.index.AppMapIndexedRootsSetContributor"/>
 
         <toolWindow id="applandToolWindow" anchor="right" secondary="false"
                     icon="appland.Icons.TOOL_WINDOW"


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/345, but this is only a partial fix

This adds AppMap output directories as watched roots and adds an indexable file set contributor, which is now the default extension point in 2023.2 to add (excluded) directories to the indexed locations.

This should fix missing items in the AppMap tool window with 2023.2.