### PR TITLE
Enforce that PsiFile is fetched with a slow/background data provider

### DIFF
--- a/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
@@ -114,6 +114,11 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
 
     @Override
     public @Nullable Object getData(@NotNull @NonNls String dataId) {
+        // don't provide PsiFile on the EDT, but delegate to the slow providers
+        if (CommonDataKeys.PSI_FILE.is(dataId) || CommonDataKeys.NAVIGATABLE.is(dataId)) {
+            return null;
+        }
+
         if (PlatformCoreDataKeys.SLOW_DATA_PROVIDERS.is(dataId)) {
             return List.of((DataProvider) this::getDataImpl);
         }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/490

Fixes exceptions on newer SDKs. It seems like the slow data provider is only queried if the fast provider does not provide a result.
This PR is always returning `null` when `PsiFile` is requested to enforce this.

I've tested this manually with 2021.3 and 2023.2.