### PR TITLE
Don't override properties of an existing appmap.yml file

### DIFF
--- a/plugin-core/src/main/java/appland/index/AppMapSearchScopes.java
+++ b/plugin-core/src/main/java/appland/index/AppMapSearchScopes.java
@@ -32,6 +32,7 @@ public final class AppMapSearchScopes {
     public static @NotNull GlobalSearchScope appMapConfigSearchScope(@NotNull Project project) {
         return ProjectScope.getContentScope(project);
     }
+
     /**
      * Search scope, which contains all project files and also excluded files of the project.
      * This implementation is based on IntelliJ's {@link ProjectScopeImpl}.

--- a/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
@@ -66,7 +66,6 @@ public final class AppMapPatcherUtil {
 
         // launches its own ReadAction
         var config = AppMapJavaPackageConfig.createOrUpdateAppMapConfig(module,
-                configuration,
                 workingDir,
                 appMapOutputDirectory);
 

--- a/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigTest.java
+++ b/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigTest.java
@@ -3,6 +3,7 @@ package appland.execution;
 import appland.AppMapBaseTest;
 import appland.config.AppMapConfigFile;
 import com.intellij.execution.RunManager;
+import com.intellij.execution.jar.JarApplicationConfiguration;
 import com.intellij.execution.jar.JarApplicationConfigurationType;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
@@ -47,10 +48,12 @@ public class AppMapJavaPackageConfigTest extends AppMapBaseTest {
     private void assertConfigUpdate(@NotNull VirtualFile contextFile,
                                     @NotNull Path appMapOutputDirPath,
                                     @NotNull String expectedAppMapDir) throws IOException {
-        var runConfig = RunManager.getInstance(getProject()).createConfiguration("temp run config", JarApplicationConfigurationType.class);
+        var runConfigSettings = RunManager.getInstance(getProject()).createConfiguration("temp run config", JarApplicationConfigurationType.class);
+        var runConfig = (JarApplicationConfiguration) runConfigSettings.getConfiguration();
+        // update module to enforce a search scope of the run configuration
+        runConfig.setModule(getModule());
 
         var configFilePath = AppMapJavaPackageConfig.createOrUpdateAppMapConfig(getModule(),
-                runConfig.getConfiguration(),
                 contextFile,
                 appMapOutputDirPath);
 
@@ -63,7 +66,6 @@ public class AppMapJavaPackageConfigTest extends AppMapBaseTest {
         config.writeTo(configFilePath);
 
         var updatedConfigFilePath = AppMapJavaPackageConfig.createOrUpdateAppMapConfig(getModule(),
-                runConfig.getConfiguration(),
                 contextFile,
                 Path.of(appMapOutputDirPath + "-updated"));
         assertEquals("Update must write to the same file again", configFilePath, updatedConfigFilePath);


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/385

The appmap.yml wasn't properly located if the executed run configuration defined its own search scope.
The test was updated to make the previous implementation fail as  expected.
Now, the search scope is just the content search scope of the module.