### PR TITLE
Support "Delete AppMaps" and "Delete all AppMaps" in the AppMap toolwindow

### DIFF
--- a/plugin-core/src/main/java/appland/files/DeleteAppMapIndexDataFileListener.java
+++ b/plugin-core/src/main/java/appland/files/DeleteAppMapIndexDataFileListener.java
@@ -1,0 +1,72 @@
+package appland.files;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.AsyncFileListener;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Deletes corresponding AppMap index data after a *.appmap.json file was deleted.
+ */
+public class DeleteAppMapIndexDataFileListener implements AsyncFileListener {
+    @Nullable
+    @Override
+    public ChangeApplier prepareChange(@NotNull List<? extends @NotNull VFileEvent> events) {
+        var deletedAppMaps = events.stream()
+                .map(DeleteAppMapIndexDataFileListener::findIndexDirectory)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return deletedAppMaps.isEmpty() ? null : new DeleteAppMapIndexDataChangeApplier(deletedAppMaps);
+    }
+
+    private static @Nullable VirtualFile findIndexDirectory(VFileEvent event) {
+        var file = event.getFile();
+        return file != null && event instanceof VFileDeleteEvent && AppMapFiles.isAppMap(file)
+                ? AppMapFiles.findAppMapMetadataDirectory(file)
+                : null;
+    }
+
+    private static class DeleteAppMapIndexDataChangeApplier implements ChangeApplier {
+        private final @NotNull List<VirtualFile> appMapIndexDirectories;
+
+        public DeleteAppMapIndexDataChangeApplier(@NotNull List<VirtualFile> appMapIndexDirectories) {
+            this.appMapIndexDirectories = appMapIndexDirectories;
+        }
+
+        @Override
+        public void afterVfsChange() {
+            var application = ApplicationManager.getApplication();
+            application.invokeLater(() -> {
+                CommandProcessor.getInstance().runUndoTransparentAction(() -> {
+                    application.runWriteAction(() -> {
+                        appMapIndexDirectories.forEach(DeleteAppMapIndexDataChangeApplier::safeDeleteDirectory);
+                    });
+                });
+            }, ModalityState.defaultModalityState());
+        }
+
+        private static void safeDeleteDirectory(@NotNull VirtualFile indexDirectory) {
+            if (!indexDirectory.isValid() || !indexDirectory.isDirectory()) {
+                return;
+            }
+
+            try {
+                indexDirectory.delete(DeleteAppMapIndexDataFileListener.class);
+            } catch (Exception e) {
+                var logger = Logger.getInstance(DeleteAppMapIndexDataChangeApplier.class);
+                logger.warn("Exception deleting AppMap index directory " + indexDirectory.getPath());
+            }
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
@@ -1,0 +1,51 @@
+package appland.toolwindow.appmap;
+
+import appland.AppMapBundle;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.DeleteProvider;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.fileChooser.actions.VirtualFileDeleteProvider;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Action to delete all AppMaps displayed in the AppMap panel.
+ */
+final class DeleteAllMapsAction extends AnAction {
+    private final DeleteProvider deleteHandler = new VirtualFileDeleteProvider();
+
+    public DeleteAllMapsAction() {
+        super(AppMapBundle.get("toolwindow.appmap.actions.deleteAllAppMaps.title"), null, AllIcons.General.Remove);
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        var enabled = deleteHandler.canDeleteElement(new CustomizedDataContext(e.getDataContext()));
+        e.getPresentation().setEnabled(enabled);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        // Pass a customized context to the delete handler to delete all Appand not just the array of selected AppMaps
+        deleteHandler.deleteElement(new CustomizedDataContext(e.getDataContext()));
+    }
+
+    /**
+     * Customized context to provide the value of {@link AppMapWindowPanel#KEY_ALL_APPMAPS}
+     * when the delete implementation requests files to delete via {@link CommonDataKeys#VIRTUAL_FILE_ARRAY}.
+     */
+    private static class CustomizedDataContext extends DataContextWrapper {
+        public CustomizedDataContext(@NotNull DataContext delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public @Nullable Object getData(@NotNull @NonNls String dataId) {
+            if (CommonDataKeys.VIRTUAL_FILE_ARRAY.is(dataId)) {
+                return super.getData(AppMapWindowPanel.KEY_ALL_APPMAPS);
+            }
+            return super.getData(dataId);
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/AppMapGroupNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/AppMapGroupNode.java
@@ -5,11 +5,13 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.tree.LeafState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 class AppMapGroupNode extends Node {
@@ -41,6 +43,14 @@ class AppMapGroupNode extends Node {
         return appMaps.stream()
                 .sorted(Comparator.comparing(AppMapMetadata::getName))
                 .map(appMap -> new AppMapNode(myProject, this, appMap))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public @NotNull List<VirtualFile> getFiles() {
+        return appMaps.stream()
+                .map(AppMapMetadata::getAppMapFile)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/Node.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/Node.java
@@ -8,6 +8,7 @@ import com.intellij.ui.tree.LeafState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 
 public abstract class Node extends PresentableNodeDescriptor<Node> implements LeafState.Supplier {
@@ -30,5 +31,13 @@ public abstract class Node extends PresentableNodeDescriptor<Node> implements Le
      */
     public @Nullable VirtualFile getFile() {
         return null;
+    }
+
+    /**
+     * @return List of {@link VirtualFile} associated with this node or an empty list if no files are associated.
+     */
+    public @NotNull List<VirtualFile> getFiles() {
+        var file = getFile();
+        return file != null ? List.of(file) : Collections.emptyList();
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/ProjectNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/ProjectNode.java
@@ -5,12 +5,14 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.tree.LeafState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 class ProjectNode extends Node {
@@ -59,5 +61,13 @@ class ProjectNode extends Node {
 
         var capitalizedType = StringUtil.capitalize(recorderType);
         return String.format("%s (%s + %s)", capitalizedType, languageName, recorderName);
+    }
+
+    @Override
+    public @NotNull List<VirtualFile> getFiles() {
+        return appMaps.stream()
+                .map(AppMapMetadata::getAppMapFile)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/RootNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/RootNode.java
@@ -8,13 +8,12 @@ import com.intellij.ide.projectView.PresentationData;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.tree.LeafState;
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -57,6 +56,19 @@ public class RootNode extends Node {
                 .sorted(Map.Entry.comparingByKey())
                 .map(entry -> (Node) new ProjectNode(myProject, this, entry.getKey(), entry.getValue()))
                 .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    @Override
+    public @NotNull List<VirtualFile> getFiles() {
+        var appMaps = getCachedAppMaps();
+        if (appMaps.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return appMaps.stream()
+                .map(AppMapMetadata::getAppMapFile)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     private @NotNull String getAppMapProjectName(@NotNull AppMapMetadata appMapMetadata) {

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -111,6 +111,7 @@
 
         <!-- Generic AppMap file handling -->
         <vfs.asyncListener implementation="appland.files.AppMapAsyncFileListener"/>
+        <vfs.asyncListener implementation="appland.files.DeleteAppMapIndexDataFileListener"/>
         <virtualFileManagerListener implementation="appland.files.VirtualFileManagerLister"/>
 
         <!-- CLI service -->

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -72,6 +72,9 @@ toolwindow.appmap.documentation=Documentation
 toolwindow.appmap.runtimeAnalysis=Runtime Analysis
 toolwindow.appmap.instructions=Instructions
 
+toolwindow.appmap.actions.deleteAppMap.title=Delete selected AppMaps...
+toolwindow.appmap.actions.deleteAllAppMaps.title=Delete All AppMaps...
+
 toolwindow.jcefUnsupported.emptyText=Your IDE does not support JCEF HTML webviews.
 toolwindow.jcefUnsupported.emptyText2=Please change the Boot Java Runtime to the newest version
 toolwindow.jcefUnsupported.emptyText3=that includes JCEF by following this guide:

--- a/plugin-core/src/test/java/appland/files/DeleteAppMapIndexDataFileListenerTest.java
+++ b/plugin-core/src/test/java/appland/files/DeleteAppMapIndexDataFileListenerTest.java
@@ -1,0 +1,61 @@
+package appland.files;
+
+import appland.AppMapBaseTest;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileEvent;
+import com.intellij.openapi.vfs.VirtualFileListener;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class DeleteAppMapIndexDataFileListenerTest extends AppMapBaseTest {
+    @Override
+    protected boolean runInDispatchThread() {
+        // we need to switch between EDT and non-EDT threads to make this test work
+        return false;
+    }
+
+    @Test
+    public void recursiveIndexDirectoryRemoval() throws InterruptedException {
+        var root = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/with_modification_date", "root"));
+        var appMap = root.findFileByRelativePath("tmp/appmap/with_modification_date.appmap.json");
+        assertNotNull(appMap);
+
+        var indexDirectory = ReadAction.compute(() -> root.findFileByRelativePath("tmp/appmap/with_modification_date"));
+        assertNotNull("Index directory must exist", indexDirectory);
+
+        var deletedLatch = listenForDirectoryDeletion(indexDirectory);
+        WriteCommandAction.runWriteCommandAction(getProject(), () -> {
+            try {
+                appMap.delete(this);
+            } catch (IOException e) {
+                addSuppressedException(e);
+            }
+        });
+
+        var wasDeleted = deletedLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("The index directory must be deleted when an AppMap is deleted", wasDeleted);
+        assertNull("Index directory must not exist after AppMap was deleted",
+                root.findFileByRelativePath("tmp/appmap/with_modification_date"));
+    }
+
+    @NotNull
+    private CountDownLatch listenForDirectoryDeletion(VirtualFile indexDirectory) {
+        var indexDirLatch = new CountDownLatch(1);
+        indexDirectory.getFileSystem().addVirtualFileListener(new VirtualFileListener() {
+            @Override
+            public void fileDeleted(@NotNull VirtualFileEvent event) {
+                if (indexDirectory.equals(event.getFile())) {
+                    indexDirLatch.countDown();
+                }
+            }
+        }, getTestRootDisposable());
+        return indexDirLatch;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/465

This PR
- adds a context menu to the AppMap panel in the AppMap toolwindow
  - Action "Delete selected AppMaps...", relying on the SDK's delete implementation for one or multiple files
  - Action "Delete all AppMaps...", relying on the SDK's delete implementation for one or multiple files
  - Action "Jump to source", reusing the implementation of the SDK
  - Action "Expand All", reusing the implementation of the SDK
  - Action "Collapse AlL", reusing the implementation of the SDK

This isn't testable in a good way, because
- we're reusing Actions of the SDK (which hopefully have test coverage already)
- the Actions interact with the user using UI dialogs. Tests are run in a headless environment and can't use dialogs

![Screenshot_20231005_194748](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/b17f654a-1e27-41d3-a8b4-555320a1413c)
