### PR TITLE
Fix Gradle with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ cache:
 before_install:
 - chmod +x gradlew
 
-install:
-    - ./gradlew --info build verifyPlugin runPluginVerifier
+install: skip
+
+script:
+  - ./gradlew --info build verifyPlugin runPluginVerifier
 
 before_deploy:
 - |


### PR DESCRIPTION
Don't execute Travis's default commands `./gradlew assemble` and `./gradlew check`.

This should speed up the Travis jobs.