### PR TITLE
Enforce https URL for error reports sent as GitHub issues

### DIFF
--- a/plugin-core/src/main/java/appland/GitHubErrorHandler.java
+++ b/plugin-core/src/main/java/appland/GitHubErrorHandler.java
@@ -55,7 +55,7 @@ public class GitHubErrorHandler extends ErrorReportSubmitter {
         params.put("labels", "user report");
         params.put("body", body);
 
-        var url = Urls.newHttpUrl(HOST, URL_PATH);
+        var url = Urls.newUrl("https", HOST, URL_PATH);
         url = url.addParameters(params);
 
         BrowserUtil.browse(url.toExternalForm());


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/423

This PR enforces a https connection to send error reports to the GitHub issue page. Thanks to @augustd for pointing this out.

I've manually tested this.
It would be possible to write a test with a local mock server, but that would take some time, esp. with the enforced https connection.
It's not possible to let external testers test it because they would have to trigger an exception in the plugin's code.