### PR TITLE
Support 2023.3 eap

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -273,7 +273,7 @@ project(":plugin-java") {
     }
 
     intellij {
-        plugins.set(listOf("java"))
+        plugins.set(listOf("java", "com.intellij.properties"))
     }
 }
 
@@ -284,7 +284,7 @@ project(":plugin-gradle") {
     }
 
     intellij {
-        plugins.set(listOf("java", "gradle"))
+        plugins.set(listOf("java", "gradle", "com.intellij.properties"))
     }
 }
 
@@ -295,7 +295,7 @@ project(":plugin-maven") {
     }
 
     intellij {
-        plugins.set(listOf("java", "maven"))
+        plugins.set(listOf("java", "maven", "com.intellij.properties"))
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,12 @@
 pluginVersion=0.49.0
 
 sinceBuild=213.0
-untilBuild=232.*
+untilBuild=233.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2021.3.3,IC-2023.1.1
+ideVersionVerifier=IC-2021.3.3,IC-233.6745.305
 
 lombokVersion=1.18.24
-
-appMapJvmAgent=1.17.2
 
 # alternative versions to simplify development and testing
 ideVersion=IC-2021.3.3
@@ -17,6 +15,7 @@ ideVersion=IC-2021.3.3
 #ideVersion=IC-2022.3
 #ideVersion=IC-2023.1.1
 #ideVersion=IC-2023.2
+#ideVersion=IC-233.6745.305-EAP-SNAPSHOT
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=false


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/456

Adds compatibility to the new EAP and removes unused build properties.

The build dependency on the properties plugin is added because of https://youtrack.jetbrains.com/issue/IDEA-333586/Exception-Trying-to-add-extensions-to-non-registered-file-type-Properties-Plugin-com.intellij.java-in-tests