### PR TITLE
Show findings without source file in Runtime Analysis panel

### DIFF
--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -152,7 +152,10 @@ public final class AppMapFiles {
      * @return The .appmap.json file, which is the source of the given metadata file
      */
     @RequiresReadLock
-    public static @Nullable VirtualFile findAppMapFileByMetadataFile(@NotNull VirtualFile appMapMetadataFile) {
+    public static @Nullable VirtualFile findAppMapFileByMetadataFile(@Nullable VirtualFile appMapMetadataFile) {
+        if (appMapMetadataFile == null) {
+            return null;
+        }
         return findAppMapByMetadataDirectory(appMapMetadataFile.getParent());
     }
 

--- a/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
@@ -217,10 +217,11 @@ public class FindingsManager implements ProblemsProvider {
         }
     }
 
-    public @NotNull List<ScannerProblem> findProblemByHash(@NotNull String hashV2) {
+    public @NotNull List<ScannerFinding> findFindingsByHash(@NotNull String hashV2) {
         synchronized (lock) {
             return sourceFileToProblems.values().stream()
-                    .filter(p -> hashV2.equals(p.getFinding().getAppMapHashWithFallback()))
+                    .map(ScannerProblem::getFinding)
+                    .filter(p -> hashV2.equals(p.getAppMapHashWithFallback()))
                     .collect(Collectors.toList());
         }
     }

--- a/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
@@ -69,11 +69,15 @@ public class FindingsManager implements ProblemsProvider {
         return project;
     }
 
+    /**
+     * @return All known findings, including findings without known source files in the project.
+     */
     public @NotNull List<ScannerFinding> getAllFindings() {
         synchronized (lock) {
-            return sourceFileToProblems.values().stream()
-                    .map(ScannerProblem::getFinding)
-                    .collect(Collectors.toList());
+            return Streams.concat(
+                    sourceFileToProblems.values().stream().map(ScannerProblem::getFinding),
+                    findingsWithoutSourceFiles.stream()
+            ).collect(Collectors.toList());
         }
     }
 

--- a/plugin-core/src/main/java/appland/problemsView/ScannerProblem.java
+++ b/plugin-core/src/main/java/appland/problemsView/ScannerProblem.java
@@ -26,7 +26,7 @@ public final class ScannerProblem implements FileProblem {
         this.annotatedFile = annotatedFile;
         this.finding = finding;
 
-        var location = finding.getProblemLocation();
+        var location = finding.getProblemLocationFromStack();
         this.line = location != null ? location.getZeroBasedLine(-1) : -1;
     }
 

--- a/plugin-core/src/main/java/appland/problemsView/model/FindingsMetadata.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/FindingsMetadata.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 @EqualsAndHashCode
 public final class FindingsMetadata {
     @SerializedName("name")
-    public @Nullable String name = null;
+    public @Nullable String appMapName = null;
 
     @SerializedName("test_status")
     public @Nullable TestStatus testStatus = null;

--- a/plugin-core/src/main/java/appland/problemsView/model/ScannerFinding.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/ScannerFinding.java
@@ -102,13 +102,11 @@ public class ScannerFinding {
         return FileLocation.parse(candidate);
     }
 
-    public @Nullable VirtualFile findAnnotatedFile(@NotNull Project project, @NotNull VirtualFile findingsFile) {
-        var parentDir = findingsFile.getParent();
+    public @Nullable VirtualFile findAnnotatedSourceFile(@NotNull Project project, @NotNull VirtualFile findingsFile) {
         var location = getProblemLocation();
-        if (location != null) {
-            return FileLookup.findRelativeFile(project, parentDir, location.filePath);
-        }
-        return null;
+        return location != null
+                ? FileLookup.findRelativeFile(project, findingsFile.getParent(), location.filePath)
+                : null;
     }
 
     public @Nullable Integer getEventId() {

--- a/plugin-core/src/main/java/appland/problemsView/model/ScannerFinding.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/ScannerFinding.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,6 +18,7 @@ import java.util.Date;
 import java.util.List;
 
 @EqualsAndHashCode
+@ToString
 public class ScannerFinding {
     @SerializedName("hash")
     public @Nullable String appMapHash = null;
@@ -89,7 +91,7 @@ public class ScannerFinding {
         return null;
     }
 
-    public @Nullable FileLocation getProblemLocation() {
+    public @Nullable FileLocation getProblemLocationFromStack() {
         if (stack.isEmpty()) {
             return null;
         }
@@ -103,7 +105,7 @@ public class ScannerFinding {
     }
 
     public @Nullable VirtualFile findAnnotatedSourceFile(@NotNull Project project, @NotNull VirtualFile findingsFile) {
-        var location = getProblemLocation();
+        var location = getProblemLocationFromStack();
         return location != null
                 ? FileLookup.findRelativeFile(project, findingsFile.getParent(), location.filePath)
                 : null;

--- a/plugin-core/src/main/java/appland/problemsView/model/ScannerFindingEvent.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/ScannerFindingEvent.java
@@ -1,9 +1,19 @@
 package appland.problemsView.model;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.jetbrains.annotations.Nullable;
 
+@EqualsAndHashCode
+@ToString
 public class ScannerFindingEvent {
     @SerializedName("id")
     public @Nullable Integer id = null;
+
+    @SerializedName("path")
+    public @Nullable String path = null;
+
+    @SerializedName("http_server_request")
+    public @Nullable ScannerHttpRequestEvent httpServerRequest;
 }

--- a/plugin-core/src/main/java/appland/problemsView/model/ScannerHttpRequestEvent.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/ScannerHttpRequestEvent.java
@@ -1,0 +1,18 @@
+package appland.problemsView.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+@EqualsAndHashCode
+@ToString
+public class ScannerHttpRequestEvent {
+    @SerializedName("request_method")
+    @Nullable
+    public String requestMethod;
+
+    @SerializedName("path_info")
+    @Nullable
+    public String pathInfo;
+}

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/AppMapProjectFindingsNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/AppMapProjectFindingsNode.java
@@ -1,6 +1,6 @@
 package appland.toolwindow.runtimeAnalysis.nodes;
 
-import appland.problemsView.ScannerProblem;
+import appland.problemsView.model.ScannerFinding;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
@@ -18,15 +18,15 @@ import java.util.List;
  */
 final class AppMapProjectFindingsNode extends Node {
     private final String projectName;
-    private final List<ScannerProblem> problems;
+    private final @NotNull List<ScannerFinding> findings;
 
     public AppMapProjectFindingsNode(@NotNull Project project,
                                      @NotNull NodeDescriptor parentDescriptor,
                                      @NotNull String projectName,
-                                     @NotNull List<ScannerProblem> problems) {
+                                     @NotNull List<ScannerFinding> findings) {
         super(project, parentDescriptor);
         this.projectName = projectName;
-        this.problems = problems;
+        this.findings = findings;
     }
 
     @Override
@@ -37,7 +37,7 @@ final class AppMapProjectFindingsNode extends Node {
 
     @Override
     public List<? extends Node> getChildren() {
-        if (problems.isEmpty()) {
+        if (findings.isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -48,7 +48,7 @@ final class AppMapProjectFindingsNode extends Node {
             nodes.add(new FailedTestsNode(myProject, this, failedAppMaps));
         }
 
-        nodes.add(new FailedAndSuccessfulFindingsNode(myProject, this, problems));
+        nodes.add(new FailedAndSuccessfulFindingsNode(myProject, this, findings));
 
         return nodes;
     }

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/DateBucketNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/DateBucketNode.java
@@ -1,6 +1,6 @@
 package appland.toolwindow.runtimeAnalysis.nodes;
 
-import appland.problemsView.ScannerProblem;
+import appland.problemsView.model.ScannerFinding;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
@@ -18,15 +18,15 @@ import java.util.stream.Collectors;
  */
 final class DateBucketNode extends Node {
     private final String label;
-    private final List<ScannerProblem> problems;
+    private final List<ScannerFinding> findings;
 
     public DateBucketNode(@NotNull Project project,
                           @NotNull NodeDescriptor parentDescriptor,
                           @NotNull String label,
-                          @NotNull List<ScannerProblem> problems) {
+                          @NotNull List<ScannerFinding> findings) {
         super(project, parentDescriptor);
         this.label = label;
-        this.problems = problems;
+        this.findings = findings;
     }
 
     @Override
@@ -42,10 +42,10 @@ final class DateBucketNode extends Node {
 
     @Override
     public List<? extends Node> getChildren() {
-        var byImpactDomain = problems.stream()
-                .filter(problem -> problem.getFinding().impactDomain != null)
+        var byImpactDomain = findings.stream()
+                .filter(problem -> problem.impactDomain != null)
                 .collect(Collectors.groupingBy(
-                        item -> item.getFinding().impactDomain,
+                        finding -> finding.impactDomain,
                         TreeMap::new,
                         Collectors.toList()));
 

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/FailedAndSuccessfulFindingsNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/FailedAndSuccessfulFindingsNode.java
@@ -1,7 +1,7 @@
 package appland.toolwindow.runtimeAnalysis.nodes;
 
 import appland.AppMapBundle;
-import appland.problemsView.ScannerProblem;
+import appland.problemsView.model.ScannerFinding;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
@@ -22,13 +22,13 @@ import java.util.stream.Collectors;
  * Displays all findings, regardless of the test_status flag.
  */
 final class FailedAndSuccessfulFindingsNode extends Node {
-    private final List<ScannerProblem> problems;
+    private final @NotNull List<ScannerFinding> findings;
 
     public FailedAndSuccessfulFindingsNode(@NotNull Project project,
                                            @NotNull NodeDescriptor parentDescriptor,
-                                           @NotNull List<ScannerProblem> problems) {
+                                           @NotNull List<ScannerFinding> findings) {
         super(project, parentDescriptor);
-        this.problems = problems;
+        this.findings = findings;
     }
 
     @Override
@@ -46,8 +46,7 @@ final class FailedAndSuccessfulFindingsNode extends Node {
     public List<? extends Node> getChildren() {
         var now = Instant.now();
 
-        var byDateBucket = problems.stream().collect(Collectors.groupingBy(problem -> {
-            var finding = problem.getFinding();
+        var byDateBucket = findings.stream().collect(Collectors.groupingBy(finding -> {
             var date = finding.eventsModifiedDate != null ? finding.eventsModifiedDate : finding.scopeModifiedDate;
             var ageMillis = date != null ? ChronoUnit.MILLIS.between(date.toInstant(), now) : null;
             return DateBucket.findBucket(ageMillis);

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/FindingLocationNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/FindingLocationNode.java
@@ -2,6 +2,7 @@ package appland.toolwindow.runtimeAnalysis.nodes;
 
 import appland.problemsView.model.ScannerFinding;
 import appland.webviews.findingDetails.FindingDetailsEditorProvider;
+import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.fileTypes.FileTypeManager;
@@ -59,6 +60,8 @@ final class FindingLocationNode extends Node {
 
     @Override
     protected void update(@NotNull PresentationData presentation) {
+        var event = finding.event;
+
         if (finding.getProblemLocationFromStack() != null) {
             var filePath = finding.getProblemLocationFromStack().filePath;
             var fileName = PathUtil.getFileName(filePath);
@@ -68,9 +71,13 @@ final class FindingLocationNode extends Node {
             presentation.setIcon(fileType.getIcon());
 
             presentation.setLocationString(filePath);
-        } else {
-            // fixme
-            presentation.setPresentableText("- unknown -");
+        } else if (event != null) {
+            if (event.path != null) {
+                presentation.setPresentableText(event.path);
+            } else if (event.httpServerRequest != null) {
+                var request = event.httpServerRequest;
+                presentation.setPresentableText(String.format("%s %s", request.requestMethod, request.pathInfo));
+            }
         }
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/ImpactDomainNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/ImpactDomainNode.java
@@ -1,7 +1,7 @@
 package appland.toolwindow.runtimeAnalysis.nodes;
 
-import appland.problemsView.ScannerProblem;
 import appland.problemsView.model.ImpactDomain;
+import appland.problemsView.model.ScannerFinding;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.project.Project;
@@ -18,12 +18,12 @@ import java.util.stream.Collectors;
  */
 public final class ImpactDomainNode extends Node {
     private final @NotNull ImpactDomain impactDomain;
-    private final @NotNull List<ScannerProblem> domainFindings;
+    private final @NotNull List<ScannerFinding> domainFindings;
 
     public ImpactDomainNode(@NotNull Project project,
                             @NotNull NodeDescriptor parentDescriptor,
                             @NotNull ImpactDomain impactDomain,
-                            @NotNull List<ScannerProblem> domainFindings) {
+                            @NotNull List<ScannerFinding> domainFindings) {
         super(project, parentDescriptor);
         this.impactDomain = impactDomain;
         this.domainFindings = domainFindings;
@@ -41,7 +41,7 @@ public final class ImpactDomainNode extends Node {
         }
 
         var byRuleTitle = domainFindings.stream().collect(Collectors.groupingBy(problem -> {
-            var ruleTitle = problem.getFinding().ruleTitle;
+            var ruleTitle = problem.ruleTitle;
             return ruleTitle.isEmpty() ? "Unknown" : ruleTitle;
         }));
 

--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
@@ -98,7 +98,7 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
             // attach findings, which belong to this AppMap, as property "findings" (same as in VSCode)
             var findingsFile = ReadAction.compute(() -> AppMapFiles.findRelatedFindingsFile(file));
             if (findingsFile != null) {
-                var matchingFindings = FindingsManager.getInstance(project).getAllProblems()
+                var matchingFindings = FindingsManager.getInstance(project).getAllFindings()
                         .stream()
                         .filter(problem -> findingsFile.equals(problem.getFindingsFile()))
                         .collect(Collectors.toList());

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditorProvider.java
@@ -2,7 +2,7 @@ package appland.webviews.findingDetails;
 
 import appland.AppMapBundle;
 import appland.Icons;
-import appland.problemsView.ScannerProblem;
+import appland.problemsView.model.ScannerFinding;
 import appland.telemetry.TelemetryService;
 import appland.webviews.WebviewEditor;
 import appland.webviews.WebviewEditorProvider;
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 public class FindingDetailsEditorProvider extends WebviewEditorProvider {
     private static final String TYPE_ID = "appland.findingDetails";
-    static final Key<List<ScannerProblem>> KEY_FINDINGS = Key.create("appmap.findingDetailsData");
+    static final Key<List<ScannerFinding>> KEY_FINDINGS = Key.create("appmap.findingDetailsData");
 
     public FindingDetailsEditorProvider() {
         super(TYPE_ID);
@@ -34,7 +34,7 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
      * @param project  Current project
      * @param findings Findings to show in the webview
      */
-    public static void openEditor(@NotNull Project project, @NotNull List<ScannerProblem> findings) {
+    public static void openEditor(@NotNull Project project, @NotNull List<ScannerFinding> findings) {
         var provider = WebviewEditorProvider.findEditorProvider(TYPE_ID);
         assert provider != null;
 
@@ -64,7 +64,7 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
      * because we only want to reuse for the same list of findings.
      */
     private static boolean reuseExistingEditor(@NotNull Project project,
-                                               @NotNull List<ScannerProblem> findings,
+                                               @NotNull List<ScannerFinding> findings,
                                                @NotNull WebviewEditorProvider provider) {
         for (var editor : FileEditorManager.getInstance(project).getAllEditors()) {
             var file = editor.getFile();
@@ -79,13 +79,13 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
         return false;
     }
 
-    private static String findEditorTitle(@NotNull List<ScannerProblem> findings) {
+    private static String findEditorTitle(@NotNull List<ScannerFinding> findings) {
         return findings.isEmpty()
                 ? AppMapBundle.get("webview.findingDetails.title")
-                : findings.get(0).getFinding().ruleTitle;
+                : findings.get(0).ruleTitle;
     }
 
-    private static void queueTelemetryMessage(@NotNull List<ScannerProblem> findings) {
+    private static void queueTelemetryMessage(@NotNull List<ScannerFinding> findings) {
         if (findings.isEmpty()) {
             return;
         }
@@ -94,11 +94,10 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
         // and have the same properties
         var finding = findings.get(0);
         TelemetryService.getInstance().sendEvent("analysis:view_finding", eventData -> {
-            eventData.property("appmap.finding.rule", finding.getFinding().ruleId);
-            eventData.property("appmap.finding.hash", finding.getFinding().getAppMapHashWithFallback());
-            var impactDomain = finding.getFinding().impactDomain;
-            if (impactDomain != null) {
-                eventData.property("appmap.finding.impact_domain", impactDomain.getJsonId());
+            eventData.property("appmap.finding.rule", finding.ruleId);
+            eventData.property("appmap.finding.hash", finding.getAppMapHashWithFallback());
+            if (finding.impactDomain != null) {
+                eventData.property("appmap.finding.impact_domain", finding.impactDomain.getJsonId());
             }
             return eventData;
         });

--- a/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
@@ -118,7 +118,7 @@ public class FindingsOverviewEditor extends WebviewEditor<List<ScannerFinding>> 
     }
 
     private void openFindingsByHash(@NotNull String hash) {
-        var findings = FindingsManager.getInstance(project).findProblemByHash(hash);
+        var findings = FindingsManager.getInstance(project).findFindingsByHash(hash);
         ApplicationManager.getApplication().invokeLater(() -> {
             if (findings.isEmpty()) {
                 Messages.showErrorDialog("Unable to locate AppMap with ID", "Error Locating AppMap");

--- a/plugin-core/src/test/java/appland/problemsView/ScannerProblemTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/ScannerProblemTest.java
@@ -13,7 +13,7 @@ public class ScannerProblemTest extends AppMapBaseTest {
         var scannerFinding = new ScannerFinding();
         scannerFinding.stack = List.of("parent/child/package/file.java:100");
         scannerFinding.setFindingsFile(new LightVirtualFile());
-        var problemLocation = scannerFinding.getProblemLocation();
+        var problemLocation = scannerFinding.getProblemLocationFromStack();
         assertNotNull(problemLocation);
         assertEquals(Integer.valueOf(100), problemLocation.line);
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/368

This PR enhances the findings tree of "Runtime Analysis" to also show findings, which don't have a source files. This matches VSCode's implementation.
This also fixes the display label of findings based on HTTP requests, because they were displayed incorrectly when I tested this PR with spring-petclinic. The updated implementation follows [VSCode's code](https://github.com/getappmap/vscode-appland/blob/694feea75f046d3a9b8179727ab249ec2811690a/src/tree/findingsTreeDataProvider.ts#L128).