### PR TITLE
Debug information for AppMap metadata indexes

### DIFF
--- a/plugin-core/src/main/java/appland/index/AbstractAppMapMetadataFileIndex.java
+++ b/plugin-core/src/main/java/appland/index/AbstractAppMapMetadataFileIndex.java
@@ -3,22 +3,54 @@ package appland.index;
 import com.google.gson.JsonParseException;
 import com.intellij.json.JsonFileType;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.indexing.*;
+import com.intellij.util.indexing.FileBasedIndex;
+import com.intellij.util.indexing.FileContent;
+import com.intellij.util.indexing.SingleEntryFileBasedIndexExtension;
+import com.intellij.util.indexing.SingleEntryIndexer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Base class for an indexe based on a AppMap metadata file.
+ * Base class for an index based on a AppMap metadata file.
  * <p>
  * Only files in the local file system are indexed.
  *
  * @param <T> Type of the result value
  */
 abstract class AbstractAppMapMetadataFileIndex<T> extends SingleEntryFileBasedIndexExtension<T> {
+    private static final Logger LOG = Logger.getInstance(AbstractAppMapMetadataFileIndex.class);
+
+    private final FileBasedIndex.InputFilter inputFilter = new NamedFileTypeFilter(JsonFileType.INSTANCE, fileName -> {
+        return getIndexedFileName().equalsIgnoreCase(fileName);
+    });
+
+    private final SingleEntryIndexer<T> indexer = new SingleEntryIndexer<>(false) {
+        @Override
+        protected @Nullable T computeValue(@NotNull FileContent inputData) {
+            try {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Indexing with " + getClass().getSimpleName() + ": " + inputData.getFile().getPath());
+                }
+
+                var value = parseMetadataFile(inputData.getContentAsText().toString());
+                if (value == null && LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Empty index result returned by AppMap metadata index: %s, file: %s",
+                            getClass().getSimpleName(),
+                            inputData.getFile().getPath()));
+                }
+                return value;
+            } catch (JsonParseException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("error indexing AppMap metadata file: " + getIndexedFileName(), e);
+                }
+                return null;
+            }
+        }
+    };
+
     /**
-     * Parse the file content to retrieve the result
+     * Parse the file content to retrieve the result.
+     * {@link JsonParseException} thrown by this method are handled by the caller.
      *
      * @param fileContent File content, metadata files are usually JSON
      * @return The result based on fileContent, if available.
@@ -37,26 +69,17 @@ abstract class AbstractAppMapMetadataFileIndex<T> extends SingleEntryFileBasedIn
 
     @Override
     public @NotNull FileBasedIndex.InputFilter getInputFilter() {
-        return new DefaultFileTypeSpecificInputFilter(JsonFileType.INSTANCE) {
-            @Override
-            public boolean acceptInput(@NotNull VirtualFile file) {
-                return file.isInLocalFileSystem() && FileUtil.namesEqual(getIndexedFileName(), file.getName());
-            }
-        };
+        return inputFilter;
+    }
+
+    @Override
+    public final boolean dependsOnFileContent() {
+        // final method to prevent an accidental override
+        return true;
     }
 
     @Override
     public @NotNull SingleEntryIndexer<T> getIndexer() {
-        return new SingleEntryIndexer<>(false) {
-            @Override
-            protected @Nullable T computeValue(@NotNull FileContent inputData) {
-                try {
-                    return parseMetadataFile(inputData.getContentAsText().toString());
-                } catch (JsonParseException e) {
-                    Logger.getInstance(SingleEntryIndexer.class).debug("error indexing AppMap metadata file: " + getIndexedFileName(), e);
-                    return null;
-                }
-            }
-        };
+        return indexer;
     }
 }

--- a/plugin-core/src/main/java/appland/index/IndexUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexUtil.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 final class IndexUtil {
     // base version for our indexes, increase when the data structures or the parsing logic change
-    static final int BASE_VERSION = 60;
+    static final int BASE_VERSION = 61;
 
     // filenames covered by our own indexes
     static final Set<String> indexedFilenames = Collections.unmodifiableSet(findIndexedFilenames());


### PR DESCRIPTION
Adds more debug information for AppMap metadata indexes to help with debugging, e.g. when no AppMaps show up in the AppMap toolwindow.
Cleans some of the base class of AppMap metadata indexes to follow the SDK's way of handling the indexer, for example.