### PR TITLE
Use read action to fix exception with 2023.2

### DIFF
--- a/plugin-core/src/main/java/appland/utils/RunConfigurationUtil.java
+++ b/plugin-core/src/main/java/appland/utils/RunConfigurationUtil.java
@@ -3,6 +3,7 @@ package appland.utils;
 import com.intellij.execution.configurations.ModuleBasedConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -27,7 +28,9 @@ public final class RunConfigurationUtil {
                                                             @NotNull VirtualFile context) {
         var module = getRunConfigurationModule(runProfile);
         if (module == null) {
-            module = ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(context, false);
+            module = DumbService.getInstance(project).runReadActionInSmartMode(() -> {
+                return ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(context, false);
+            });
         }
         if (module == null) {
             throw new IllegalStateException("unable to locate module to store AppMap files");


### PR DESCRIPTION
With 2023.2, a read action is required. Earlier versions (tested with IC-2021.3.3) did not need it.