### PR TITLE
Properly unescape indexer file paths

### DIFF
--- a/plugin-core/src/main/java/appland/cli/IndexerEventUtil.java
+++ b/plugin-core/src/main/java/appland/cli/IndexerEventUtil.java
@@ -27,10 +27,36 @@ class IndexerEventUtil {
     }
 
     private static @NotNull String unescapeFilePath(@NotNull String value) {
-        return value
-                .replace("\\\\", "\\")
-                .replace("\\n", "\n")
-                .replace("\\0", "\0")
-                .replace("\\\"", "\"");
+        var result = new StringBuilder(value.length());
+        var escaped = false;
+        for (var i = 0; i < value.length(); i++) {
+            var c = value.charAt(i);
+
+            if (!escaped) {
+                if (c == '\\') {
+                    escaped = true;
+                } else {
+                    result.append(c);
+                }
+            } else {
+                switch (c) {
+                    case '\\':
+                        result.append('\\');
+                        break;
+                    case 'n':
+                        result.append('\n');
+                        break;
+                    case '0':
+                        result.append('\0');
+                        break;
+                    case '"':
+                        result.append('"');
+                        break;
+                }
+
+                escaped = false;
+            }
+        }
+        return result.toString();
     }
 }

--- a/plugin-core/src/test/java/appland/cli/IndexerEventUtilTest.java
+++ b/plugin-core/src/test/java/appland/cli/IndexerEventUtilTest.java
@@ -39,4 +39,16 @@ public class IndexerEventUtilTest extends AppMapBaseTest {
         assertNull(extractIndexedFilePath("\"\""));
         assertNull(extractIndexedFilePath("Not an indexed message"));
     }
+
+    @Test
+    public void unescapeOrder() {
+        // newline
+        assertEquals("\n", extractIndexedFilePath("Indexed \"\\n\""));
+        // backslash
+        assertEquals("\\", extractIndexedFilePath("Indexed \"\\\\\""));
+        // backslash, 'n'
+        assertEquals("\\n", extractIndexedFilePath("Indexed \"\\\\n\""));
+        // 'a', newline, backslash, 'n'
+        assertEquals("a\n\\n.txt", extractIndexedFilePath("Indexed \"a\\n\\\\n.txt\""));
+    }
 }


### PR DESCRIPTION
Resolves the issue reported at https://github.com/getappmap/appmap-intellij-plugin/pull/417#pullrequestreview-1632257758

Multiple rounds of replacements create ambiguities, we're now iterating the string only once and remember if the last char was escaped or not.

