### PR TITLE
Open AppMap toolwindow when the plugin is launched for the first time

### DIFF
--- a/plugin-core/src/main/java/appland/startup/AppLandStartupActivity.java
+++ b/plugin-core/src/main/java/appland/startup/AppLandStartupActivity.java
@@ -1,16 +1,12 @@
 package appland.startup;
 
 import appland.AppLandLifecycleService;
-import appland.installGuide.InstallGuideEditorProvider;
-import appland.installGuide.InstallGuideViewPage;
 import appland.problemsView.FindingsManager;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.telemetry.TelemetryService;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
-import com.intellij.openapi.startup.StartupManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -22,18 +18,6 @@ public class AppLandStartupActivity implements StartupActivity {
         FindingsManager.getInstance(project).reloadAsync();
 
         registerFindingsTelemetryListener(project);
-
-        // show AppMap intro at first start
-        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        if (AppMapApplicationSettingsService.getInstance().isFirstStart() && !unitTestMode) {
-            AppMapApplicationSettingsService.getInstance().setFirstStart(false);
-
-            openToolWindowAndQuickstart(project);
-
-            var telemetry = TelemetryService.getInstance();
-            telemetry.notifyTelemetryUsage(project);
-            telemetry.sendEvent("plugin:install");
-        }
     }
 
     private void registerFindingsTelemetryListener(@NotNull Project project) {
@@ -68,11 +52,5 @@ public class AppLandStartupActivity implements StartupActivity {
                         TelemetryService.getInstance().sendEvent(eventName);
                     }
                 });
-    }
-
-    static void openToolWindowAndQuickstart(@NotNull Project project) {
-        StartupManager.getInstance(project).runWhenProjectIsInitialized(() -> {
-            InstallGuideEditorProvider.open(project, InstallGuideViewPage.InstallAgent);
-        });
     }
 }

--- a/plugin-core/src/main/java/appland/startup/DynamicPluginListener.java
+++ b/plugin-core/src/main/java/appland/startup/DynamicPluginListener.java
@@ -1,6 +1,6 @@
 package appland.startup;
 
-import appland.settings.AppMapApplicationSettingsService;
+import appland.AppMapPlugin;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
@@ -18,9 +18,8 @@ public class DynamicPluginListener implements com.intellij.ide.plugins.DynamicPl
             return;
         }
 
-        if (AppMapApplicationSettingsService.getInstance().isFirstStart()) {
-            AppMapApplicationSettingsService.getInstance().setFirstStart(false);
-            AppLandStartupActivity.openToolWindowAndQuickstart(project);
+        if (AppMapPlugin.getDescriptor().equals(pluginDescriptor)) {
+            ShowAppLandToolWindowStartupActivity.handleFirstStart(project);
         }
     }
 }

--- a/plugin-core/src/main/java/appland/startup/ShowAppLandToolWindowStartupActivity.java
+++ b/plugin-core/src/main/java/appland/startup/ShowAppLandToolWindowStartupActivity.java
@@ -1,0 +1,47 @@
+package appland.startup;
+
+import appland.settings.AppMapApplicationSettingsService;
+import appland.telemetry.TelemetryService;
+import appland.toolwindow.AppMapToolWindowFactory;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.startup.StartupManager;
+import com.intellij.openapi.util.EmptyRunnable;
+import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.NotNull;
+
+public class ShowAppLandToolWindowStartupActivity implements StartupActivity.DumbAware {
+    private static void showAppMapToolWindow(@NotNull Project project) {
+        StartupManager.getInstance(project).runAfterOpened(() -> ApplicationManager.getApplication().invokeLater(() -> {
+            var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(AppMapToolWindowFactory.TOOLWINDOW_ID);
+            if (toolWindow != null && !toolWindow.isVisible()) {
+                toolWindow.activate(EmptyRunnable.getInstance(), false);
+            }
+        }, ModalityState.defaultModalityState()));
+    }
+
+    private static void sendTelemetry(@NotNull Project project) {
+        var telemetry = TelemetryService.getInstance();
+        telemetry.notifyTelemetryUsage(project);
+        telemetry.sendEvent("plugin:install");
+    }
+
+    @Override
+    public void runActivity(@NotNull Project project) {
+        handleFirstStart(project);
+    }
+
+    /**
+     * If it's the first launch of the AppLand plugin, it opens the AppMap toolwindow and sends telemetry.
+     */
+    static void handleFirstStart(@NotNull Project project) {
+        var settings = AppMapApplicationSettingsService.getInstance();
+        if (settings.isFirstStart() && !ApplicationManager.getApplication().isUnitTestMode()) {
+            settings.setFirstStart(false);
+            showAppMapToolWindow(project);
+            sendTelemetry(project);
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -24,6 +24,9 @@ import javax.swing.*;
  * state of user authentication.
  */
 public class AppMapToolWindowFactory implements ToolWindowFactory, DumbAware {
+    // must match the value in plugin.xml
+    public static final String TOOLWINDOW_ID = "applandToolWindow";
+
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
         updateToolWindowContent(project, toolWindow);

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -41,6 +41,7 @@
         <projectService serviceImplementation="appland.AppLandLifecycleService"/>
 
         <postStartupActivity implementation="appland.startup.AppLandStartupActivity"/>
+        <postStartupActivity implementation="appland.startup.ShowAppLandToolWindowStartupActivity"/>
         <postStartupActivity implementation="appland.cli.RegisterContentRootsActivity"/>
         <postStartupActivity implementation="appland.cli.DownloadToolsStartupActivity"/>
 


### PR DESCRIPTION
Closes https://github.com/getappmap/board/issues/293
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/400

This PR needs manual testing.
I manually tested this myself with PyCharm 2023.2 and IntelliJ Community 2021.2.

Previously, the "Install Guide" webview was opened at first launch. This happened even if the user was not yet signed in.

Now, the AppMap tool window is shown instead at first launch. The tool window displays the "sign in" webview.

Test instructions:
- The AppMap tool window must open when the first project is opened after the AppMap plugin was installed. It must display the "Sign in" page.
- The AppMap tool window must NOT be shown again when another project is opened or the IDE is restarted after the initial launch. You need to hide the AppMap tool window to test this because the IDE restores the last state of tool windows when a project is opened.

Screenshot after onboarding:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/35488f8a-ba80-4730-800e-16d096ac18d7)
