### PR TITLE
Better determination of when Runtime Analysis is marked as complete

### DIFF
--- a/plugin-core/src/main/java/appland/index/AppMapFindingsUtil.java
+++ b/plugin-core/src/main/java/appland/index/AppMapFindingsUtil.java
@@ -2,7 +2,10 @@ package appland.index;
 
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.PathUtil;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,5 +21,10 @@ public final class AppMapFindingsUtil {
 
     public static boolean isFindingFile(@Nullable VirtualFile file) {
         return file != null && FileUtil.fileNameEquals(file.getName(), FINDINGS_FILE_NAME);
+    }
+
+    @RequiresReadLock
+    public static boolean isAnalysisPerformed(GlobalSearchScope searchScope) {
+        return !FilenameIndex.getVirtualFilesByName(FINDINGS_FILE_NAME, searchScope).isEmpty();
     }
 }

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -8,11 +8,9 @@ import appland.index.IndexedFileListenerUtil;
 import appland.installGuide.projectData.ProjectDataService;
 import appland.installGuide.projectData.ProjectMetadata;
 import appland.oauth.AppMapLoginAction;
-import appland.problemsView.FindingsViewTab;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.settings.AppMapSettingsListener;
-import appland.telemetry.TelemetryService;
 import appland.webviews.WebviewEditor;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
 import com.google.gson.Gson;
@@ -68,14 +66,23 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
         this.currentPage = page;
     }
 
