### PR TITLE
Handle disposed webview editor

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -252,6 +252,11 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
         new Task.Backgroundable(project, getLoadingProgressTitle(), false, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
+                if (!isValid()) {
+                    // editor was closed before the init completed
+                    return;
+                }
+
                 var initData = createInitData();
                 var initMessage = createMessageObject("init");
                 setupInitMessage(initData, initMessage);


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/412

The exception popped up while testing on Windows. Most likely, the slowness of the Windows VM made it more likely to occur.

I don't know of a way to test this. It depends on the timing of a background operation, which can't be controlled by our testing code or a tester.