### PR TITLE
Always attach AppMap agent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,14 +134,12 @@ allprojects {
             // always execute tests, don't skip by Gradle's up-to-date checks in development
             outputs.upToDateWhen { false }
 
-            // attach AppMap agent, but only if Gradle is online
-            if (!project.gradle.startParameter.isOffline) {
-                dependsOn(":downloadAppMapAgent")
-                jvmArgs("-javaagent:$agentOutputPath",
-                        "-Dappmap.config.file=${rootProject.file("appmap.yml")}",
-                        "-Dappmap.output.directory=${rootProject.buildDir.resolve("appmap")}")
-                systemProperty("appmap.test.withAgent", "true")
-            }
+            // attach AppMap agent
+            dependsOn(":downloadAppMapAgent")
+            jvmArgs("-javaagent:$agentOutputPath",
+                    "-Dappmap.config.file=${rootProject.file("appmap.yml")}",
+                    "-Dappmap.output.directory=${rootProject.buildDir.resolve("appmap")}")
+            systemProperty("appmap.test.withAgent", "true")
 
             // logging setup
             testLogging {


### PR DESCRIPTION
For unknown reasons ` if (!project.gradle.startParameter.isOffline) { ... }` prevented that the AppMap agent was attached on GitHub Actions. We're now always attaching it. When we switch to the official AppMap Gradle plugin, we don't have to care about the offline mode, anyways.