### PR TITLE
Notifiy user about first AppMap

### DIFF
--- a/plugin-core/src/main/java/appland/files/AppMapFileChangeListener.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFileChangeListener.java
@@ -2,6 +2,7 @@ package appland.files;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
@@ -24,5 +25,5 @@ public interface AppMapFileChangeListener {
      * Sent after any refresh of the local file system
      * and after changes to .appmap.json files (e.g. created, updated, deleted, renamed).
      */
-    void refreshAppMaps(Set<AppMapFileEventType> changeTypes);
+    void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes);
 }

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -14,10 +14,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.util.function.Consumer;
 
 import static appland.AppMapBundle.lazy;
-
-import java.util.function.Consumer;
 
 public final class AppMapNotifications {
     public static final String REMOTE_RECORDING_ID = "appmap.remoteRecording";
@@ -93,16 +92,16 @@ public final class AppMapNotifications {
     }
 
     public static void showTelemetryNotification(@NotNull Project project,
-    @Nullable String title,
-    @NotNull String content,
-    @NotNull NotificationType type,
-    @NotNull Consumer<Boolean> onDismiss) {
+                                                 @Nullable String title,
+                                                 @NotNull String content,
+                                                 @NotNull NotificationType type,
+                                                 @NotNull Consumer<Boolean> onDismiss) {
         ApplicationManager.getApplication().invokeLater(() -> {
             Notification notification = new AppMapFullContentNotification(
-                        TELEMETRY_ID, null,
-                        title, null, content,
-                        type, null
-                );
+                    TELEMETRY_ID, null,
+                    title, null, content,
+                    type, null
+            );
 
             var denyAction = NotificationAction.create(lazy("telemetry.permission.deny"), (e, n) -> {
                 onDismiss.accept(false);

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -1,7 +1,13 @@
 package appland.notifications;
 
+import appland.AppMapBundle;
 import appland.AppMapPlugin;
 import appland.actions.StopAppMapRecordingAction;
+import appland.installGuide.InstallGuideEditorProvider;
+import appland.installGuide.InstallGuideViewPage;
+import appland.startup.FirstAppMapLaunchStartupActivity;
+import appland.toolwindow.AppMapToolWindowFactory;
+import appland.webviews.findings.FindingsOverviewEditorProvider;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
@@ -9,7 +15,10 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.ui.EdtInvocationManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -109,6 +118,27 @@ public final class AppMapNotifications {
             });
 
             notification = notification.addAction(denyAction);
+            notification.notify(project);
+        });
+    }
+
+    public static void showFirstAppMapNotification(@NotNull Project project, @NotNull VirtualFile appMap) {
+        EdtInvocationManager.invokeLaterIfNeeded(() -> {
+            var content = AppMapBundle.get("notification.firstAppMap.content");
+
+            Notification notification = new AppMapFullContentNotification(
+                    GENERIC_NOTIFICATIONS_ID, null,
+                    null, null, content,
+                    NotificationType.INFORMATION, null
+            );
+
+            var openAction = NotificationAction.create(lazy("notification.firstAppMap.openAction"), (e, n) -> {
+                InstallGuideEditorProvider.open(project, InstallGuideViewPage.OpenAppMaps);
+                FirstAppMapLaunchStartupActivity.showAppMapToolWindow(project);
+                n.expire();
+            });
+
+            notification = notification.addAction(openAction);
             notification.notify(project);
         });
     }

--- a/plugin-core/src/main/java/appland/notifications/FirstAppMapListener.java
+++ b/plugin-core/src/main/java/appland/notifications/FirstAppMapListener.java
@@ -1,0 +1,72 @@
+package appland.notifications;
+
+import appland.files.AppMapFileChangeListener;
+import appland.files.AppMapFileEventType;
+import appland.index.AppMapSearchScopes;
+import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import com.intellij.util.ui.EdtInvocationManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+/**
+ * Displays a notification after the user created the first AppMap ever.
+ * The notification is only displayed once for an IDE installation, i.e. it's an application setting.
+ */
+public class FirstAppMapListener implements AppMapFileChangeListener {
+    private final @NotNull Project project;
+
+    public FirstAppMapListener(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes) {
+        if (!changeTypes.contains(AppMapFileEventType.Create)) {
+            return;
+        }
+
+        if (AppMapApplicationSettingsService.getInstance().isShowFirstAppMapNotification()) {
+            EdtInvocationManager.invokeLaterIfNeeded(() -> {
+                DumbService.getInstance(project).runReadActionInSmartMode(this::showFirstAppMapNotification);
+            });
+        }
+    }
+
+    /**
+     * Executed in a read action in smart mode.
+     */
+    @RequiresReadLock
+    private void showFirstAppMapNotification() {
+        if (project.isDisposed()) {
+            return;
+        }
+
+        var settings = AppMapApplicationSettingsService.getInstance();
+        if (settings.isShowFirstAppMapNotification()) {
+            var chosenAppMap = chooseSuitableAppmap();
+            if (chosenAppMap != null) {
+                settings.setShowFirstAppMapNotification(false);
+                AppMapNotifications.showFirstAppMapNotification(project, chosenAppMap);
+            }
+        }
+    }
+
+    /**
+     * Choose a suitable AppMap. It must not use an AppMap index, because AppMaps indexing may be in progress.
+     *
+     * @return AppMap to open from the notification
+     */
+    @RequiresReadLock
+    private @Nullable VirtualFile chooseSuitableAppmap() {
+        var searchScope = AppMapSearchScopes.appMapsWithExcluded(project);
+        var files = FilenameIndex.getAllFilesByExt(project, "appmap.json", searchScope);
+        return files.isEmpty() ? null : files.stream().findFirst().orElse(null);
+    }
+}

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -14,20 +14,19 @@ import java.util.Objects;
  * Persistent application state of the AppMap plugin.
  */
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
 public class AppMapApplicationSettings {
-    @Setter
     private volatile boolean appmapInstructionsViewed = false;
-
-    @Setter
     private volatile boolean firstStart = true;
-
-    @Setter
     private volatile boolean enableTelemetry = true;
-
-    @Setter
     private volatile @Nullable String apiKey = null;
+    /**
+     * {@code true} if the notification should be displayed the next time an AppMap is created.
+     * This flag is synced with {@link  #firstStart} to avoid the notification with existing users.
+     */
+    private volatile boolean showFirstAppMapNotification = false;
 
     public AppMapApplicationSettings() {
     }
@@ -37,6 +36,7 @@ public class AppMapApplicationSettings {
         this.firstStart = settings.firstStart;
         this.enableTelemetry = settings.enableTelemetry;
         this.apiKey = settings.apiKey;
+        this.showFirstAppMapNotification = settings.showFirstAppMapNotification;
     }
 
     public void setApiKeyNotifying(@Nullable String apiKey) {

--- a/plugin-core/src/main/java/appland/startup/DynamicPluginListener.java
+++ b/plugin-core/src/main/java/appland/startup/DynamicPluginListener.java
@@ -19,7 +19,7 @@ public class DynamicPluginListener implements com.intellij.ide.plugins.DynamicPl
         }
 
         if (AppMapPlugin.getDescriptor().equals(pluginDescriptor)) {
-            ShowAppLandToolWindowStartupActivity.handleFirstStart(project);
+            FirstAppMapLaunchStartupActivity.handleFirstStart(project);
         }
     }
 }

