### PR TITLE
Always enable AppMap findings in the AppMap tool window

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -3,8 +3,6 @@ package appland.cli;
 import appland.config.AppMapConfigFile;
 import appland.config.AppMapConfigFileListener;
 import appland.files.AppMapVfsUtils;
-import appland.settings.AppMapApplicationSettingsService;
-import appland.settings.AppMapSettingsListener;
 import com.intellij.execution.CantRunException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -45,12 +43,6 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
     public DefaultCommandLineService() {
         var connection = ApplicationManager.getApplication().getMessageBus().connect(this);
         connection.subscribe(AppMapConfigFileListener.TOPIC, (AppMapConfigFileListener) this::refreshForOpenProjectsInBackground);
-        connection.subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsListener() {
-            @Override
-            public void enableFindingsChanged() {
-                refreshForOpenProjectsInBackground();
-            }
-        });
     }
 
     @Override
@@ -220,45 +212,6 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         stopAll(false);
     }
 
-    private void doRefreshForOpenProjectsLocked() {
-        var topLevelRoots = new VfsUtilCore.DistinctVFilesRootsCollection(VirtualFile.EMPTY_ARRAY);
-        for (var project : ProjectManager.getInstance().getOpenProjects()) {
-            if (!project.isDefault() && !project.isDisposed()) {
-                for (var contentRoot : ProjectRootManager.getInstance(project).getContentRoots()) {
-                    if (isDirectoryEnabled(contentRoot)) {
-                        topLevelRoots.add(contentRoot);
-                    }
-                }
-            }
-        }
-
-        var scannerProcessRequired = AppMapApplicationSettingsService.getInstance().isAnalysisEnabled();
-
-        // remove processes of roots, which no longer have a matching content root in a project
-        // or which don't match the settings anymore. We need to launch the scanner when "enableFindings" changes.
-        // We're iterating on a copy, because stop() is called inside the loop and modifies "processes"
-        for (var entry : List.copyOf(processes.entrySet())) {
-            var activeRoot = entry.getKey();
-            var scannerProcessMismatch = scannerProcessRequired == (entry.getValue().scanner == null);
-            if (!topLevelRoots.contains(activeRoot) || scannerProcessMismatch) {
-                try {
-                    stop(activeRoot, false);
-                } catch (Exception e) {
-                    LOG.warn("Error stopping processes for root: " + activeRoot.getPath());
-                }
-            }
-        }
-
-        // launch missing cli processes
-        for (var root : topLevelRoots) {
-            try {
-                start(root, false);
-            } catch (ExecutionException e) {
-                LOG.warn("Error launching cli process for root: " + root);
-            }
-        }
-    }
-
     private static @Nullable CliProcesses startProcesses(@NotNull VirtualFile directory) throws ExecutionException {
         if (!isSupported()) {
             return null;
@@ -274,9 +227,8 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return null;
         }
 
-        var launchScanner = AppMapApplicationSettingsService.getInstance().isAnalysisEnabled();
         var scannerPath = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.Scanner);
-        if (launchScanner && (scannerPath == null || Files.notExists(scannerPath))) {
+        if (scannerPath == null || Files.notExists(scannerPath)) {
             return null;
         }
 
@@ -293,9 +245,6 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         }
 
         var indexer = startProcess(workingDir, indexerPath.toString(), "index", "--watch", "--appmap-dir", watchedDir.toString());
-        if (!launchScanner) {
-            return new CliProcesses(indexer, null);
-        }
 
         try {
             var scanner = startProcess(workingDir, scannerPath.toString(), "scan", "--watch", "--appmap-dir", watchedDir.toString());
@@ -308,6 +257,42 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
                 LOG.debug("Error terminating scanner process", ex);
             }
             throw new CantRunException("Failed to execute AppMap scanner process", e);
