### PR TITLE
Execute GitHub Actions on Windows and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,13 @@ on:
 
 jobs:
     test:
-        name: Test
-        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+        name: Test ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 45
         steps:
             - name: Fetch Sources
               uses: actions/checkout@v3
@@ -27,12 +32,15 @@ jobs:
             # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
             - name: Show GitHub Actions rate limit
               shell: bash
+              # curl is unavailable on Windows
+              if: runner.os != 'Windows'
               run: |
                   curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -i https://api.github.com/users/octocat | grep x-ratelimit
 
             - name: Run Linters and Test
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
               run: ./gradlew check
 
             - name: Verify plugin
@@ -41,20 +49,22 @@ jobs:
 
             - name: Run Plugin Verifier
               shell: bash
+              # JetBrains plugin verifier should always report the same results, regardless of the OS
+              if: runner.os == 'Linux'
               run: ./gradlew runPluginVerifier
 
             - name: Upload Test Reports
               uses: actions/upload-artifact@v3
               if: always()
               with:
-                  name: test-reports-linux
+                  name: test-reports-${{ matrix.os }}
                   path: |
                       build/reports/
                       **/build/reports/
 
             - name: Save AppMaps
               uses: actions/cache/save@v3
-              if: always()
+              if: runner.os == 'Linux'
               with:
                   path: tmp/appmap
                   key: appmaps-${{ github.sha }}-${{ github.run_attempt }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,20 @@ jobs:
               run: |
                   curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -i https://api.github.com/users/octocat | grep x-ratelimit
 
-            - name: Run Linters and Test
+            - name: Run Linters and Test (Linux and macOS)
+              if: runner.os != 'Windows'
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: ./gradlew check
+
+            # Termination of AppMap CLI processes is failing with IC-2021.3 for unknown reasons (process.destroy() etc.)
+            - name: Run Linters and Test with 2023.2 (Windows)
+              if: runner.os == 'Windows'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              run: ./gradlew check -PideVersion=IC-2023.2.1
 
             - name: Verify plugin
               shell: bash

--- a/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
@@ -174,17 +174,31 @@ public class FindingsManager implements ProblemsProvider {
                 .expireWith(this)
                 .coalesceBy(getClass(), project)
                 .finishOnUiThread(ModalityState.any(), findingFiles -> {
+                    if (project.isDisposed()) {
+                        return;
+                    }
+
                     // We can't use "submit().onSuccess()" to process the files, because the non-blocking ReadAction
                     // cancels the progress indicator, which is wrapping the code of "onSuccess()". But loading the
                     // findings must not be cancelled, so we're moving into our own ReadAction outside the original
                     // progress indicator.
-                    ApplicationManager.getApplication().executeOnPooledThread(() -> ReadAction.run(() -> {
-                        clearAndNotify();
-                        for (var findingFile : findingFiles) {
-                            addFindingsFile(findingFile);
+                    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                        if (project.isDisposed()) {
+                            return;
                         }
-                        project.getMessageBus().syncPublisher(ScannerFindingsListener.TOPIC).afterFindingsReloaded();
-                    }));
+
+                        ReadAction.run(() -> {
+                            if (project.isDisposed()) {
+                                return;
+                            }
+
+                            clearAndNotify();
+                            for (var findingFile : findingFiles) {
+                                addFindingsFile(findingFile);
+                            }
+                            project.getMessageBus().syncPublisher(ScannerFindingsListener.TOPIC).afterFindingsReloaded();
+                        });
+                    });
                 }).submit(AppExecutorUtil.getAppExecutorService());
     }
 

--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -14,12 +14,15 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.testFramework.EdtTestUtilKt;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
 import com.intellij.util.ThrowableRunnable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 
 import java.util.Collections;
