### PR TITLE
Restart AppMap process when it terminates unexpectedly

### DIFF
--- a/plugin-core/src/main/java/appland/cli/LoggingProcessAdapter.java
+++ b/plugin-core/src/main/java/appland/cli/LoggingProcessAdapter.java
@@ -1,0 +1,37 @@
+package appland.cli;
+
+import com.intellij.execution.process.BaseProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Process adapter which logs events received from the process.
+ */
+class LoggingProcessAdapter extends ProcessAdapter {
+    private static final Logger LOG = Logger.getInstance(LoggingProcessAdapter.class);
+
+    static final ProcessListener INSTANCE = new LoggingProcessAdapter();
+
+    @Override
+    public void processTerminated(@NotNull ProcessEvent event) {
+        if (LOG.isDebugEnabled()) {
+            var process = event.getProcessHandler();
+            if (process instanceof BaseProcessHandler<?>) {
+                LOG.debug("CLI tool terminated: " + ((BaseProcessHandler<?>) process).getCommandLine() + ", exit code: " + event.getExitCode());
+            } else {
+                LOG.debug("CLI tool terminated: " + event);
+            }
+        }
+    }
+
+    @Override
+    public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(event.getText());
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/411

This PR implements restart of AppMap CLI processes.
Initially, when processes are launched for an AppMap-enabled directory, both indexer and scanner processes are started.
Now, when one of the processes terminates unexpectedly, this process is restarted after a delay. The initial delay is `5s`, the next next `5s*1.5=7.25s` and the next `7.25s*1.5=10.9s` and after the third unexpected termination no further restart is attempted.

This PR adds a tests to verify the restart.