+        }
+    }
+
+    private void doRefreshForOpenProjectsLocked() {
+        var topLevelRoots = new VfsUtilCore.DistinctVFilesRootsCollection(VirtualFile.EMPTY_ARRAY);
+        for (var project : ProjectManager.getInstance().getOpenProjects()) {
+            if (!project.isDefault() && !project.isDisposed()) {
+                for (var contentRoot : ProjectRootManager.getInstance(project).getContentRoots()) {
+                    if (isDirectoryEnabled(contentRoot)) {
+                        topLevelRoots.add(contentRoot);
+                    }
+                }
+            }
+        }
+
+        // remove processes of roots, which no longer have a matching content root in a project
+        // or which don't match the settings anymore. We need to launch the scanner when "enableFindings" changes.
+        // We're iterating on a copy, because stop() is called inside the loop and modifies "processes"
+        for (var entry : List.copyOf(processes.entrySet())) {
+            var activeRoot = entry.getKey();
+            if (!topLevelRoots.contains(activeRoot)) {
+                try {
+                    stop(activeRoot, false);
+                } catch (Exception e) {
+                    LOG.warn("Error stopping processes for root: " + activeRoot.getPath());
+                }
+            }
+        }
+
+        // launch missing cli processes
+        for (var root : topLevelRoots) {
+            try {
+                start(root, false);
+            } catch (ExecutionException e) {
+                LOG.warn("Error launching cli process for root: " + root);
+            }
         }
     }
 

--- a/plugin-core/src/main/java/appland/config/AppMapConfigFileListener.java
+++ b/plugin-core/src/main/java/appland/config/AppMapConfigFileListener.java
@@ -5,6 +5,7 @@ import com.intellij.util.messages.Topic;
 /**
  * Listener for changes to appmap.yaml files.
  */
+@FunctionalInterface
 public interface AppMapConfigFileListener {
     @Topic.AppLevel
     Topic<AppMapConfigFileListener> TOPIC = Topic.create("AppMap config file change", AppMapConfigFileListener.class);

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -238,7 +238,6 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
         json.addProperty("page", type.getPageId());
         json.addProperty("userAuthenticated", settings.getApiKey() != null);
         json.addProperty("analysisEnabled", true);
-        json.addProperty("findingsEnabled", true);
     }
 
     private void handleMessageClickLink(@NotNull JsonObject message) {

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -101,11 +101,6 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
                     }
 
                     @Override
-                    public void enableFindingsChanged() {
-                        settingsRefreshAlarm.cancelAndRequest();
-                    }
-
-                    @Override
                     public void createOpenApiChanged() {
                         settingsRefreshAlarm.cancelAndRequest();
                     }
@@ -115,10 +110,10 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
                         settingsRefreshAlarm.cancelAndRequest();
                     }
 
-            @Override
-            public void investigatedFindingsChanged() {
-                settingsRefreshAlarm.cancelAndRequest();
-            }
+                    @Override
+                    public void investigatedFindingsChanged() {
+                        settingsRefreshAlarm.cancelAndRequest();
+                    }
                 });
     }
 
@@ -242,8 +237,8 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
 
         json.addProperty("page", type.getPageId());
         json.addProperty("userAuthenticated", settings.getApiKey() != null);
