### PR TITLE
Don't check read access on the EDT

### DIFF
--- a/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
@@ -36,7 +36,9 @@ public final class AppMapPatcherUtil {
     public static @NotNull List<String> prepareJavaParameters(@NotNull Project project,
                                                               @NotNull RunProfile configuration,
                                                               @NotNull SimpleJavaParameters javaParameters) throws Exception {
-        ApplicationManager.getApplication().assertReadAccessNotAllowed();
+        if (!ApplicationManager.getApplication().isDispatchThread()) {
+            ApplicationManager.getApplication().assertReadAccessNotAllowed();
+        }
 
         var task = new Task.WithResult<List<String>, Exception>(project, AppMapBundle.get("appMapConfig.creatingConfig"), true) {
             @Override


### PR DESCRIPTION
The assert was added with #348 , but is too strict when it's launched on the event dispatch thread.
This happened for Gradle project.