### PR TITLE
Refresh local filesystem after AppMap indexes were create or updated

### DIFF
--- a/.github/workflows/appmap-analysis.yml
+++ b/.github/workflows/appmap-analysis.yml
@@ -16,6 +16,7 @@ jobs:
             - name: Install AppMap tools
               uses: getappmap/install-action@v1
               with:
+                  tools-url: https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fappmap%40feat%2Fcustomize-report-sections/appmap-linux-x64
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   install-appmap-library: false
 
@@ -30,9 +31,10 @@ jobs:
               uses: getappmap/archive-action@main
 
             - name: Analyze AppMaps
-              uses: getappmap/analyze-action@main
+              uses: getappmap/analyze-action@feat/customize-sections
               if: github.event_name == 'pull_request'
               with:
                   base-revision: ${{ github.event.pull_request.base.sha }}
                   head-revision: ${{ github.event.pull_request.head.sha }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+                  exclude-sections: openapi-diff

--- a/plugin-core/src/main/java/appland/cli/IndexerEventUtil.java
+++ b/plugin-core/src/main/java/appland/cli/IndexerEventUtil.java
@@ -1,0 +1,36 @@
+package appland.cli;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Parses the "Indexed" messages documented at
+ * <a href="https://github.com/getappmap/appmap-js/blob/main/packages/cli/doc/index-verbose.md">index-verbose.md</a>.
+ */
+class IndexerEventUtil {
+    private IndexerEventUtil() {
+    }
+
+    static boolean isIndexedEvent(@NotNull String message) {
+        return message.startsWith("Indexed ");
+    }
+
+    static @Nullable String extractIndexedFilePath(@NotNull String message) {
+        if (!isIndexedEvent(message)) {
+            return null;
+        }
+
+        var value = message.substring("Indexed ".length()).trim();
+        return value.length() >= 3 && value.startsWith("\"") && value.endsWith("\"")
+                ? unescapeFilePath(value.substring(1, value.length() - 1))
+                : value;
+    }
+
+    private static @NotNull String unescapeFilePath(@NotNull String value) {
+        return value
+                .replace("\\\\", "\\")
+                .replace("\\n", "\n")
+                .replace("\\0", "\0")
+                .replace("\\\"", "\"");
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/IndexerEventUtilTest.java
+++ b/plugin-core/src/test/java/appland/cli/IndexerEventUtilTest.java
@@ -1,0 +1,42 @@
+package appland.cli;
+
+import appland.AppMapBaseTest;
+import org.junit.Test;
+
+import static appland.cli.IndexerEventUtil.extractIndexedFilePath;
+import static appland.cli.IndexerEventUtil.isIndexedEvent;
+
+public class IndexerEventUtilTest extends AppMapBaseTest {
+    @Test
+    public void messageType() {
+        // UNIX paths
+        assertTrue(isIndexedEvent("Indexed /home/user/project/tmp/appmap/map1.appmap.json"));
+        assertTrue(isIndexedEvent("Indexed \"/home/user/\\\"weird\\0path\\n!\\\"/tmp/appmap/map2.appmap.json\""));
+
+        // Windows paths
+        assertTrue(isIndexedEvent("Indexed C:\\Users\\Emmanuel Goldstein\\Projects\\Contoso\\tmp\\appmap\\test.appmap.json"));
+        assertTrue(isIndexedEvent("Indexed \"C:\\\\Users\\\\user\\\\\\\"Important\\\" project\\\\tmp\\\\appmap\\\\test.appmap.json\""));
+    }
+
+    @Test
+    public void validFilePaths() {
+        // unescaped paths
+        assertEquals("/home/user/project/tmp/appmap/map1.appmap.json",
+                extractIndexedFilePath("Indexed /home/user/project/tmp/appmap/map1.appmap.json"));
+        assertEquals("C:\\Users\\Emmanuel Goldstein\\Projects\\Contoso\\tmp\\appmap\\test.appmap.json",
+                extractIndexedFilePath("Indexed C:\\Users\\Emmanuel Goldstein\\Projects\\Contoso\\tmp\\appmap\\test.appmap.json"));
+
+        // escaped paths
+        assertEquals("/home/user/\"weird\0path\n!\"/tmp/appmap/map2.appmap.json",
+                extractIndexedFilePath("Indexed \"/home/user/\\\"weird\\0path\\n!\\\"/tmp/appmap/map2.appmap.json\""));
+        assertEquals("C:\\Users\\user\\\"Important\" project\\tmp\\appmap\\test.appmap.json",
+                extractIndexedFilePath("Indexed \"C:\\\\Users\\\\user\\\\\\\"Important\\\" project\\\\tmp\\\\appmap\\\\test.appmap.json\"\n"));
+    }
+
+    @Test
+    public void invalidFilePaths() {
+        assertNull(extractIndexedFilePath("\""));
+        assertNull(extractIndexedFilePath("\"\""));
+        assertNull(extractIndexedFilePath("Not an indexed message"));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/366

This PR contains tests for the parsing of `Indexed` events.

The plugin now listens to `Indexed ` events emitted by the AppMap indexer tool. 
This is used to detect new or changed AppMap indexes more reliably. The existing implementation to convince the IDE to index AppMap data is left untouched.

The process listener triggers an async refresh of the file cache and data based on it, e.g. of our file-based indexes.