### PR TITLE
Fix NPE caused by a `null` value for the name property of AppMap metadata.json

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ version = pluginVersion
 
 val isCI = System.getenv("CI") == "true"
 val agentOutputPath = rootProject.buildDir.resolve("appmap-agent.jar")
+val githubToken = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() }
 
 allprojects {
     repositories {
@@ -124,8 +125,8 @@ allprojects {
         withType<Test> {
             systemProperty("idea.test.execution.policy", "appland.AppLandTestExecutionPolicy")
             systemProperty("appland.testDataPath", rootProject.rootDir.resolve("src/test/data").path)
-            if (isCI) {
-                systemProperty("appland.github_token", System.getenv("GITHUB_TOKEN"))
+            if (isCI && githubToken != null) {
+                systemProperty("appland.github_token", githubToken)
             }
 
             // to allow tests to access the custom Java 11 JDK
@@ -242,8 +243,8 @@ project(":") {
             dest(project.buildDir.resolve("appmap-java.json"))
             overwrite(true)
             quiet(true)
-            if (isCI) {
-                header("Authorization", "Bearer ${System.getenv("GITHUB_TOKEN")}")
+            if (isCI && githubToken != null) {
+                header("Authorization", "Bearer $githubToken")
             }
 
             doLast {
@@ -257,8 +258,8 @@ project(":") {
                     src(jarAsset)
                     dest(agentOutputPath)
                     overwrite(false)
-                    if (isCI) {
-                        header("Authorization", "Bearer ${System.getenv("GITHUB_TOKEN")}")
+                    if (isCI && githubToken != null) {
+                        header("Authorization", "Bearer $githubToken")
                     }
                 }
             }

--- a/plugin-core/src/main/java/appland/index/BasicAppMapMetadataExternalizer.java
+++ b/plugin-core/src/main/java/appland/index/BasicAppMapMetadataExternalizer.java
@@ -10,13 +10,17 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 class BasicAppMapMetadataExternalizer implements DataExternalizer<BasicAppMapMetadata> {
-    public static final BasicAppMapMetadataExternalizer INSTANCE = new BasicAppMapMetadataExternalizer();
+    static final @NotNull BasicAppMapMetadataExternalizer INSTANCE = new BasicAppMapMetadataExternalizer();
+
+    private BasicAppMapMetadataExternalizer() {
+    }
 
     @Override
     public BasicAppMapMetadata read(@NotNull DataInput in) throws IOException {
-        var name = IOUtil.readUTF(in);
-        var hasTestStatus = in.readBoolean();
+        var hasName = in.readBoolean();
+        var name = hasName ? IOUtil.readUTF(in) : null;
 
+        var hasTestStatus = in.readBoolean();
         TestStatus testStatus = null;
         if (hasTestStatus) {
             var jsonId = IOUtil.readUTF(in);
@@ -27,8 +31,11 @@ class BasicAppMapMetadataExternalizer implements DataExternalizer<BasicAppMapMet
     }
 
     @Override
-    public void save(@NotNull DataOutput out, BasicAppMapMetadata value) throws IOException {
-        IOUtil.writeUTF(out, value.name);
+    public void save(@NotNull DataOutput out, @NotNull BasicAppMapMetadata value) throws IOException {
+        out.writeBoolean(value.name != null);
+        if (value.name != null) {
+            IOUtil.writeUTF(out, value.name);
+        }
 
         out.writeBoolean(value.testStatus != null);
         if (value.testStatus != null) {

--- a/plugin-core/src/main/java/appland/index/IndexUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexUtil.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 final class IndexUtil {
     // base version for our indexes, increase when the data structures or the parsing logic change
-    static final int BASE_VERSION = 61;
+    static final int BASE_VERSION = 62;
 
     // filenames covered by our own indexes
     static final Set<String> indexedFilenames = Collections.unmodifiableSet(findIndexedFilenames());

--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -17,6 +17,7 @@ import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
 import com.intellij.util.ThrowableRunnable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 
@@ -49,17 +50,23 @@ public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4Tes
     }
 
     public @NotNull VirtualFile createAppMapWithIndexes(@NotNull String appMapName) throws Throwable {
-        return createAppMapWithIndexes(appMapName, 0, 0, 0);
+        return createAppMapWithIndexes(appMapName, 0, 0, 0, appMapName);
     }
 
-    public @NotNull VirtualFile createAppMapWithIndexes(@NotNull String appMapName, int requestCount, int queryCount, int functionCount) throws Throwable {
+    public @NotNull VirtualFile createAppMapWithIndexes(@NotNull String appMapName,
+                                                        int requestCount,
+                                                        int queryCount,
+                                                        int functionCount,
+                                                        @Nullable String appMapNameProperty) throws Throwable {
+        var namePropertyValue = appMapNameProperty != null ? "\"" + appMapNameProperty + "\"" : null;
+
         return WriteAction.computeAndWait((ThrowableComputable<VirtualFile, Throwable>) () -> {
             // create empty .appmap.json files because we're not indexing it
             var appMapFile = myFixture.createFile(appMapName + ".appmap.json", "");
 
             // create name/metadata.json with a name property
             var appMapDir = appMapFile.getParent().createChildDirectory(this, appMapName);
-            VfsUtil.saveText(appMapDir.createChildData(this, "metadata.json"), "{\"name\": \"" + appMapName + "\"}");
+            VfsUtil.saveText(appMapDir.createChildData(this, "metadata.json"), "{\"name\": " + namePropertyValue + "}");
 
             if (requestCount > 0) {
                 var json = "[" + StringUtil.trimEnd(StringUtil.repeat("{},", requestCount), ",") + "]";

--- a/plugin-core/src/test/java/appland/index/AppMapMetadataIndexTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapMetadataIndexTest.java
@@ -3,7 +3,6 @@ package appland.index;
 import appland.AppMapBaseTest;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Comparator;
 
 public class AppMapMetadataIndexTest extends AppMapBaseTest {
@@ -36,7 +35,7 @@ public class AppMapMetadataIndexTest extends AppMapBaseTest {
 
     @Test
     public void indexWithCounts() throws Throwable {
-        createAppMapWithIndexes("a", 5, 10, 15);
+        createAppMapWithIndexes("a", 5, 10, 15, "a");
 
         var appMaps = AppMapMetadataService.getInstance(getProject()).findAppMaps();
         assertEquals(1, appMaps.size());

--- a/plugin-core/src/test/java/appland/index/AppMapNameIndexTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapNameIndexTest.java
@@ -1,0 +1,23 @@
+package appland.index;
+
+import appland.AppMapBaseTest;
+import appland.files.AppMapFiles;
+import org.junit.Test;
+
+public class AppMapNameIndexTest extends AppMapBaseTest {
+    @Test
+    public void nullName() throws Throwable {
+        // appmap with a null value for the name JSON property in metadata.json
+        var appMap = createAppMapWithIndexes("a", 0, 0, 0, null);
+
+        var metadataDir = AppMapFiles.findAppMapMetadataDirectory(appMap);
+        assertNotNull(metadataDir);
+
+        var appMapByIndex = AppMapNameIndex.getBasicMetadata(getProject(), metadataDir);
+        assertNotNull(appMapByIndex);
+        assertNull(appMapByIndex.name);
+
+        // the metadata service is skipping AppMaps without a name
+        assertEquals(0, AppMapMetadataService.getInstance(getProject()).findAppMaps().size());
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/397

This fixes a user-reported exception. I'm not entirely sure how `name` of metadata.json could become empty. This PR supports the `null` value during indexing to now throw an exception.

This PR adds a test and a few necessary modifications to allow creation of AppMap metadata.json with a `null` name property value in our tests.