@@ -44,10 +47,30 @@ public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4Tes
 
     @After
     public void shutdownAppMapProcesses() {
-        AppLandCommandLineService.getInstance().stopAll(true);
+        var commandLineService = AppLandCommandLineService.getInstance();
+        try {
+            // multiple shutdown attempts because Windows CI is constantly failing
+            var attempts = 5;
+            for (var i = 1; i <= attempts; i++) {
+                if (commandLineService.getActiveRoots().isEmpty()) {
+                    break;
+                }
 
-        // reset to default settings
-        ApplicationManager.getApplication().getService(AppMapApplicationSettingsService.class).loadState(new AppMapApplicationSettings());
+                LOG.debug(String.format("Attempting to terminate AppMap processes: %d/%d", i, attempts));
+                if (i > 1) {
+                    Thread.sleep(5_000);
+                }
+                commandLineService.stopAll(true);
+            }
+        } catch (Throwable t) {
+            addSuppressedException(t);
+        } finally {
+            // reset to default settings
+            ApplicationManager.getApplication().getService(AppMapApplicationSettingsService.class).loadState(new AppMapApplicationSettings());
+
+            var activeRoots = commandLineService.getActiveRoots();
+            Assert.assertTrue("All AppMap CLIs must be terminated: " + activeRoots, activeRoots.isEmpty());
+        }
     }
 
     public @NotNull VirtualFile createAppMapWithIndexes(@NotNull String appMapName) throws Throwable {

--- a/plugin-core/src/test/java/appland/toolwindow/codeObjects/CodeObjectsModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/codeObjects/CodeObjectsModelTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.List;
 
 public class CodeObjectsModelTest extends AppMapBaseTest {
     @Test
@@ -53,8 +52,9 @@ public class CodeObjectsModelTest extends AppMapBaseTest {
                                  @NotNull String expectedOutputFileName) throws IOException {
         var output = new StringBuilder();
         buildTreeRepresentation(model, node, output, 0);
-        var expectedOutput = Files.readString(Paths.get(getTestDataPath()).resolve(expectedOutputFileName));
-        assertEquals("Tree rendering does not match expected file content: " + expectedOutputFileName, expectedOutput.trim(), output.toString().trim());
+        var fileContent = Files.readString(Paths.get(getTestDataPath()).resolve(expectedOutputFileName));
+        var expectedOutput = StringUtil.convertLineSeparators(fileContent).trim();
+        assertEquals("Tree rendering does not match expected file content: " + expectedOutputFileName, expectedOutput, output.toString().trim());
     }
 
     private void buildTreeRepresentation(@NotNull CodeObjectsModel model, @NotNull Node node, @NotNull StringBuilder output, int indentationLevel) {

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -113,7 +113,9 @@ public final class AppMapJavaPackageConfig {
                                            @NotNull Path relativeAppMapOutputPath) throws IOException {
         var config = AppMapConfigFile.parseConfigFile(appMapConfig);
         if (config != null) {
-            config.setAppMapDir(relativeAppMapOutputPath.toString());
+            // appmap_dir should be "dir/subdir" even on Windows
+            var agnosticOutputPath = PathUtil.toSystemIndependentName(relativeAppMapOutputPath.toString());
+            config.setAppMapDir(agnosticOutputPath);
             config.writeTo(appMapConfig);
         }
     }


### PR DESCRIPTION
Closes #261  

This adds CI support for Windows and macOS using GitHub Actions.

- I added a few fixes to our tests to successfully run on Windows. Some test errors only happened, because of (apparently) dramatically slower Windows machines, e.g. background thread activity long after a project was disposed by a test.
- With the default platform version tests on Windows failed. The AppMap CLI processes failed to terminate and continued to run. The running processes locked the `tmp/appmap` dir, which then prevented to successfully terminate and cleanup tests using AppMap data. I wasn't able to reproduce or to find a working fix. Building against a later JetBrains platform version worked, though. My assumption is, that the later SDKs fixed process termination on Windows.
- I manually verified that the AppMap CLI processes are terminated on Windows with 2021.2 when a project is closed. It's still possible that the above error of failing process termination is also present for Windows users, but so far it seems only limited to our tests and/or Windows via GitHub Actions.
- I also observed GH actions workflow executions, which did not finish. I limited the execution time to 45 minutes to terminate early. Updating to latest Gradle wasn't possible because of https://github.com/gradle/gradle/issues/25752

It also helped to find and fix a real bug:
- https://github.com/getappmap/appmap-intellij-plugin/pull/401/commits/6c04a3c95625f4227288a229a21ed82658bced41 fixed the update of `appmap_dir:`. Previously, the Windows file separator was used instead of `/` on all platforms.

Stack from a hung workflow: https://github.com/getappmap/appmap-intellij-plugin/actions/runs/6125286203/job/16626940066
```
"main" #1 prio=5 os_prio=0 cpu=4812.50ms elapsed=1213.11s tid=0x000001c8183732b0 nid=0x620 runnable  [0x00000092d0dfc000]
   java.lang.Thread.State: RUNNABLE
	at sun.nio.ch.WEPoll.wait(java.base@17.0.8.1/Native Method)
	at sun.nio.ch.WEPollSelectorImpl.doSelect(java.base@17.0.8.1/WEPollSelectorImpl.java:111)
	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@17.0.8.1/SelectorImpl.java:129)
	- locked <0x00000000fc8aa5d0> (a sun.nio.ch.Util$2)
	- locked <0x00000000fc8aa3d8> (a sun.nio.ch.WEPollSelectorImpl)
	at sun.nio.ch.SelectorImpl.select(java.base@17.0.8.1/SelectorImpl.java:146)
	at org.gradle.internal.remote.internal.inet.SocketConnection$SocketInputStream.read(SocketConnection.java:185)
	at com.esotericsoftware.kryo.io.Input.fill(Input.java:146)
	at com.esotericsoftware.kryo.io.Input.require(Input.java:178)
	at com.esotericsoftware.kryo.io.Input.readVarInt(Input.java:355)
	at com.esotericsoftware.kryo.io.Input.readInt(Input.java:350)
	at org.gradle.internal.serialize.kryo.KryoBackedDecoder.readSmallInt(KryoBackedDecoder.java:133)
	at org.gradle.internal.serialize.DefaultSerializerRegistry$TaggedTypeSerializer.read(DefaultSerializerRegistry.java:155)
	at org.gradle.internal.serialize.Serializers$StatefulSerializerAdapter$1.read(Serializers.java:36)
	at org.gradle.internal.remote.internal.inet.SocketConnection.receive(SocketConnection.java:81)
	at org.gradle.launcher.daemon.client.DaemonClientConnection.receive(DaemonClientConnection.java:77)
	at org.gradle.launcher.daemon.client.DaemonClientConnection.receive(DaemonClientConnection.java:35)
	at org.gradle.launcher.daemon.client.DaemonClient.monitorBuild(DaemonClient.java:235)
	at org.gradle.launcher.daemon.client.DaemonClient.executeBuild(DaemonClient.java:204)
	at org.gradle.launcher.daemon.client.DaemonClient.execute(DaemonClient.java:167)
	at org.gradle.launcher.daemon.client.DaemonClient.execute(DaemonClient.java:99)
	at org.gradle.launcher.cli.RunBuildAction.run(RunBuildAction.java:57)
	at org.gradle.internal.Actions$RunnableActionAdapter.execute(Actions.java:210)
	at org.gradle.launcher.cli.DefaultCommandLineActionFactory$ParseAndBuildAction.execute(DefaultCommandLineActionFactory.java:259)
	at org.gradle.launcher.cli.DefaultCommandLineActionFactory$ParseAndBuildAction.execute(DefaultCommandLineActionFactory.java:230)
	at org.gradle.launcher.cli.DebugLoggerWarningAction.execute(DebugLoggerWarningAction.java:82)
	at org.gradle.launcher.cli.DebugLoggerWarningAction.execute(DebugLoggerWarningAction.java:30)
	at org.gradle.launcher.cli.WelcomeMessageAction.execute(WelcomeMessageAction.java:96)
	at org.gradle.launcher.cli.WelcomeMessageAction.execute(WelcomeMessageAction.java:40)
	at org.gradle.launcher.cli.NativeServicesInitializingAction.execute(NativeServicesInitializingAction.java:44)
	at org.gradle.launcher.cli.NativeServicesInitializingAction.execute(NativeServicesInitializingAction.java:26)
	at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:41)
	at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:26)
	at org.gradle.launcher.cli.DefaultCommandLineActionFactory$WithLogging.execute(DefaultCommandLineActionFactory.java:[361](https://github.com/getappmap/appmap-intellij-plugin/actions/runs/6125286203/job/16626940066#step:7:362))
	at org.gradle.launcher.Main.doAction(Main.java:35)
	at org.gradle.launcher.bootstrap.EntryPoint.run(EntryPoint.java:50)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.8.1/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.8.1/NativeMethodAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.8.1/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@17.0.8.1/Method.java:568)
	at org.gradle.launcher.bootstrap.ProcessBootstrap.runNoExit(ProcessBootstrap.java:60)
	at org.gradle.launcher.bootstrap.ProcessBootstrap.run(ProcessBootstrap.java:37)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.8.1/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.8.1/NativeMethodAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.8.1/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@17.0.8.1/Method.java:568)
	at org.gradle.launcher.GradleMain.main(GradleMain.java:34)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@17.0.8.1/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@17.0.8.1/NativeMethodAccessorImpl.java:77)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.8.1/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@17.0.8.1/Method.java:568)
	at org.gradle.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:35)
	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:110)
	at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:66)
```