### PR TITLE
Display AppMap hierarchy

### DIFF
--- a/plugin-core/src/main/java/appland/index/AppMapMetadata.java
+++ b/plugin-core/src/main/java/appland/index/AppMapMetadata.java
@@ -21,6 +21,9 @@ public final class AppMapMetadata {
      */
     private final @NotNull String name;
     private final @Nullable TestStatus testStatus;
+    private final @Nullable String languageName;
+    private final @Nullable String recorderType;
+    private final @Nullable String recorderName;
     private final int requestCount;
     private final int queryCount;
     private final int functionsCount;
@@ -28,16 +31,23 @@ public final class AppMapMetadata {
 
     @TestOnly
     public AppMapMetadata(@NotNull String name, @Nullable VirtualFile appMapFile) {
-        this(name, appMapFile, null, 0, 0, 0);
+        this(name, appMapFile, null, null, null, null, 0, 0, 0);
     }
 
     public AppMapMetadata(@NotNull String name,
                           @Nullable VirtualFile appMapFile,
-                          @Nullable TestStatus testStatus, int requestCount,
+                          @Nullable TestStatus testStatus,
+                          @Nullable String languageName,
+                          @Nullable String recorderType,
+                          @Nullable String recorderName,
+                          int requestCount,
                           int queryCount,
                           int functionsCount) {
         this.name = name;
         this.appMapFile = appMapFile;
+        this.languageName = languageName;
+        this.recorderType = recorderType;
+        this.recorderName = recorderName;
         this.requestCount = requestCount;
         this.queryCount = queryCount;
         this.functionsCount = functionsCount;

--- a/plugin-core/src/main/java/appland/index/AppMapMetadataService.java
+++ b/plugin-core/src/main/java/appland/index/AppMapMetadataService.java
@@ -63,7 +63,12 @@ public class AppMapMetadataService {
             var data = AppMapNameIndex.getBasicMetadata(project, directory);
             if (data != null && data.getName() != null) {
                 if (lowercaseNameFilter == null || data.getName().toLowerCase().contains(lowercaseNameFilter)) {
-                    result.add(createMetadataWithIndex(directory, data.getName(), data.testStatus));
+                    result.add(createMetadataWithIndex(directory,
+                            data.getName(),
+                            data.testStatus,
+                            data.languageName, data.recorderType,
+                            data.recorderName
+                    ));
                 }
             }
             if (result.size() >= maxSize) {
@@ -93,17 +98,33 @@ public class AppMapMetadataService {
             return null;
         }
 
-        return createMetadataWithIndex(appMapMetadataDirectory, name, data.testStatus);
+        return createMetadataWithIndex(appMapMetadataDirectory,
+                name,
+                data.testStatus,
+                data.languageName,
+                data.recorderType,
+                data.recorderName
+        );
     }
 
     private @NotNull AppMapMetadata createMetadataWithIndex(@NotNull VirtualFile directory,
                                                             @NotNull String name,
-                                                            @Nullable TestStatus testStatus) {
+                                                            @Nullable TestStatus testStatus,
+                                                            @Nullable String languageName, @Nullable String recorderType,
+                                                            @Nullable String recorderName) {
         var appMapFile = AppMapFiles.findAppMapByMetadataDirectory(directory);
         var requestCount = AppMapServerRequestCountIndex.getRequestCount(project, directory);
         var queryCount = AppMapSqlQueriesCountIndex.getQueryCount(project, directory);
         var functionsCount = ClassMapTypeIndex.findItemsByAppMapDirectory(project, directory, ClassMapItemType.Function).size();
 
-        return new AppMapMetadata(name, appMapFile, testStatus, requestCount, queryCount, functionsCount);
+        return new AppMapMetadata(name,
+                appMapFile,
+                testStatus,
+                languageName,
+                recorderType,
+                recorderName,
+                requestCount,
+                queryCount,
+                functionsCount);
     }
 }

--- a/plugin-core/src/main/java/appland/index/AppMapNameIndex.java
+++ b/plugin-core/src/main/java/appland/index/AppMapNameIndex.java
@@ -102,7 +102,10 @@ public class AppMapNameIndex extends AbstractAppMapMetadataFileIndex<BasicAppMap
         if (!fileContent.isEmpty()) {
             var json = GsonUtils.GSON.fromJson(fileContent, MetadataFileContent.class);
             if (json != null) {
-                return new BasicAppMapMetadata(json.name, json.testStatus);
+                var languageName = json.language != null ? json.language.name : null;
+                var recorderType = json.recorder != null ? json.recorder.type : null;
+                var recorderName = json.recorder != null ? json.recorder.name : null;
+                return new BasicAppMapMetadata(json.name, json.testStatus, recorderType, recorderName, languageName);
             }
         }
         return null;
@@ -113,11 +116,29 @@ public class AppMapNameIndex extends AbstractAppMapMetadataFileIndex<BasicAppMap
         return BasicAppMapMetadataExternalizer.INSTANCE;
     }
 
+    private static class MetadataRecorder {
+        @SerializedName("type")
+        public String type;
+        @SerializedName("name")
+        public String name;
+    }
+
+    private static class MetadataLanguage {
+        @SerializedName("name")
+        public String name;
+    }
+
     private static class MetadataFileContent {
         @SerializedName("name")
         public String name;
 
+        @SerializedName("language")
+        public @Nullable MetadataLanguage language = null;
+
         @SerializedName("test_status")
         public @Nullable TestStatus testStatus = null;
+
+        @SerializedName("recorder")
+        public @Nullable MetadataRecorder recorder = null;
     }
 }

--- a/plugin-core/src/main/java/appland/index/BasicAppMapMetadata.java
+++ b/plugin-core/src/main/java/appland/index/BasicAppMapMetadata.java
@@ -15,4 +15,7 @@ import org.jetbrains.annotations.Nullable;
 public class BasicAppMapMetadata {
     @Nullable String name = null;
     @Nullable TestStatus testStatus = null;
+    @Nullable String recorderType = null;
+    @Nullable String recorderName = null;
+    @Nullable String languageName = null;
 }

--- a/plugin-core/src/main/java/appland/index/BasicAppMapMetadataExternalizer.java
+++ b/plugin-core/src/main/java/appland/index/BasicAppMapMetadataExternalizer.java
@@ -2,12 +2,14 @@ package appland.index;
 
 import appland.problemsView.model.TestStatus;
 import com.intellij.util.io.DataExternalizer;
-import com.intellij.util.io.IOUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+
+import static appland.index.IndexUtil.readOptionalString;
+import static appland.index.IndexUtil.writeOptionalString;
 
 class BasicAppMapMetadataExternalizer implements DataExternalizer<BasicAppMapMetadata> {
     static final @NotNull BasicAppMapMetadataExternalizer INSTANCE = new BasicAppMapMetadataExternalizer();
@@ -17,29 +19,24 @@ class BasicAppMapMetadataExternalizer implements DataExternalizer<BasicAppMapMet
 
     @Override
     public BasicAppMapMetadata read(@NotNull DataInput in) throws IOException {
-        var hasName = in.readBoolean();
-        var name = hasName ? IOUtil.readUTF(in) : null;
+        var name = readOptionalString(in);
 
-        var hasTestStatus = in.readBoolean();
-        TestStatus testStatus = null;
-        if (hasTestStatus) {
-            var jsonId = IOUtil.readUTF(in);
-            testStatus = TestStatus.byJsonId(jsonId);
-        }
+        var testStatusValue = readOptionalString(in);
+        var testStatus = testStatusValue != null ? TestStatus.byJsonId(testStatusValue) : null;
 
-        return new BasicAppMapMetadata(name, testStatus);
+        var recorderType = readOptionalString(in);
+        var recorderName = readOptionalString(in);
+        var languageName = readOptionalString(in);
+
+        return new BasicAppMapMetadata(name, testStatus, recorderType, recorderName, languageName);
     }
 
     @Override
     public void save(@NotNull DataOutput out, @NotNull BasicAppMapMetadata value) throws IOException {
-        out.writeBoolean(value.name != null);
-        if (value.name != null) {
-            IOUtil.writeUTF(out, value.name);
-        }
-
-        out.writeBoolean(value.testStatus != null);
-        if (value.testStatus != null) {
-            IOUtil.writeUTF(out, value.testStatus.getJsonId());
-        }
+        writeOptionalString(out, value.name);
+        writeOptionalString(out, value.testStatus != null ? value.testStatus.getJsonId() : null);
+        writeOptionalString(out, value.recorderType);
+        writeOptionalString(out, value.recorderName);
+        writeOptionalString(out, value.languageName);
     }
 }

--- a/plugin-core/src/main/java/appland/index/IndexUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexUtil.java
@@ -12,9 +12,13 @@ import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.intellij.util.indexing.FileBasedIndexExtension;
 import com.intellij.util.indexing.ID;
+import com.intellij.util.io.IOUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -22,10 +26,22 @@ import java.util.stream.Collectors;
 
 final class IndexUtil {
     // base version for our indexes, increase when the data structures or the parsing logic change
-    static final int BASE_VERSION = 62;
+    static final int BASE_VERSION = 64;
 
     // filenames covered by our own indexes
     static final Set<String> indexedFilenames = Collections.unmodifiableSet(findIndexedFilenames());
+
+    static void writeOptionalString(@NotNull DataOutput out, @Nullable String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            IOUtil.writeUTF(out, value);
+        }
+    }
+
+    static @Nullable String readOptionalString(@NotNull DataInput in) throws IOException {
+        var available = in.readBoolean();
+        return available ? IOUtil.readUTF(in) : null;
+    }
 
     /**
      * @param project Current project

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -2,6 +2,7 @@ package appland.toolwindow;
 
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
+import appland.toolwindow.appmap.AppMapWindowPanel;
 import appland.toolwindow.signInView.SignInViewPanel;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapModel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapModel.java
@@ -1,4 +1,4 @@
-package appland.toolwindow;
+package appland.toolwindow.appmap;
 
 import appland.Icons;
 import appland.index.AppMapMetadata;

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
@@ -1,4 +1,4 @@
-package appland.toolwindow;
+package appland.toolwindow.appmap;
 
 import appland.AppMapBundle;
 import appland.actions.StartAppMapRecordingAction;
@@ -7,6 +7,9 @@ import appland.index.AppMapMetadata;
 import appland.index.IndexedFileListenerUtil;
 import appland.installGuide.InstallGuideEditorProvider;
 import appland.installGuide.InstallGuideViewPage;
+import appland.toolwindow.AppMapContentPanel;
+import appland.toolwindow.AppMapToolWindowContent;
+import appland.toolwindow.CollapsiblePanel;
 import appland.toolwindow.codeObjects.CodeObjectsPanel;
 import appland.toolwindow.installGuide.InstallGuidePanel;
 import appland.toolwindow.installGuide.UrlLabel;
@@ -283,7 +286,7 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
         panelWithFilter.add(createToolBar(appMapModel), BorderLayout.NORTH);
         panelWithFilter.add(appMapListPanel, BorderLayout.CENTER);
 
-        return new CollapsiblePanel(project,
+        return new appland.toolwindow.CollapsiblePanel(project,
                 AppMapBundle.get("toolwindow.appmap.appMaps"),
                 "appmap.toolWindow.appMaps.collapsed",
                 true,
@@ -300,7 +303,7 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
 
     @NotNull
     private static JPanel createInstallGuidePanel(@NotNull Project project, @NotNull Disposable parent) {
-        return new CollapsiblePanel(project,
+        return new appland.toolwindow.CollapsiblePanel(project,
                 AppMapBundle.get("toolwindow.appmap.instructions"),
                 "appmap.toolWindow.installGuide.collapsed",
                 false,
@@ -311,7 +314,7 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
     private static JPanel createRuntimeAnalysisPanel(@NotNull Project project, @NotNull Disposable parent) {
         var runtimeAnalysisPanel = new RuntimeAnalysisPanel(project, parent);
         runtimeAnalysisPanel.setMinimumSize(new JBDimension(0, 100));
-        return new CollapsiblePanel(project,
+        return new appland.toolwindow.CollapsiblePanel(project,
                 AppMapBundle.get("toolwindow.appmap.runtimeAnalysis"),
                 "appmap.toolWindow.runtimeAnalysis.collapsed",
                 true,
@@ -322,7 +325,7 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
     private static JPanel createCodeObjectsPanel(@NotNull Project project, @NotNull Disposable parentDisposable) {
         var codeObjectsPanel = new CodeObjectsPanel(project, parentDisposable);
         codeObjectsPanel.setMinimumSize(new JBDimension(0, 100));
-        return new CollapsiblePanel(project,
+        return new appland.toolwindow.CollapsiblePanel(project,
                 AppMapBundle.get("toolwindow.appmap.codeObjects"),
                 "appmap.toolWindow.codeObjects.collapsed",
                 true,

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/AppMapGroupNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/AppMapGroupNode.java
@@ -1,0 +1,46 @@
+package appland.toolwindow.appmap.nodes;
+
+import appland.index.AppMapMetadata;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.tree.LeafState;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class AppMapGroupNode extends Node {
+    private final String groupName;
+    private final List<AppMapMetadata> appMaps;
+
+    AppMapGroupNode(@NotNull Project project,
+                    @NotNull NodeDescriptor parentDescriptor,
+                    @NotNull String groupName,
+                    @NotNull List<AppMapMetadata> appMaps) {
+        super(project, parentDescriptor);
+        this.groupName = groupName;
+        this.appMaps = appMaps;
+    }
+
+    @Override
+    public @NotNull LeafState getLeafState() {
+        return LeafState.NEVER;
+    }
+
+    @Override
+    protected void update(@NotNull PresentationData presentation) {
+        presentation.setPresentableText(groupName);
+        presentation.setIcon(AllIcons.Nodes.Folder);
+    }
+
+    @Override
+    public List<? extends Node> getChildren() {
+        return appMaps.stream()
+                .sorted(Comparator.comparing(AppMapMetadata::getName))
+                .map(appMap -> new AppMapNode(myProject, this, appMap))
+                .collect(Collectors.toList());
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/AppMapNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/AppMapNode.java
@@ -1,0 +1,44 @@
+package appland.toolwindow.appmap.nodes;
+
+import appland.Icons;
+import appland.index.AppMapMetadata;
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.tree.LeafState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+class AppMapNode extends Node {
+    private final AppMapMetadata appMap;
+
+    AppMapNode(@NotNull Project project, @Nullable NodeDescriptor parentDescriptor, @NotNull AppMapMetadata appMap) {
+        super(project, parentDescriptor);
+        this.appMap = appMap;
+    }
+
+    @Override
+    public @NotNull LeafState getLeafState() {
+        return LeafState.ALWAYS;
+    }
+
+    @Override
+    public List<? extends Node> getChildren() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @Nullable VirtualFile getFile() {
+        return appMap.getAppMapFile();
+    }
+
+    @Override
+    protected void update(@NotNull PresentationData presentation) {
+        presentation.setPresentableText(appMap.getName());
+        presentation.setIcon(Icons.APPMAP_FILE_SMALL);
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/Node.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/Node.java
@@ -1,0 +1,34 @@
+package appland.toolwindow.appmap.nodes;
+
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.intellij.ide.util.treeView.PresentableNodeDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.tree.LeafState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public abstract class Node extends PresentableNodeDescriptor<Node> implements LeafState.Supplier {
+    public Node(@NotNull Project project, @Nullable NodeDescriptor parentDescriptor) {
+        super(project, parentDescriptor);
+    }
+
+    @Override
+    public Node getElement() {
+        return this;
+    }
+
+    /**
+     * @return List of child nodes or an empty collection for leaf nodes.
+     */
+    public abstract List<? extends Node> getChildren();
+
+    /**
+     * @return {@link VirtualFile} associated with this node. {@code null} if it's a node without a file.
+     */
+    public @Nullable VirtualFile getFile() {
+        return null;
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/ProjectNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/ProjectNode.java
@@ -1,0 +1,63 @@
+package appland.toolwindow.appmap.nodes;
+
+import appland.index.AppMapMetadata;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.ui.tree.LeafState;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class ProjectNode extends Node {
+    private final String projectName;
+    private final List<AppMapMetadata> appMaps;
+
+    public ProjectNode(@NotNull Project project,
+                       @NotNull Node parentNode,
+                       @NotNull String projectName,
+                       @NotNull List<AppMapMetadata> appMaps) {
+        super(project, parentNode);
+        this.projectName = projectName;
+        this.appMaps = appMaps;
+    }
+
+    @Override
+    public @NotNull LeafState getLeafState() {
+        return LeafState.NEVER;
+    }
+
+    @Override
+    protected void update(@NotNull PresentationData presentation) {
+        presentation.setPresentableText(projectName);
+        presentation.setIcon(AllIcons.Nodes.Module);
+    }
+
+    @Override
+    public List<? extends Node> getChildren() {
+        var byGroupName = appMaps.stream().collect(Collectors.groupingBy(this::getAppMapGroupName));
+        return byGroupName.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new AppMapGroupNode(myProject, this, entry.getKey(), entry.getValue()))
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    private @NotNull String getAppMapGroupName(@NotNull AppMapMetadata appMap) {
+        var languageName = appMap.getLanguageName();
+        var recorderType = appMap.getRecorderType();
+        var recorderName = appMap.getRecorderName();
+
+        if (languageName == null || recorderType == null || recorderName == null) {
+            // fallback to AppMap name
+            return appMap.getName();
+        }
+
+        var capitalizedType = StringUtil.capitalize(recorderType);
+        return String.format("%s (%s + %s)", capitalizedType, languageName, recorderName);
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/RootNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/RootNode.java
@@ -1,0 +1,80 @@
+package appland.toolwindow.appmap.nodes;
+
+import appland.index.AppMapMetadata;
+import appland.index.AppMapMetadataService;
+import appland.toolwindow.appmap.AppMapModel;
+import appland.utils.AppMapProjectUtil;
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.tree.LeafState;
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+public class RootNode extends Node {
+    private final @NotNull AppMapModel model;
+    private final AtomicBoolean needAppMapRefresh = new AtomicBoolean(true);
+    private final AtomicReference<List<AppMapMetadata>> cachedAppMaps = new AtomicReference<>();
+
+    public RootNode(@NotNull Project project, @NotNull AppMapModel model) {
+        super(project, null);
+        this.model = model;
+    }
+
+    @Override
+    public @NotNull LeafState getLeafState() {
+        return LeafState.NEVER;
+    }
+
+    @Override
+    protected void update(@NotNull PresentationData presentation) {
+        // the root node isn't visible
+        presentation.setPresentableText("AppMaps");
+    }
+
+    public void queueAppMapRefresh() {
+        needAppMapRefresh.set(true);
+    }
+
+    @Override
+    public List<? extends Node> getChildren() {
+        var byProjectName = ReadAction.compute(() -> {
+            return getCachedAppMaps().stream()
+                    .filter(appMap -> appMap.getAppMapFile() != null)
+                    .collect(Collectors.groupingBy(this::getAppMapProjectName));
+        });
+
+        return byProjectName.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> (Node) new ProjectNode(myProject, this, entry.getKey(), entry.getValue()))
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    private @NotNull String getAppMapProjectName(@NotNull AppMapMetadata appMapMetadata) {
+        assert appMapMetadata.getAppMapFile() != null;
+        return AppMapProjectUtil.getAppMapProjectName(myProject, appMapMetadata.getAppMapFile());
+    }
+
+    @RequiresBackgroundThread
+    private List<AppMapMetadata> getCachedAppMaps() {
+        if (needAppMapRefresh.compareAndSet(true, false)) {
+            cachedAppMaps.set(loadAppMaps());
+        }
+        return cachedAppMaps.get();
+    }
+
+    private List<AppMapMetadata> loadAppMaps() {
+        return DumbService.getInstance(myProject).runReadActionInSmartMode(() -> {
+            return AppMapMetadataService.getInstance(myProject).findAppMaps(model.getNameFilter());
+        });
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/RootNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/RootNode.java
@@ -1,10 +1,10 @@
 package appland.toolwindow.runtimeAnalysis.nodes;
 
-import appland.files.AppMapFiles;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.listener.ScannerFindingsListener;
 import appland.problemsView.model.ScannerFinding;
 import appland.toolwindow.runtimeAnalysis.RuntimeAnalysisModel;
+import appland.utils.AppMapProjectUtil;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ReadAction;
@@ -64,14 +64,7 @@ public final class RootNode extends Node implements Disposable {
     }
 
     private @NotNull String getAppMapProjectName(@NotNull ScannerFinding finding) {
-        return ReadAction.compute(() -> {
-            var root = finding.getFindingsFile() != null
-                    ? AppMapFiles.findTopLevelContentRoot(myProject, finding.getFindingsFile())
-                    : null;
-            return root != null
-                    ? root.getName()
-                    : "- unknown -";
-        });
+        return ReadAction.compute(() -> AppMapProjectUtil.getAppMapProjectName(myProject, finding.getFindingsFile()));
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/utils/AppMapProjectUtil.java
+++ b/plugin-core/src/main/java/appland/utils/AppMapProjectUtil.java
@@ -1,0 +1,26 @@
+package appland.utils;
+
+import appland.files.AppMapFiles;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class AppMapProjectUtil {
+    private AppMapProjectUtil() {
+    }
+
+    @RequiresReadLock
+    public static @NotNull String getAppMapProjectName(@NotNull Project project, @Nullable VirtualFile contentFile) {
+        ApplicationManager.getApplication().assertReadAccessAllowed();
+
+        var root = contentFile != null
+                ? AppMapFiles.findTopLevelContentRoot(project, contentFile)
+                : null;
+        return root != null
+                ? root.getName()
+                : "- unknown -";
+    }
+}

--- a/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
@@ -1,0 +1,83 @@
+package appland.toolwindow.appmap;
+
+import appland.AppMapBaseTest;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.junit.Test;
+
+import static appland.utils.ModelTestUtil.assertTreeHierarchy;
+
+public class AppMapModelTest extends AppMapBaseTest {
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
+    @Override
+    protected TempDirTestFixture createTempDirTestFixture() {
+        // create temp files on disk
+        return new TempDirTestFixtureImpl();
+    }
+
+    @Test
+    public void emptyAppMaps() {
+        var model = new AppMapModel(getProject());
+        var expected = "-AppMaps\n";
+        assertTreeHierarchy(model, expected, getTestRootDisposable());
+    }
+
+    @Test
+    public void hierarchyOneAppMapProject() throws Exception {
+        // copy into parent dir, because the default location is "src/", which already is a content root
+        var rootOne = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_one"));
+
+        withContentRoot(getModule(), rootOne, () -> {
+            var model = new AppMapModel(getProject());
+            var expected = "-AppMaps\n" +
+                    " -root_one\n" +
+                    "  -Tests (ruby + minitest)\n" +
+                    "   Failed test 1\n" +
+                    "   Failed test 2\n" +
+                    "   Successful Test 1\n" +
+                    "   Successful Test 2\n";
+            assertTreeHierarchy(model, expected, getTestRootDisposable());
+        });
+    }
+
+    @Test
+    public void hierarchyTwoAppMapProjects() throws Exception {
+        // copy into parent dir, because the default location is "src/", which already is a content root
+        var rootOne = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_one"));
+        var rootTwo = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_two"));
+
+        withContentRoot(getModule(), rootOne, () -> {
+            withContentRoot(getModule(), rootTwo, () -> {
+                var model = new AppMapModel(getProject());
+                var expected = "-AppMaps\n" +
+                        " -root_one\n" +
+                        "  -Tests (ruby + minitest)\n" +
+                        "   Failed test 1\n" +
+                        "   Failed test 2\n" +
+                        "   Successful Test 1\n" +
+                        "   Successful Test 2\n" +
+                        " -root_two\n" +
+                        "  -Tests (ruby + minitest)\n" +
+                        "   Failed test 1\n" +
+                        "   Failed test 2\n" +
+                        "   Successful Test 1\n" +
+                        "   Successful Test 2\n";
+                assertTreeHierarchy(model, expected, getTestRootDisposable());
+            });
+        });
+    }
+
+    @Test
+    public void emptyTree() {
+        WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/empty-appMapDir", "root"));
+
+        var model = new AppMapModel(getProject());
+        var expected = "-AppMaps\n";
+        assertTreeHierarchy(model, expected, getTestRootDisposable());
+    }
+}

--- a/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
@@ -8,11 +8,7 @@ import appland.toolwindow.runtimeAnalysis.nodes.FindingsTableNode;
 import appland.toolwindow.runtimeAnalysis.nodes.ImpactDomainNode;
 import appland.toolwindow.runtimeAnalysis.nodes.Node;
 import appland.toolwindow.runtimeAnalysis.nodes.RootNode;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.WriteAction;
-import com.intellij.ui.tree.AsyncTreeModel;
-import com.intellij.ui.tree.TreeTestUtil;
-import com.intellij.ui.treeStructure.Tree;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assume;
@@ -21,6 +17,8 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static appland.utils.ModelTestUtil.assertTreeHierarchy;
 
 public class RuntimeAnalysisModelTest extends AppMapBaseTest {
     @Override
@@ -103,7 +101,7 @@ public class RuntimeAnalysisModelTest extends AppMapBaseTest {
                 "      user.rb\n" +
                 "      user.rb\n" +
                 "      user.rb\n";
-        assertTreeHierarchy(model, expected);
+        assertTreeHierarchy(model, expected, getTestRootDisposable());
     }
 
     @NotNull
@@ -129,18 +127,6 @@ public class RuntimeAnalysisModelTest extends AppMapBaseTest {
     private void assertOverviewNode(@NotNull RootNode root) {
         var node = assertNode(root.getChildren().get(0), "Findings Table");
         assertTrue(node instanceof FindingsTableNode);
-    }
-
-    private void assertTreeHierarchy(RuntimeAnalysisModel model, @NotNull String expected) {
-        ApplicationManager.getApplication().invokeAndWait(() -> {
-            new TreeTestUtil(new Tree(new AsyncTreeModel(model, getTestRootDisposable())))
-                    .expandAll()
-                    .expandAll()
-                    .expandAll()
-                    .expandAll()
-                    .expandAll()
-                    .assertStructure(expected);
-        });
     }
 
     private void loadFindingsDirectory(@NotNull String directoryPath) throws Exception {

--- a/plugin-core/src/test/java/appland/utils/ModelTestUtil.java
+++ b/plugin-core/src/test/java/appland/utils/ModelTestUtil.java
@@ -1,0 +1,29 @@
+package appland.utils;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.ui.tree.AsyncTreeModel;
+import com.intellij.ui.tree.TreeTestUtil;
+import com.intellij.ui.treeStructure.Tree;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.tree.TreeModel;
+
+public final class ModelTestUtil {
+    private ModelTestUtil() {
+    }
+
+    public static void assertTreeHierarchy(@NotNull TreeModel model,
+                                           @NotNull String expected,
+                                           @NotNull Disposable disposable) {
+        ApplicationManager.getApplication().invokeAndWait(() -> {
+            new TreeTestUtil(new Tree(new AsyncTreeModel(model, disposable)))
+                    .expandAll()
+                    .expandAll()
+                    .expandAll()
+                    .expandAll()
+                    .expandAll()
+                    .assertStructure(expected);
+        });
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/421

AppMaps are now displayed in a hierarchy:
- `<module name>`
  - `<recorder type> (<language name> + <recorder name>`)
    - `<AppMap name>`
- The tree hierarchy is expanded by default 
- The indexed data of AppMaps had to be enhanced to provide the data needed to group AppMaps
- Adds unit tests for empty AppMaps, AppMaps in one module and AppMaps in two modules of a project

![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/b9437682-22c3-44d8-82dd-b9f8c1a58520)
