### PR TITLE
Show "Runtime Analysis" step as completed when the page is opened for the first time

### DIFF
--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -70,12 +70,15 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
         this.type = type;
     }
 
-    public void navigateTo(@NotNull InstallGuideViewPage page) {
+    public void navigateTo(@NotNull InstallGuideViewPage page, boolean postWebviewMessage) {
         this.type = page;
         if (page == InstallGuideViewPage.RuntimeAnalysis) {
             AppMapProjectSettingsService.getState(project).setInvestigatedFindings(true);
         }
-        postMessage(createPageNavigationJSON(page));
+
+        if (postWebviewMessage) {
+            postMessage(createPageNavigationJSON(page));
+        }
     }
 
     private void refreshProjects() {
@@ -111,6 +114,11 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
                     public void openedAppMapChanged() {
                         settingsRefreshAlarm.cancelAndRequest();
                     }
+
+            @Override
+            public void investigatedFindingsChanged() {
+                settingsRefreshAlarm.cancelAndRequest();
+            }
                 });
     }
 

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditorProvider.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditorProvider.java
@@ -35,14 +35,18 @@ public class InstallGuideEditorProvider implements FileEditorProvider, DumbAware
                     assert editor instanceof InstallGuideEditor;
 
                     FileEditorManagerEx.getInstanceEx(project).openFile(file, true, true);
-                    ((InstallGuideEditor) editor).navigateTo(page);
+                    ((InstallGuideEditor) editor).navigateTo(page, true);
                     return;
                 }
             }
 
             var file = new LightVirtualFile(AppMapBundle.get("installGuide.editor.title"));
             INSTALL_GUIDE_PAGE_KEY.set(file, page);
-            editorManager.openFile(file, true);
+            var newEditors = editorManager.openFile(file, true);
+            if (newEditors.length == 1) {
+                // don't post webview message because the init message of the new editor was just sent
+                ((InstallGuideEditor) newEditors[0]).navigateTo(page, false);
+            }
         } finally {
             // notify in a background thread because we don't want to delay opening the editor
             ApplicationManager.getApplication().executeOnPooledThread(() -> {

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettings.java
@@ -150,6 +150,18 @@ public class AppMapProjectSettings {
         }
     }
 
+    public void setInvestigatedFindings(boolean investigatedFindings) {
+        boolean changed;
+        synchronized (this) {
+            changed = this.investigatedFindings != investigatedFindings;
+            this.investigatedFindings = investigatedFindings;
+        }
+
+        if (changed) {
+            settingsPublisher().investigatedFindingsChanged();
+        }
+    }
+
     @NotNull
     private AppMapSettingsListener settingsPublisher() {
         return ApplicationManager.getApplication().getMessageBus().syncPublisher(AppMapSettingsListener.TOPIC);

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -18,6 +18,9 @@ public interface AppMapSettingsListener {
     default void openedAppMapChanged() {
     }
 
+    default void investigatedFindingsChanged() {
+    }
+
     default void appMapWebViewFiltersChanged() {
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/339

When the user navigates to the page, it should be shown as completed. This wasn't implemented so far.
This also updates the update logic for the "Runtime Analysis" step displayed in the AppMap tool window. Previously, it was marked as done if there was at least one finding. But this implementation was different to VSCode and also different to the logic used for the status of the webview step (i.e. the other change of this PR).