### PR TITLE
Better fallbacks for AppMap output directory

### DIFF
--- a/plugin-gradle/src/main/java/appland/execution/AppMapExternalSystemExtension.java
+++ b/plugin-gradle/src/main/java/appland/execution/AppMapExternalSystemExtension.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 
+import java.nio.file.Paths;
+
 public class AppMapExternalSystemExtension extends ExternalSystemRunConfigurationExtension {
     private static final Logger LOG = Logger.getInstance(AppMapExternalSystemExtension.class);
 
@@ -29,7 +31,9 @@ public class AppMapExternalSystemExtension extends ExternalSystemRunConfiguratio
         if (executor instanceof AppMapJvmExecutor) {
             var project = configuration.getProject();
             try {
-                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters);
+                // we know that we're executing with Gradle
+                var gradleFallbackPath = Paths.get("build", "appmap");
+                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters, gradleFallbackPath);
                 javaParameters.getVMParametersList().addAll(jvmParams);
             } catch (Exception e) {
                 LOG.warn("Unable to execute run configuration", e);

--- a/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaProgramPatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaProgramPatcher.java
@@ -9,7 +9,9 @@ import com.intellij.execution.configurations.RunProfile;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Path;
 import java.util.List;
 
 public abstract class AbstractAppMapJavaProgramPatcher implements AppMapProgramPatcher {
@@ -24,7 +26,7 @@ public abstract class AbstractAppMapJavaProgramPatcher implements AppMapProgramP
         if (executor instanceof AppMapJvmExecutor && isSupported(configuration)) {
             var project = ((RunConfiguration) configuration).getProject();
             try {
-                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters, null);
+                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters, getRelativeOutputFallback());
                 applyJvmParameters(javaParameters, jvmParams);
             } catch (Exception e) {
                 LOG.warn("Unable to execute run configuration", e);
@@ -35,6 +37,13 @@ public abstract class AbstractAppMapJavaProgramPatcher implements AppMapProgramP
                         true);
             }
         }
+    }
+
+    /**
+     * @return A relative fallback path if the context allows to provide a better value than "tmp/appmap".
+     */
+    protected @Nullable Path getRelativeOutputFallback() {
+        return null;
     }
 
     protected void applyJvmParameters(JavaParameters javaParameters, List<String> jvmParams) {

--- a/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaProgramPatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaProgramPatcher.java
@@ -24,7 +24,7 @@ public abstract class AbstractAppMapJavaProgramPatcher implements AppMapProgramP
         if (executor instanceof AppMapJvmExecutor && isSupported(configuration)) {
             var project = ((RunConfiguration) configuration).getProject();
             try {
-                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters);
+                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters, null);
                 applyJvmParameters(javaParameters, jvmParams);
             } catch (Exception e) {
                 LOG.warn("Unable to execute run configuration", e);

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaConfigUtil.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaConfigUtil.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Set;
 
@@ -26,12 +27,13 @@ public final class AppMapJavaConfigUtil {
     /**
      * Locate the directory, where AppMap JSON files should be stored in the given module.
      *
-     * @param module  Current module
-     * @param context Context, which is used to compute the fallback if no output directory is defined for the module.
+     * @param module               Current module
+     * @param context              Context, which is used to compute the fallback if no output directory is defined for the module.
+     * @param relativeFallbackPath Better fallback path then tmp/appmap, if available
      * @return The path to the directory, where AppMap files should be stored.
      */
     @RequiresReadLock
-    public static @Nullable Path findAppMapOutputDirectory(@NotNull Module module, @NotNull VirtualFile context) {
+    public static @Nullable Path findAppMapOutputDirectory(@NotNull Module module, @NotNull VirtualFile context, @Nullable Path relativeFallbackPath) {
         ApplicationManager.getApplication().assertReadAccessAllowed();
 
         var topLevelOutputDir = findSupportedTopLevelOutputDirectory(module);
@@ -45,7 +47,10 @@ public final class AppMapJavaConfigUtil {
         var contentRoot = findBestAppMapContentRootDirectory(module, context);
         var contentRootPath = contentRoot.getFileSystem().getNioPath(contentRoot);
         if (contentRootPath != null) {
-            return contentRootPath.resolve("tmp").resolve("appmap");
+            var appMapDir = relativeFallbackPath != null && !relativeFallbackPath.isAbsolute()
+                    ? relativeFallbackPath
+                    : Paths.get("tmp", "appmap");
+            return contentRootPath.resolve(appMapDir);
         }
 
         return null;

--- a/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
+++ b/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
@@ -4,8 +4,11 @@ import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.openapi.util.text.Strings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.execution.MavenRunConfiguration;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 public class AppMapMavenProgramPatcher extends AbstractAppMapJavaProgramPatcher {
@@ -21,5 +24,10 @@ public class AppMapMavenProgramPatcher extends AbstractAppMapJavaProgramPatcher 
         // delegate to Maven child processes via argLine. It follows the implementation of the Maven surefire plugin
         // https://github.com/apache/maven-surefire/blob/78805045bb90d7cc5692b6a388e3605d648146d2/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java#L372
         javaParameters.getVMParametersList().add("-DargLine=" + Strings.join(jvmParams, " "));
+    }
+
+    @Override
+    protected @Nullable Path getRelativeOutputFallback() {
+        return Paths.get("target", "appmap");
     }
 }


### PR DESCRIPTION
Adds better fallback path for projects based on Maven or Gradle.

Especially Gradle projects have a complex structure. The root module does not have an output directory, only modules "main" or "test" have one attached (for spring-petclinic). Because we only receive the root module (without an output path), we were using "tmp/appmap" as fallback, but we need to use "target/appmap" for Gradle.

This adds a similar fallback for Maven based run configurations.

Unfortunately, I'm not aware of a way to run unit tests based on Gradle or Maven run configurations. The SDK's gradle plugin does something similar, but the test suite is not provided with the SDK and replicating it is out of scope (in my opinion).