-    public void navigateTo(@NotNull InstallGuideViewPage page, boolean postWebviewMessage) {
+    /**
+     * Navigate to the given page.
+     *
+     * @param page               Target page
+     * @param postWebviewMessage If the webview should be instructed to navigate to the given page.
+     * @param fromWebview        If the navigation originated from the webview
+     */
+    public void navigateTo(@NotNull InstallGuideViewPage page, boolean postWebviewMessage, boolean fromWebview) {
         this.currentPage = page;
 
-        if (page == InstallGuideViewPage.RuntimeAnalysis) {
-            AppMapProjectSettingsService.getState(project).setInvestigatedFindings(true);
+        var projectSettings = AppMapProjectSettingsService.getState(project);
+        if (fromWebview && page == InstallGuideViewPage.RuntimeAnalysis && projectSettings.isOpenedAppMapEditor()) {
+            projectSettings.setInvestigatedFindings(true);
         }
 
         if (postWebviewMessage) {
+            assert !fromWebview;
             postMessage(createPageNavigationJSON(page));
         }
     }
@@ -217,7 +224,7 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
 
     @NotNull
     private List<ProjectMetadata> findProjects() {
-        return ProjectDataService.getInstance(project).getAppMapProjects();
+        return ProjectDataService.getInstance(project).getAppMapProjects(true);
     }
 
     /**
@@ -275,7 +282,7 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
     private void handleMessageOpenPage(@NotNull JsonObject message) {
         // update state, which is based on the new page
         var viewId = message.getAsJsonPrimitive("page").getAsString();
-        navigateTo(InstallGuideViewPage.findByPageId(viewId), false);
+        navigateTo(InstallGuideViewPage.findByPageId(viewId), false, true);
     }
 
     private void executeInstallCommand(String path, String language) {

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditorProvider.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditorProvider.java
@@ -35,7 +35,7 @@ public class InstallGuideEditorProvider implements FileEditorProvider, DumbAware
                     assert editor instanceof InstallGuideEditor;
 
                     FileEditorManagerEx.getInstanceEx(project).openFile(file, true, true);
-                    ((InstallGuideEditor) editor).navigateTo(page, true);
+                    ((InstallGuideEditor) editor).navigateTo(page, true, false);
                     return;
                 }
             }
@@ -45,7 +45,7 @@ public class InstallGuideEditorProvider implements FileEditorProvider, DumbAware
             var newEditors = editorManager.openFile(file, true);
             if (newEditors.length == 1) {
                 // don't post webview message because the init message of the new editor was just sent
-                ((InstallGuideEditor) newEditors[0]).navigateTo(page, false);
+                ((InstallGuideEditor) newEditors[0]).navigateTo(page, false, false);
             }
         } finally {
             // notify in a background thread because we don't want to delay opening the editor

--- a/plugin-core/src/main/java/appland/installGuide/projectData/DefaultProjectDataService.java
+++ b/plugin-core/src/main/java/appland/installGuide/projectData/DefaultProjectDataService.java
@@ -19,7 +19,6 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScopes;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -47,10 +46,11 @@ public class DefaultProjectDataService implements ProjectDataService {
 
     @SuppressWarnings("UnstableApiUsage")
     @Override
-    public @NotNull List<ProjectMetadata> getAppMapProjects() {
-        ApplicationManager.getApplication().assertReadAccessNotAllowed();
-
-        updateMetadata();
+    public @NotNull List<ProjectMetadata> getAppMapProjects(boolean updateMetadata) {
+        if (updateMetadata) {
+            ApplicationManager.getApplication().assertReadAccessNotAllowed();
+            updateMetadata();
+        }
         return cachedProjects.get();
     }
 
@@ -203,7 +203,7 @@ public class DefaultProjectDataService implements ProjectDataService {
     @RequiresReadLock
     private boolean isAnalysisPerformed(@NotNull VirtualFile root) {
         var searchScope = GlobalSearchScopes.directoryScope(project, root, true);
-        return !FilenameIndex.getVirtualFilesByName(AppMapFindingsUtil.FINDINGS_FILE_NAME, searchScope).isEmpty();
+        return AppMapFindingsUtil.isAnalysisPerformed(searchScope);
     }
 
     private boolean isNodeSupported(@Nullable NodeVersion nodeVersion) {

--- a/plugin-core/src/main/java/appland/installGuide/projectData/ProjectDataService.java
+++ b/plugin-core/src/main/java/appland/installGuide/projectData/ProjectDataService.java
@@ -10,5 +10,10 @@ public interface ProjectDataService {
         return project.getService(ProjectDataService.class);
     }
 
-    @NotNull List<ProjectMetadata> getAppMapProjects();
+    /**
+     * @param updateMetadata If the metadata should be updated before retuning the cached projects.
+     *                       If {@code true}, then this method MUST NOT be invoked in a ReadAction.
+     * @return The available AppMap projects
+     */
+    @NotNull List<ProjectMetadata> getAppMapProjects(boolean updateMetadata);
 }

--- a/plugin-core/src/test/java/appland/installGuide/VSCodeFixturesTest.java
+++ b/plugin-core/src/test/java/appland/installGuide/VSCodeFixturesTest.java
@@ -22,7 +22,7 @@ public class VSCodeFixturesTest extends AppMapBaseTest {
         // copy into src, which is the only content root of the test project
         WriteAction.runAndWait(() -> myFixture.copyDirectoryToProject("project-a", ""));
 
-        var projects = ProjectDataService.getInstance(getProject()).getAppMapProjects();
+        var projects = ProjectDataService.getInstance(getProject()).getAppMapProjects(true);
         Assert.assertEquals(1, projects.size());
 
         var projectA = projects.get(0);

--- a/plugin-core/src/test/java/appland/installGuide/projectData/DefaultProjectDataServiceTest.java
+++ b/plugin-core/src/test/java/appland/installGuide/projectData/DefaultProjectDataServiceTest.java
@@ -14,7 +14,7 @@ public class DefaultProjectDataServiceTest extends AppMapBaseTest {
     public void selectedSampleObjects() {
         WriteAction.runAndWait(() -> myFixture.copyDirectoryToProject("appmap-scanner/with_findings", "root"));
 
-        var projects = ProjectDataService.getInstance(getProject()).getAppMapProjects();
+        var projects = ProjectDataService.getInstance(getProject()).getAppMapProjects(true);
         assertEquals(1, projects.size());
 
         var samples = projects.get(0).sampleCodeObjects;
@@ -43,7 +43,7 @@ public class DefaultProjectDataServiceTest extends AppMapBaseTest {
     public void truncatedSampleObjects() {
         WriteAction.runAndWait(() -> myFixture.copyDirectoryToProject("appmap-scanner/untruncated_findings", "root"));
 
-        var projects = ProjectDataService.getInstance(getProject()).getAppMapProjects();
+        var projects = ProjectDataService.getInstance(getProject()).getAppMapProjects(true);
         assertEquals(1, projects.size());
 
         var samples = projects.get(0).sampleCodeObjects;


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/396

This PR updates the status check of the "Runtime Analysis" step.
Setting "investigated findings" is now only set to `true` if it originates from user action in the webview and happens after the user opened an AppMap in the current project.
The VSCode plugin scopes the "user navigates to Runtime Analysis" to workspace folders, but we can't do this because there's just one panel per project. It was discussed and decided to just keep a flag per project.

Because the updated check requires read access in a background thread, I refactored the update to use a single (non-blocking) ReadAction in a background thread instead of up to four different ReadActions for a single update of the four items. This is now a clearer flow and should also be faster.

The labels are now updated after indexing finished, i.e. when a new project is opened for the first time the green checkmarks may appear a bit later than before.

## Testing
This PR needs manual testing because user webview interaction triggers the update.