### PR TITLE
Center AppMap webview on finding

### DIFF
--- a/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsManager.java
@@ -297,14 +297,24 @@ public class FindingsManager implements ProblemsProvider {
 
     private void loadFileLocked(@NotNull VirtualFile findingsFile, @NotNull Consumer<Problem> notifier) {
         var fileData = loadFindingsFile(findingsFile);
-        if (fileData != null && fileData.findings != null) {
-            for (var finding : fileData.findings) {
-                finding.setFindingsFile(findingsFile);
+        if (fileData != null && fileData.findingsJSON != null) {
+            var ruleMapping = fileData.createRuleInfoMapping();
 
-                // multiple metadata values exist to support scanner batch mode,
-                // but this is mostly deprecated now and shouldn't exist for user-generated AppMap data.
-                if (fileData.metadata != null && !fileData.metadata.isEmpty()) {
-                    var metaData = fileData.metadata.values().iterator().next();
+            // Multiple metadata values exist to support scanner batch mode, but this is mostly deprecated now and
+            // shouldn't exist for user-generated AppMap data.
+            var metaData = fileData.metadata != null && !fileData.metadata.isEmpty()
+                    ? fileData.metadata.values().iterator().next()
+                    : null;
+
+            for (var findingJSON : fileData.findingsJSON) {
+                var finding = GsonUtils.GSON.fromJson(findingJSON, ScannerFinding.class);
+                finding.setFindingsFile(findingsFile);
+                finding.setOriginalJsonData(findingJSON);
+
+                // update rule info with the ruleId of the finding
+                finding.ruleInfo = ruleMapping.get(finding.ruleId);
+
+                if (metaData != null) {
                     finding.setFindingsMetaData(metaData);
                 }
 
@@ -355,15 +365,7 @@ public class FindingsManager implements ProblemsProvider {
         }
 
         try {
-            var data = GsonUtils.GSON.fromJson(doc.getText(), FindingsFileData.class);
-            if (data != null && data.findings != null && !data.findings.isEmpty()) {
-                var ruleMapping = data.createRuleInfoMapping();
-                for (var finding : data.findings) {
-                    // update rule info with the ruleId of the finding
-                    finding.ruleInfo = ruleMapping.get(finding.ruleId);
-                }
-            }
-            return data;
+            return GsonUtils.GSON.fromJson(doc.getText(), FindingsFileData.class);
         } catch (JsonSyntaxException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Failed to load findings file: " + file.getPath(), e);

--- a/plugin-core/src/main/java/appland/problemsView/FindingsUtil.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsUtil.java
@@ -51,7 +51,7 @@ public final class FindingsUtil {
                                                              @NotNull ScannerFinding finding,
                                                              @NotNull String rulePropertyName) {
         var jsonItem = new JsonObject();
-        jsonItem.add("finding", gson.toJsonTree(finding));
+        jsonItem.add("finding", finding.getOriginalJsonData());
         jsonItem.add("appMapUri", createAppMapUriJson(finding));
         jsonItem.add("problemLocation", createProblemLocationJson(finding));
         jsonItem.add("stackLocations", ReadAction.compute(() -> createStackLocationsJson(gson, project, finding)));

--- a/plugin-core/src/main/java/appland/problemsView/model/FindingsFileData.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/FindingsFileData.java
@@ -1,5 +1,6 @@
 package appland.problemsView.model;
 
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,7 +12,7 @@ import java.util.Map;
 
 public final class FindingsFileData {
     @SerializedName("findings")
-    public @Nullable List<ScannerFinding> findings;
+    public @Nullable List<JsonObject> findingsJSON;
 
     @SerializedName("checks")
     public @Nullable List<CheckInfo> checks;

--- a/plugin-core/src/main/java/appland/problemsView/model/ScannerFinding.java
+++ b/plugin-core/src/main/java/appland/problemsView/model/ScannerFinding.java
@@ -2,6 +2,7 @@ package appland.problemsView.model;
 
 import appland.files.FileLocation;
 import appland.files.FileLookup;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
@@ -68,6 +69,12 @@ public class ScannerFinding {
     @Getter
     @Setter
     private transient @Nullable FindingsMetadata findingsMetaData;
+
+    // attached after JSON parsing, links to the original source of this finding to pass the complete data to the AppMap
+    // webview.
+    @Getter
+    @Setter
+    private transient @Nullable JsonObject originalJsonData;
 
     public @Nullable String getAppMapHashWithFallback() {
         return StringUtil.nullize(StringUtil.defaultIfEmpty(appMapHashV2, appMapHash));

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/FindingLocationNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/nodes/FindingLocationNode.java
@@ -2,7 +2,6 @@ package appland.toolwindow.runtimeAnalysis.nodes;
 
 import appland.problemsView.model.ScannerFinding;
 import appland.webviews.findingDetails.FindingDetailsEditorProvider;
-import com.intellij.icons.AllIcons;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.fileTypes.FileTypeManager;
@@ -38,7 +37,9 @@ final class FindingLocationNode extends Node {
         return new Navigatable() {
             @Override
             public void navigate(boolean requestFocus) {
-                FindingDetailsEditorProvider.openEditor(myProject, List.of(finding));
+                var hash = finding.getAppMapHashWithFallback();
+                assert hash != null;
+                FindingDetailsEditorProvider.openEditor(myProject, hash, List.of(finding));
             }
 
             @Override

--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditorState.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditorState.java
@@ -47,4 +47,14 @@ public class AppMapFileEditorState {
         state.addProperty("selectedObject", nodeId);
         return new AppMapFileEditorState(GsonUtils.GSON.toJson(state));
     }
+
+    /**
+     * @param findingHash Hash of the finding to show in the AppMap webview.
+     * @return State to instruct the AppMap webview to center on the given finding.
+     */
+    public static @NotNull AppMapFileEditorState createFindingState(@NotNull String findingHash) {
+        var state = new JsonObject();
+        state.addProperty("selectedObject", String.format("analysis-finding:%s", findingHash));
+        return new AppMapFileEditorState(GsonUtils.GSON.toJson(state));
+    }
 }

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
@@ -65,8 +65,9 @@ public class FindingDetailsEditor extends WebviewEditor<Void> {
                 assert message != null;
                 var path = GsonUtils.getPath(message, "uri", "path");
                 if (path != null) {
-                    var fragment = GsonUtils.getPath(message, "uri", "fragment");
-                    openAppMapUri(path.getAsString(), fragment != null ? fragment.getAsString() : "{}");
+                    var hash = FindingDetailsEditorProvider.KEY_FINDING_HASH.get(file);
+                    assert hash != null;
+                    openAppMapUri(path.getAsString(), AppMapFileEditorState.createFindingState(hash));
                 }
                 break;
         }
@@ -115,13 +116,13 @@ public class FindingDetailsEditor extends WebviewEditor<Void> {
         }
     }
 
-    private void openAppMapUri(@NotNull String appMapUri, @NotNull String jsonState) {
+    private void openAppMapUri(@NotNull String appMapUri, @NotNull AppMapFileEditorState editorState) {
         var file = LocalFileSystem.getInstance().findFileByPath(StringUtil.split(appMapUri, "#").get(0));
         if (file != null) {
             ApplicationManager.getApplication().invokeLater(() -> {
                 var appMapEditors = FileEditorManager.getInstance(project).openFile(file, true);
                 if (appMapEditors.length == 1 && appMapEditors[0] instanceof AppMapFileEditor) {
-                    ((AppMapFileEditor) appMapEditors[0]).setWebViewState(AppMapFileEditorState.of(jsonState));
+                    ((AppMapFileEditor) appMapEditors[0]).setWebViewState(editorState);
                 }
             }, ModalityState.defaultModalityState());
         } else {

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditorProvider.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 public class FindingDetailsEditorProvider extends WebviewEditorProvider {
     private static final String TYPE_ID = "appland.findingDetails";
+    static final Key<String> KEY_FINDING_HASH = Key.create("appmap.findingDetailsHash");
     static final Key<List<ScannerFinding>> KEY_FINDINGS = Key.create("appmap.findingDetailsData");
 
     public FindingDetailsEditorProvider() {
@@ -33,7 +34,9 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
      * @param project  Current project
      * @param findings Findings to show in the webview
      */
-    public static void openEditor(@NotNull Project project, @NotNull List<ScannerFinding> findings) {
+    public static void openEditor(@NotNull Project project,
+                                  @NotNull String findingHash,
+                                  @NotNull List<ScannerFinding> findings) {
         var provider = WebviewEditorProvider.findEditorProvider(TYPE_ID);
         assert provider != null;
 
@@ -42,6 +45,7 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
         }
 
         var file = provider.createVirtualFile(findEditorTitle(findings));
+        KEY_FINDING_HASH.set(file, findingHash);
         KEY_FINDINGS.set(file, findings);
         FileEditorManager.getInstance(project).openFile(file, true);
 

--- a/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
@@ -85,7 +85,7 @@ public class FindingsOverviewEditor extends WebviewEditor<List<ScannerFinding>> 
                 var title = AppMapBundle.get("findingsOverview.openFindingsByHashError.title");
                 Messages.showErrorDialog(message, title);
             } else {
-                FindingDetailsEditorProvider.openEditor(project, findings);
+                FindingDetailsEditorProvider.openEditor(project, hash, findings);
             }
         });
     }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/407

- Keep the source finding hash in the finding details editor
- Use this hash to create the editor state for the new AppMap webview
- Use the new state to center the newly opened AppMap editor on the source finding

(@ahtrotta Why wasn't the fragment changed, which is passed from finding webview to the webview host? I think this would have changed the behavior in both VSCode and JetBrains without changes to the plugins)

## Testing
This PR  needs manual testing to verify the navigation