### PR TITLE
Update name of remote recording before allowing the AppMap indexer to index it

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=213.0
 untilBuild=233.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2021.3.3,IC-233.6745.305
+ideVersionVerifier=IC-2021.3.3,IC-233.10527.20
 
 lombokVersion=1.18.24
 

--- a/plugin-core/src/test/java/appland/WithoutAppMapAgent.java
+++ b/plugin-core/src/test/java/appland/WithoutAppMapAgent.java
@@ -1,0 +1,7 @@
+package appland;
+
+/**
+ * JUnit category to mark tests, which are incompatible with the AppMap agent.
+ */
+public final class WithoutAppMapAgent {
+}

--- a/plugin-core/src/test/java/appland/remote/DefaultRemoteRecordingServiceTest.java
+++ b/plugin-core/src/test/java/appland/remote/DefaultRemoteRecordingServiceTest.java
@@ -1,6 +1,7 @@
 package appland.remote;
 
 import appland.AppMapBaseTest;
+import appland.WithoutAppMapAgent;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.intellij.openapi.progress.ProgressManager;
@@ -8,28 +9,22 @@ import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.apache.http.HttpStatus;
-import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 
 import static appland.remote.DefaultRemoteRecordingService.url;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
+@Category(WithoutAppMapAgent.class)
 public class DefaultRemoteRecordingServiceTest extends AppMapBaseTest {
     @Rule
     public final WireMockRule serverRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
-
-    @BeforeClass
-    public static void compatibility() {
-        Assume.assumeFalse(Objects.equals(System.getProperty("appmap.test.withAgent"), "true"));
-    }
 
     @Override
     protected TempDirTestFixture createTempDirTestFixture() {


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/477

This streams the AppMap JSON of the remote recording to a temporary file, then updates the `metadata.name` property of this file and then moves it to the final file, which has a `.appmap.json` extension.

This PR re-enables test `appland.remote.DefaultRemoteRecordingServiceTest` to cover the remote recording implementation. Previously, it was disabled due to incompatibility with an active AppMap agent.