### PR TITLE
Remove usage of internal API

### DIFF
--- a/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
+++ b/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
@@ -13,9 +13,12 @@ import java.util.List;
 import java.util.function.Predicate;
 
 /**
+ * Only used in 2023.1 and earlier.
+ * <p>
  * Adds excluded "appmap" folders and excluded AppMap files for indexing.
+ * <p>
  * We can't use an {@link com.intellij.util.indexing.AdditionalIndexedRootsScope}, because it's only called at startup.
- * We also have to update indexed files after the Install Guide wizard steps,
+ * We also have to update indexed files after the "Install Guide" wizard steps,
  * which add new roots after the project was opened.
  */
 @SuppressWarnings("UnstableApiUsage")

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -26,7 +26,7 @@ import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
 import com.intellij.ide.ClipboardSynchronizer;
 import com.intellij.ide.actions.runAnything.execution.RunAnythingRunProfile;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.impl.AsyncDataContext;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -301,11 +301,11 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
                 }
             };
 
-            var dataContext = (AsyncDataContext) dataId -> {
-                if (CommonDataKeys.PROJECT.is(dataId)) {
-                    return project;
+            var dataContext = new DataContext() {
+                @Override
+                public @Nullable Object getData(@NotNull String dataId) {
+                    return CommonDataKeys.PROJECT.is(dataId) ? project : null;
                 }
-                return null;
             };
 
             try {

--- a/plugin-core/src/main/java/appland/notifications/AppMapFullContentNotification.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapFullContentNotification.java
@@ -4,7 +4,6 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.impl.NotificationFullContent;
-import com.intellij.openapi.util.NlsContexts;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -15,7 +14,19 @@ import javax.swing.*;
  * Notification, which implements {@link NotificationFullContent} to show all of its content.
  */
 class AppMapFullContentNotification extends Notification implements NotificationFullContent {
-    public AppMapFullContentNotification(@NotNull @NonNls String groupId, @Nullable Icon icon, @Nullable @NlsContexts.NotificationTitle String title, @Nullable @NlsContexts.NotificationSubtitle String subtitle, @Nullable @NlsContexts.NotificationContent String content, @NotNull NotificationType type, @Nullable NotificationListener listener) {
-        super(groupId, icon, title, subtitle, content, type, listener);
+    public AppMapFullContentNotification(@NotNull @NonNls String groupId,
+                                         @Nullable Icon icon,
+                                         @Nullable String title,
+                                         @Nullable String subtitle,
+                                         @NotNull String content,
+                                         @NotNull NotificationType type,
+                                         @Nullable NotificationListener listener) {
+        super(groupId, content, type);
+        setTitle(title);
+        setSubtitle(subtitle);
+        setIcon(icon);
+        if (listener != null) {
+            setListener(listener);
+        }
     }
 }

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -6,8 +6,6 @@ import appland.actions.StopAppMapRecordingAction;
 import appland.installGuide.InstallGuideEditorProvider;
 import appland.installGuide.InstallGuideViewPage;
 import appland.startup.FirstAppMapLaunchStartupActivity;
-import appland.toolwindow.AppMapToolWindowFactory;
-import appland.webviews.findings.FindingsOverviewEditorProvider;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
@@ -15,14 +13,12 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
 import java.util.function.Consumer;
 
 import static appland.AppMapBundle.lazy;
@@ -40,7 +36,7 @@ public final class AppMapNotifications {
 
         ApplicationManager.getApplication().invokeLater(() -> {
             // cast to Icon to avoid an ambiguity with 2021.2
-            var notification = new Notification(REMOTE_RECORDING_ID, (Icon) null, type);
+            var notification = new Notification(REMOTE_RECORDING_ID, "", type);
             if (title != null) {
                 notification.setTitle(title);
             }

--- a/plugin-core/src/main/java/appland/startup/DynamicPluginListener.java
+++ b/plugin-core/src/main/java/appland/startup/DynamicPluginListener.java
@@ -2,6 +2,8 @@ package appland.startup;
 
 import appland.AppMapPlugin;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,7 +21,9 @@ public class DynamicPluginListener implements com.intellij.ide.plugins.DynamicPl
         }
 
         if (AppMapPlugin.getDescriptor().equals(pluginDescriptor)) {
-            FirstAppMapLaunchStartupActivity.handleFirstStart(project);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                FirstAppMapLaunchStartupActivity.handleFirstStart(project);
+            }, ModalityState.defaultModalityState());
         }
     }
 }

--- a/plugin-core/src/main/java/appland/startup/FirstAppMapLaunchStartupActivity.java
+++ b/plugin-core/src/main/java/appland/startup/FirstAppMapLaunchStartupActivity.java
@@ -4,26 +4,22 @@ import appland.settings.AppMapApplicationSettingsService;
 import appland.telemetry.TelemetryService;
 import appland.toolwindow.AppMapToolWindowFactory;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
-import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.util.EmptyRunnable;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.util.concurrency.annotations.RequiresEdt;
 import org.jetbrains.annotations.NotNull;
 
-public class FirstAppMapLaunchStartupActivity implements StartupActivity.DumbAware {
+public class FirstAppMapLaunchStartupActivity implements StartupActivity {
+    @RequiresEdt
     public static void showAppMapToolWindow(@NotNull Project project) {
-        StartupManager.getInstance(project).runAfterOpened(() -> ApplicationManager.getApplication().invokeLater(() -> {
-            var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(AppMapToolWindowFactory.TOOLWINDOW_ID);
-            if (toolWindow != null && !toolWindow.isVisible()) {
-                toolWindow.activate(EmptyRunnable.getInstance(), false);
-            }
-        }, ModalityState.defaultModalityState()));
-    }
+        ApplicationManager.getApplication().assertIsDispatchThread();
 
-    private static void sendTelemetry(@NotNull Project project) {
-        TelemetryService.getInstance().notifyTelemetryUsage(project);
+        var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(AppMapToolWindowFactory.TOOLWINDOW_ID);
+        if (toolWindow != null && !toolWindow.isVisible()) {
+            toolWindow.activate(EmptyRunnable.getInstance(), false);
+        }
     }
 
     @Override
@@ -34,6 +30,7 @@ public class FirstAppMapLaunchStartupActivity implements StartupActivity.DumbAwa
     /**
      * If it's the first launch of the AppLand plugin, it opens the AppMap toolwindow and sends telemetry.
      */
+    @RequiresEdt
     static void handleFirstStart(@NotNull Project project) {
         if (ApplicationManager.getApplication().isUnitTestMode()) {
             return;
@@ -47,7 +44,7 @@ public class FirstAppMapLaunchStartupActivity implements StartupActivity.DumbAwa
             settings.setShowFirstAppMapNotification(true);
 
             showAppMapToolWindow(project);
-            sendTelemetry(project);
+            TelemetryService.getInstance().notifyTelemetryUsage(project);
         }
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
@@ -3,9 +3,11 @@ package appland.toolwindow.appmap;
 import appland.AppMapBundle;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.DeleteProvider;
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.fileChooser.actions.VirtualFileDeleteProvider;
-import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,31 +23,26 @@ final class DeleteAllMapsAction extends AnAction {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
-        var enabled = deleteHandler.canDeleteElement(new CustomizedDataContext(e.getDataContext()));
+        var enabled = deleteHandler.canDeleteElement(createDataContext(e));
         e.getPresentation().setEnabled(enabled);
     }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        // Pass a customized context to the delete handler to delete all Appand not just the array of selected AppMaps
-        deleteHandler.deleteElement(new CustomizedDataContext(e.getDataContext()));
+        // Pass a customized context to the delete handler to delete all AppMaps, not just the array of selected AppMaps
+        deleteHandler.deleteElement(createDataContext(e));
     }
 
-    /**
-     * Customized context to provide the value of {@link AppMapWindowPanel#KEY_ALL_APPMAPS}
-     * when the delete implementation requests files to delete via {@link CommonDataKeys#VIRTUAL_FILE_ARRAY}.
-     */
-    private static class CustomizedDataContext extends DataContextWrapper {
-        public CustomizedDataContext(@NotNull DataContext delegate) {
-            super(delegate);
-        }
-
-        @Override
-        public @Nullable Object getData(@NotNull @NonNls String dataId) {
-            if (CommonDataKeys.VIRTUAL_FILE_ARRAY.is(dataId)) {
-                return super.getData(AppMapWindowPanel.KEY_ALL_APPMAPS);
+    private static @NotNull DataContext createDataContext(@NotNull AnActionEvent e) {
+        var parentContext = e.getDataContext();
+        return new DataContext() {
+            @Override
+            public @Nullable Object getData(@NotNull String dataId) {
+                if (CommonDataKeys.VIRTUAL_FILE_ARRAY.is(dataId)) {
+                    return parentContext.getData(AppMapWindowPanel.KEY_ALL_APPMAPS);
+                }
+                return parentContext.getData(dataId);
             }
-            return super.getData(dataId);
-        }
+        };
     }
 }

--- a/plugin-core/src/main/java/appland/upload/AppMapUploader.java
+++ b/plugin-core/src/main/java/appland/upload/AppMapUploader.java
@@ -3,6 +3,7 @@ package appland.upload;
 import appland.AppMapBundle;
 import appland.Icons;
 import appland.settings.AppMapProjectSettingsService;
+import com.google.common.html.HtmlEscapers;
 import com.google.gson.GsonBuilder;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -19,7 +20,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Urls;
 import com.intellij.util.io.HttpRequests;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -102,7 +102,9 @@ public class AppMapUploader {
                     LOG.warn("Uploading AppMap failed", e);
                     ApplicationManager.getApplication().invokeLater(() -> {
                         Messages.showErrorDialog(project,
-                                AppMapBundle.get("upload.uploadFailed.message", file.getName(), StringEscapeUtils.escapeHtml(e.getMessage())),
+                                AppMapBundle.get("upload.uploadFailed.message",
+                                        file.getName(),
+                                        HtmlEscapers.htmlEscaper().escape(e.getMessage())),
                                 AppMapBundle.get("upload.uploadFailed.title"));
                     });
                 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/492

Replaces usage of all `@Internal` API with an alternative. We're not using internal API anymore.
This PR also drops use of API which was deprecated in 2021.3, which is the earliest supported version.

The changes to drop internal API from AppMapFilesIterator have the side-effect that we're not supporting symlinked appmap directories anymore. I don't think that it's used at all and `build/appmap` and `target/appmap` are never symlinks by default.