-        json.addProperty("analysisEnabled", settings.isAnalysisEnabled());
-        json.addProperty("findingsEnabled", settings.isEnableFindings());
+        json.addProperty("analysisEnabled", true);
+        json.addProperty("findingsEnabled", true);
     }
 
     private void handleMessageClickLink(@NotNull JsonObject message) {

--- a/plugin-core/src/main/java/appland/oauth/AppMapLoginAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLoginAction.java
@@ -21,10 +21,6 @@ public class AppMapLoginAction extends AnAction {
                 var responseData = response.get();
                 var settings = AppMapApplicationSettingsService.getInstance();
                 settings.setApiKeyNotifying(responseData.getAccessToken());
-
-                // also enabling findings, because the install-guide JS application
-                // expects this for "Enable AppMap Runtime Analysis"
-                settings.setEnableFindingsNotifying(true);
             } catch (Exception ex) {
                 Logger.getInstance(AppMapLoginAction.class).warn("Error authenticating with AppMap server", ex);
             }

--- a/plugin-core/src/main/java/appland/problemsView/FindingsPanelProvider.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsPanelProvider.java
@@ -1,6 +1,5 @@
 package appland.problemsView;
 
-import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.analysis.problemsView.toolWindow.ProblemsViewPanelProvider;
 import com.intellij.analysis.problemsView.toolWindow.ProblemsViewState;
 import com.intellij.analysis.problemsView.toolWindow.ProblemsViewTab;
@@ -21,8 +20,6 @@ public class FindingsPanelProvider implements ProblemsViewPanelProvider {
     @Nullable
     @Override
     public ProblemsViewTab create() {
-        return AppMapApplicationSettingsService.getInstance().isAnalysisEnabled()
-                ? new FindingsViewTab(project, ProblemsViewState.getInstance(project))
-                : null;
+        return new FindingsViewTab(project, ProblemsViewState.getInstance(project));
     }
 }

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -24,9 +24,6 @@ public class AppMapApplicationSettings {
     private volatile boolean firstStart = true;
 
     @Setter
-    private volatile boolean enableFindings = true;
-
-    @Setter
     private volatile boolean enableTelemetry = true;
 
     @Setter
@@ -38,18 +35,8 @@ public class AppMapApplicationSettings {
     public AppMapApplicationSettings(@NotNull AppMapApplicationSettings settings) {
         this.appmapInstructionsViewed = settings.appmapInstructionsViewed;
         this.firstStart = settings.firstStart;
-        this.enableFindings = settings.enableFindings;
         this.enableTelemetry = settings.enableTelemetry;
         this.apiKey = settings.apiKey;
-    }
-
-    public void setEnableFindingsNotifying(boolean enableFindings) {
-        var changed = !Objects.equals(enableFindings, this.enableFindings);
-        this.enableFindings = enableFindings;
-
-        if (changed) {
-            settingsPublisher().enableFindingsChanged();
-        }
     }
 
     public void setApiKeyNotifying(@Nullable String apiKey) {
@@ -59,10 +46,6 @@ public class AppMapApplicationSettings {
         if (changed) {
             settingsPublisher().apiKeyChanged();
         }
-    }
-
-    public boolean isAnalysisEnabled() {
-        return isAuthenticated() && enableFindings;
     }
 
     public boolean isAuthenticated() {

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettingsForm.form
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="appland.settings.AppMapProjectSettingsForm">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -31,17 +31,9 @@
           <text resource-bundle="messages/appland" key="projectSettings.confirmUpload"/>
         </properties>
       </component>
-      <component id="c3fb8" class="com.intellij.ui.components.JBCheckBox" binding="enableFindings">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="messages/appland" key="projectSettings.enableFindings.title"/>
-        </properties>
-      </component>
       <component id="a0b56" class="com.intellij.ui.components.JBCheckBox" binding="enableTelemetry">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="messages/appland" key="projectSettings.enableTelemetry.title"/>
@@ -49,7 +41,7 @@
       </component>
       <vspacer id="34c24">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>

--- a/plugin-core/src/main/java/appland/settings/AppMapProjectSettingsForm.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapProjectSettingsForm.java
@@ -13,7 +13,6 @@ class AppMapProjectSettingsForm {
     private JPanel mainPanel;
     private JBTextField serverName;
     private JBCheckBox confirmUpload;
-    private JBCheckBox enableFindings;
     private JBCheckBox enableTelemetry;
 
     AppMapProjectSettingsForm() {
@@ -29,7 +28,6 @@ class AppMapProjectSettingsForm {
         serverName.setText(settings.getCloudServerUrl());
         confirmUpload.setSelected(settings.isConfirmAppMapUpload());
 
-        enableFindings.setSelected(applicationSettings.isEnableFindings());
         enableTelemetry.setSelected(applicationSettings.isEnableTelemetry());
     }
 
@@ -42,10 +40,5 @@ class AppMapProjectSettingsForm {
 
         // application
         applicationSettings.setEnableTelemetry(enableTelemetry.isSelected());
-        if (notify) {
-            applicationSettings.setEnableFindingsNotifying(enableFindings.isSelected());
-        } else {
-            applicationSettings.setEnableFindings(enableFindings.isSelected());
-        }
     }
 }

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -9,9 +9,6 @@ public interface AppMapSettingsListener {
     default void apiKeyChanged() {
     }
 
-    default void enableFindingsChanged() {
-    }
-
     default void createOpenApiChanged() {
     }
 

--- a/plugin-core/src/main/java/appland/startup/AppLandStartupActivity.java
+++ b/plugin-core/src/main/java/appland/startup/AppLandStartupActivity.java
@@ -13,8 +13,6 @@ import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.startup.StartupManager;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class AppLandStartupActivity implements StartupActivity {
     @Override
     public void runActivity(@NotNull Project project) {
@@ -40,25 +38,9 @@ public class AppLandStartupActivity implements StartupActivity {
         project.getMessageBus()
                 .connect(AppLandLifecycleService.getInstance(project))
                 .subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsListener() {
-                    private final AtomicBoolean lastEnabledState = new AtomicBoolean(AppMapApplicationSettingsService.getInstance().isAnalysisEnabled());
-
                     @Override
                     public void apiKeyChanged() {
-                        sendRuntimeAnalysisTelemetry();
                         sendAuthenticationTelemetry();
-                    }
-
-                    @Override
-                    public void enableFindingsChanged() {
-                        sendRuntimeAnalysisTelemetry();
-                    }
-
-                    private void sendRuntimeAnalysisTelemetry() {
-                        var newEnabledState = AppMapApplicationSettingsService.getInstance().isAnalysisEnabled();
-                        if (lastEnabledState.getAndSet(newEnabledState) != newEnabledState) {
-                            var eventName = newEnabledState ? "analysis:enable" : "analysis:disable";
-                            TelemetryService.getInstance().sendEvent(eventName);
-                        }
                     }
 
                     private void sendAuthenticationTelemetry() {

--- a/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/installGuide/InstallGuidePanel.java
@@ -7,7 +7,6 @@ import appland.installGuide.InstallGuideViewPage;
 import appland.installGuide.projectData.ProjectDataService;
 import appland.installGuide.projectData.ProjectMetadata;
 import appland.problemsView.listener.ScannerFindingsListener;
-import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.toolwindow.AppMapContentPanel;
@@ -70,11 +69,6 @@ public class InstallGuidePanel extends AppMapContentPanel implements Disposable 
      * if findings are enabled, completed if at least one appmap-findings.json file was found
      */
     private static void updateRuntimeAnalysisLabel(@NotNull Project project, @NotNull StatusLabel label) {
-        if (!AppMapApplicationSettingsService.getInstance().isAnalysisEnabled()) {
-            label.setStatus(InstallGuideStatus.Unavailable);
-            return;
-        }
-
         var hasFindings = AppMapProjectSettingsService.getState(project).isInvestigatedFindings();
         label.setStatus(hasFindings ? InstallGuideStatus.Completed : InstallGuideStatus.Incomplete);
     }
@@ -154,11 +148,6 @@ public class InstallGuidePanel extends AppMapContentPanel implements Disposable 
         connection.subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsListener() {
             @Override
             public void apiKeyChanged() {
-                triggerLabelStatusUpdate();
-            }
-
-            @Override
-            public void enableFindingsChanged() {
                 triggerLabelStatusUpdate();
             }
         });

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModel.java
@@ -39,22 +39,10 @@ public class RuntimeAnalysisModel extends BaseTreeModel<Node> implements Invoker
     public RuntimeAnalysisModel(@NotNull Project project, @NotNull Disposable parent) {
         this.root = new RootNode(project, this);
         Disposer.register(parent, this);
-
-        // update root node state and the empty panel when the login state changed
-        project.getMessageBus().connect(this).subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsListener() {
-            @Override
-            public void enableFindingsChanged() {
-                structureChanged(null);
-            }
-        });
     }
 
     @Override
     public @Nullable RootNode getRoot() {
-        if (!AppMapApplicationSettingsService.getInstance().isEnableFindings()) {
-            return null;
-        }
-
         if (invoker.isValidThread()) {
             root.update();
         }

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisPanel.java
@@ -1,9 +1,5 @@
 package appland.toolwindow.runtimeAnalysis;
 
-import appland.AppMapBundle;
-import appland.installGuide.InstallGuideEditorProvider;
-import appland.installGuide.InstallGuideViewPage;
-import appland.oauth.AppMapLoginAction;
 import appland.toolwindow.runtimeAnalysis.nodes.Node;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -11,10 +7,8 @@ import com.intellij.openapi.actionSystem.DataProvider;
 import com.intellij.openapi.actionSystem.PlatformCoreDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.pom.Navigatable;
 import com.intellij.ui.ScrollPaneFactory;
-import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.TreeSpeedSearch;
 import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.RestoreSelectionListener;
@@ -92,23 +86,6 @@ public class RuntimeAnalysisPanel extends JPanel implements Disposable, DataProv
         new TreeSpeedSearch(tree);
         EditSourceOnDoubleClickHandler.install(tree);
         EditSourceOnEnterKeyHandler.install(tree);
-
-        var empty = tree.getEmptyText();
-        empty.setShowAboveCenter(true);
-        // the panel does not wrap text, we're splitting into rows by \n
-        var label = AppMapBundle.get("runtimeAnalysis.tree.emptyText.label");
-        for (var line : StringUtil.splitByLines(label)) {
-            empty.appendLine(line);
-        }
-
-        empty.appendLine(
-                AppMapBundle.get("runtimeAnalysis.tree.emptyText.loginText"),
-                SimpleTextAttributes.LINK_ATTRIBUTES,
-                e -> AppMapLoginAction.authenticate());
-        empty.appendLine(
-                AppMapBundle.get("runtimeAnalysis.tree.emptyText.learnModeText"),
-                SimpleTextAttributes.LINK_ATTRIBUTES,
-                e -> InstallGuideEditorProvider.open(project, InstallGuideViewPage.RuntimeAnalysis));
 
         return tree;
     }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -160,10 +160,6 @@ appMapExecutor.executionError.message=Unable to execute the run configuration: {
 annotator.quickFixFamily=AppMap
 annotator.openQuickFix.name=Open in AppMap file
 
-runtimeAnalysis.tree.emptyText.label=AppMap runtime analysis\nworks right in your code editor,\nto help you find and fix problems in your code.
-runtimeAnalysis.tree.emptyText.loginText=Sign up
-runtimeAnalysis.tree.emptyText.learnModeText=Learn more
-
 webview.loading=Loading webview...
 
 webview.findingsOverview.title=Findings Overview

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -42,7 +42,6 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         TestAppLandDownloadService.ensureDownloaded();
 
         RegisterContentRootsActivity.listenForContentRootChanges(getProject(), getTestRootDisposable());
-        AppMapApplicationSettingsService.getInstance().setEnableFindings(true);
         AppMapApplicationSettingsService.getInstance().setApiKey("api-key");
     }
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/388

This PR removes the setting "Enable findings (experimental)" and always enables the support for AppMap findings:
- The AppMap scanner process is always launched, along with the AppMap indexer
- Telemetry messages `analysis:enable` and `analysis:disable` are not sent anymore, because the user can't toggle it anymore
- The Runtime Analysis panel does not display an empty text anymore. The empty text is shown if no node is visible in the tree. This doesn't happen anymore because of the "Findings overview" node. Previously, the node was hidden if the setting was turned off and a text with sign in instructions was shown.