### PR TITLE
Always use tmp/appmap as AppMap output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 node_modules
 bin
 plugin-core/bin
+tmp/appmap

--- a/appmap.yml
+++ b/appmap.yml
@@ -1,4 +1,4 @@
 name: intellij-appmap
 packages:
     - path: appland
-appmap_dir: build/appmap
+appmap_dir: tmp/appmap

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,8 +138,7 @@ allprojects {
             // attach AppMap agent, but only if Gradle is online
             dependsOn(":downloadAppMapAgent")
             jvmArgs("-javaagent:$agentOutputPath",
-                    "-Dappmap.config.file=${rootProject.file("appmap.yml")}",
-                    "-Dappmap.output.directory=${rootProject.buildDir.resolve("appmap")}")
+                    "-Dappmap.config.file=${rootProject.file("appmap.yml")}")
             systemProperty("appmap.test.withAgent", "true")
 
             // logging setup

--- a/plugin-gradle/src/main/java/appland/execution/AppMapExternalSystemExtension.java
+++ b/plugin-gradle/src/main/java/appland/execution/AppMapExternalSystemExtension.java
@@ -13,8 +13,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 
-import java.nio.file.Paths;
-
 public class AppMapExternalSystemExtension extends ExternalSystemRunConfigurationExtension {
     private static final Logger LOG = Logger.getInstance(AppMapExternalSystemExtension.class);
 
@@ -31,9 +29,7 @@ public class AppMapExternalSystemExtension extends ExternalSystemRunConfiguratio
         if (executor instanceof AppMapJvmExecutor) {
             var project = configuration.getProject();
             try {
-                // we know that we're executing with Gradle
-                var gradleFallbackPath = Paths.get("build", "appmap");
-                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters, gradleFallbackPath);
+                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters);
                 javaParameters.getVMParametersList().addAll(jvmParams);
             } catch (Exception e) {
                 LOG.warn("Unable to execute run configuration", e);

--- a/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaProgramPatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AbstractAppMapJavaProgramPatcher.java
@@ -26,7 +26,7 @@ public abstract class AbstractAppMapJavaProgramPatcher implements AppMapProgramP
         if (executor instanceof AppMapJvmExecutor && isSupported(configuration)) {
             var project = ((RunConfiguration) configuration).getProject();
             try {
-                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters, getRelativeOutputFallback());
+                var jvmParams = AppMapPatcherUtil.prepareJavaParameters(project, configuration, javaParameters);
                 applyJvmParameters(javaParameters, jvmParams);
             } catch (Exception e) {
                 LOG.warn("Unable to execute run configuration", e);
@@ -37,13 +37,6 @@ public abstract class AbstractAppMapJavaProgramPatcher implements AppMapProgramP
                         true);
             }
         }
-    }
-
-    /**
-     * @return A relative fallback path if the context allows to provide a better value than "tmp/appmap".
-     */
-    protected @Nullable Path getRelativeOutputFallback() {
-        return null;
     }
 
     protected void applyJvmParameters(JavaParameters javaParameters, List<String> jvmParams) {

--- a/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
@@ -18,7 +18,7 @@ public final class AppMapJvmCommandLinePatcher {
     }
 
     @NotNull
-    static List<String> createJvmParams(@Nullable Path appMapConfig, @Nullable Path appMapOutputDirectory) throws CantRunException {
+    static List<String> createJvmParams(@Nullable Path appMapConfig) throws CantRunException {
         if (appMapConfig == null) {
             throw new CantRunException("Unable to find an appmap.yml file");
         }
@@ -30,9 +30,6 @@ public final class AppMapJvmCommandLinePatcher {
 
         var jvmParams = new LinkedList<String>();
         jvmParams.add("-Dappmap.config.file=" + appMapConfig);
-        if (appMapOutputDirectory != null) {
-            jvmParams.add("-Dappmap.output.directory=" + appMapOutputDirectory);
-        }
         jvmParams.add("-javaagent:" + agentJarPath);
         return jvmParams;
     }

--- a/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
@@ -70,6 +70,6 @@ public final class AppMapPatcherUtil {
                 workingDir,
                 appMapOutputDirectory);
 
-        return AppMapJvmCommandLinePatcher.createJvmParams(config, appMapOutputDirectory);
+        return AppMapJvmCommandLinePatcher.createJvmParams(config);
     }
 }

--- a/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
+++ b/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
@@ -4,11 +4,8 @@ import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.openapi.util.text.Strings;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.execution.MavenRunConfiguration;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 public class AppMapMavenProgramPatcher extends AbstractAppMapJavaProgramPatcher {
@@ -24,10 +21,5 @@ public class AppMapMavenProgramPatcher extends AbstractAppMapJavaProgramPatcher 
         // delegate to Maven child processes via argLine. It follows the implementation of the Maven surefire plugin
         // https://github.com/apache/maven-surefire/blob/78805045bb90d7cc5692b6a388e3605d648146d2/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java#L372
         javaParameters.getVMParametersList().add("-DargLine=" + Strings.join(jvmParams, " "));
-    }
-
-    @Override
-    protected @Nullable Path getRelativeOutputFallback() {
-        return Paths.get("target", "appmap");
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/408
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/419

This updates the creation and update of appmap.yml to always set `tmp/appmap` as value of the `appmap_dir` property, regardless of the build system. Manual setup via IntelliJ project and imports or Maven or Gradle project all default to `tmp/appmap`.

It also removes the passing of `appmap.output.directory` to the agent. Only `appmap.yml` contains the output directory now.

This PR does not:
- update .gitignore or similar files
- update the "exclude folder" setting of the IDE for the new `tmp/appmap` folder


**Note**
This may only be merged after https://github.com/getappmap/appmap-java/issues/210 was published in a release of the AppMap Java  agent.