--- a/plugin-core/src/main/java/appland/startup/FirstAppMapLaunchStartupActivity.java
+++ b/plugin-core/src/main/java/appland/startup/FirstAppMapLaunchStartupActivity.java
@@ -12,8 +12,8 @@ import com.intellij.openapi.util.EmptyRunnable;
 import com.intellij.openapi.wm.ToolWindowManager;
 import org.jetbrains.annotations.NotNull;
 
-public class ShowAppLandToolWindowStartupActivity implements StartupActivity.DumbAware {
-    private static void showAppMapToolWindow(@NotNull Project project) {
+public class FirstAppMapLaunchStartupActivity implements StartupActivity.DumbAware {
+    public static void showAppMapToolWindow(@NotNull Project project) {
         StartupManager.getInstance(project).runAfterOpened(() -> ApplicationManager.getApplication().invokeLater(() -> {
             var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(AppMapToolWindowFactory.TOOLWINDOW_ID);
             if (toolWindow != null && !toolWindow.isVisible()) {
@@ -37,9 +37,17 @@ public class ShowAppLandToolWindowStartupActivity implements StartupActivity.Dum
      * If it's the first launch of the AppLand plugin, it opens the AppMap toolwindow and sends telemetry.
      */
     static void handleFirstStart(@NotNull Project project) {
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            return;
+        }
+
         var settings = AppMapApplicationSettingsService.getInstance();
-        if (settings.isFirstStart() && !ApplicationManager.getApplication().isUnitTestMode()) {
+        if (settings.isFirstStart()) {
             settings.setFirstStart(false);
+
+            // set to false at first startup to enable the notification
+            settings.setShowFirstAppMapNotification(true);
+
             showAppMapToolWindow(project);
             sendTelemetry(project);
         }

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -33,6 +33,9 @@
 
         <listener topic="com.intellij.execution.ExecutionListener"
                   class="appland.execution.AppMapExecutionListener"/>
+
+        <listener topic="appland.files.AppMapFileChangeListener"
+                  class="appland.notifications.FirstAppMapListener"/>
     </projectListeners>
 
     <extensions defaultExtensionNs="com.intellij">
@@ -41,7 +44,7 @@
         <projectService serviceImplementation="appland.AppLandLifecycleService"/>
 
         <postStartupActivity implementation="appland.startup.AppLandStartupActivity"/>
-        <postStartupActivity implementation="appland.startup.ShowAppLandToolWindowStartupActivity"/>
+        <postStartupActivity implementation="appland.startup.FirstAppMapLaunchStartupActivity"/>
         <postStartupActivity implementation="appland.cli.RegisterContentRootsActivity"/>
         <postStartupActivity implementation="appland.cli.DownloadToolsStartupActivity"/>
 

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -105,6 +105,9 @@ notification.groupGeneric.title=AppMap notifications
 notification.appMapFileNotFound.title=AppMap
 notification.appMapFileNotFound.message=Unfortunately, the AppMap file could not be found.
 
+notification.firstAppMap.content=You've created your first AppMap! Congratulations.
+notification.firstAppMap.openAction=Open your new AppMap
+
 statusBar.recording.displayName=AppMap Recording
 statusBar.recording.recordingStatus=Recording...
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/432

Displays a notification when the first AppMap was created.

- It does not check if the user is signed in
- The notification is NOT shown for existing users (`isFirstStart == false`) 
- It displays the "Explore AppMaps" page when the user clicks on the link in the notification
- The notification is only displayed when a new AppMap file is created while the matching project is opened with the AppMap plugin. If a project already contains AppMap files at first startup, then no notification is displayed for these AppMaps.

Possible changes:
- We could display a title and AppMap icon for the notification. Currently, only the message content is shown.