### PR TITLE
Don't override appmap.yml with new values when it's updated

### DIFF
--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -6,6 +6,7 @@ import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.util.ThrowableComputable;
@@ -128,13 +129,13 @@ public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4Tes
         }
     }
 
-    protected void withContentRoot(@NotNull VirtualFile contentRoot, @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
+    protected void withContentRoot(@NotNull Module module, @NotNull VirtualFile contentRoot, @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
         assertTrue(contentRoot.isDirectory());
 
         var contentEntryRef = new AtomicReference<ContentEntry>();
         try {
             // hack to use ModuleRootModificationUtil and to keep a reference to the new entry
-            ModuleRootModificationUtil.updateModel(getModule(), modifiableRootModel -> {
+            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
                 contentEntryRef.set(modifiableRootModel.addContentEntry(contentRoot));
             });
 
@@ -144,7 +145,7 @@ public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4Tes
             var newEntry = contentEntryRef.get();
             assertNotNull(newEntry);
 
-            ModuleRootModificationUtil.updateModel(getModule(), modifiableRootModel -> {
+            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
                 modifiableRootModel.removeContentEntry(newEntry);
             });
         }

--- a/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
@@ -19,7 +19,7 @@ public class AppMapSearchScopesTest extends AppMapBaseTest {
         try {
             assertFalse("scope must not contain folders, which are outside content roots", scope.contains(topLevelDir));
 
-            withContentRoot(topLevelDir, () -> {
+            withContentRoot(getModule(), topLevelDir, () -> {
                 assertTrue("scope must contain content roots", scope.contains(topLevelDir));
 
                 withExcludedFolder(topLevelDir, () -> {

--- a/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
@@ -29,7 +29,7 @@ public class ScannerFilesAsyncListenerContentRootTest extends AppMapBaseTest {
         // create src/root to add it as content root to the current module
         // the file listener is using a project scope, which needs a properly set up content root
         var rootDir = myFixture.getTempDirFixture().findOrCreateDir("root");
-        withContentRoot(rootDir, () -> {
+        withContentRoot(getModule(), rootDir, () -> {
             var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
             // adding an appmap-findings.json file must trigger a refresh via the file watcher
             myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaPackageConfig.java
@@ -60,7 +60,9 @@ public final class AppMapJavaPackageConfig {
         var existingConfig = findAppMapConfig(module.getProject(), appMapConfigSearchScope);
 
         if (existingConfig != null) {
-            var relativeOutputPath = existingConfig.getParent().toNioPath().relativize(appMapOutputDirectory);
+            var relativeOutputPath = appMapOutputDirectory.isAbsolute()
+                    ? existingConfig.getParent().toNioPath().relativize(appMapOutputDirectory)
+                    : appMapOutputDirectory;
             var configNioPath = existingConfig.toNioPath();
             updateAppMapConfig(configNioPath, relativeOutputPath);
             return configNioPath;
@@ -82,7 +84,10 @@ public final class AppMapJavaPackageConfig {
                     appMapOutputDirectory));
         }
 
-        var appMapConfig = generateAppMapConfig(module, configParentPath.relativize(appMapOutputDirectory).toString());
+        var relativeAppMapOutputPath = appMapOutputDirectory.isAbsolute()
+                ? configParentPath.relativize(appMapOutputDirectory)
+                : appMapOutputDirectory;
+        var appMapConfig = generateAppMapConfig(module, relativeAppMapOutputPath.toString());
 
         // create outside a read action, because JavaProgramPatcher is always called with a ReadAction
         // and we can't execute a WriteAction inside a read action
@@ -127,7 +132,7 @@ public final class AppMapJavaPackageConfig {
             scope = AppMapSearchScopes.appMapConfigSearchScope(module.getProject());
         }
 
-        scope = scope.intersectWith(module.getModuleScope(true));
+        scope = scope.intersectWith(module.getModuleContentScope());
         return scope;
     }
 

--- a/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigTest.java
+++ b/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigTest.java
@@ -1,12 +1,77 @@
 package appland.execution;
 
 import appland.AppMapBaseTest;
+import appland.config.AppMapConfigFile;
+import com.intellij.execution.RunManager;
+import com.intellij.execution.jar.JarApplicationConfigurationType;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
 public class AppMapJavaPackageConfigTest extends AppMapBaseTest {
+    @Override
+    protected TempDirTestFixture createTempDirTestFixture() {
+        // create temp files on disk
+        return new TempDirTestFixtureImpl();
+    }
+
     @Test
     public void systemIndependentAppMapDir() {
         var config = AppMapJavaPackageConfig.generateAppMapConfig(getModule(), "tmp\\appmap");
         assertEquals("tmp/appmap", config.getAppMapDir());
+    }
+
+    @Test
+    public void updateConfigMustNotOverrideWithRelativePath() throws Exception {
+        var contextFile = myFixture.configureByText("a.java", "").getVirtualFile();
+
+        // wrap with withContentRoot, because the scope to locate an existing appmap.yml is based on content roots
+        withContentRoot(getModule(), contextFile.getParent(), () -> assertConfigUpdate(contextFile, Path.of("tmp/appmap"), "tmp/appmap"));
+    }
+
+    @Test
+    public void updateConfigMustNotOverrideWithAbsolutePath() throws Exception {
+        var contextFile = myFixture.configureByText("a.java", "").getVirtualFile();
+
+        // wrap with withContentRoot, because the scope to locate an existing appmap.yml is based on content roots
+        var absoluteConfigPath = contextFile.toNioPath().resolveSibling("tmp/appmap").toAbsolutePath();
+        withContentRoot(getModule(), contextFile.getParent(), () -> assertConfigUpdate(contextFile, absoluteConfigPath, "tmp/appmap"));
+    }
+
+    private void assertConfigUpdate(@NotNull VirtualFile contextFile,
+                                    @NotNull Path appMapOutputDirPath,
+                                    @NotNull String expectedAppMapDir) throws IOException {
+        var runConfig = RunManager.getInstance(getProject()).createConfiguration("temp run config", JarApplicationConfigurationType.class);
+
+        var configFilePath = AppMapJavaPackageConfig.createOrUpdateAppMapConfig(getModule(),
+                runConfig.getConfiguration(),
+                contextFile,
+                appMapOutputDirPath);
+
+        var config = AppMapConfigFile.parseConfigFile(configFilePath);
+        assertNotNull(config);
+        assertEquals(expectedAppMapDir, config.getAppMapDir());
+
+        // update packages and write to file to verify update in the next step
+        config.setPackages(List.of("appmap.a", "appmap.b"));
+        config.writeTo(configFilePath);
+
+        var updatedConfigFilePath = AppMapJavaPackageConfig.createOrUpdateAppMapConfig(getModule(),
+                runConfig.getConfiguration(),
+                contextFile,
+                Path.of(appMapOutputDirPath + "-updated"));
+        assertEquals("Update must write to the same file again", configFilePath, updatedConfigFilePath);
+
+        var updatedConfig = AppMapConfigFile.parseConfigFile(configFilePath);
+        assertNotNull(updatedConfig);
+        assertEquals(expectedAppMapDir + "-updated", updatedConfig.getAppMapDir());
+        assertEquals(config.getName(), updatedConfig.getName());
+        assertEquals(config.getPackages(), updatedConfig.getPackages());
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/385

`appmap.yml` was overridden with a new configuration because the search scope to locate existing configurations did not contain all content roots of a module. 

This PR fixes the bug and adds test for relative and absolute input paths to define the appmap_dir value. The `appmap_dir` value is always output as a relative path, as before. This PR also corrects an issue with the handling of relative path values, which was discovered by the new tests.