### PR TITLE
Action to sign in with a text API key

### DIFF
--- a/plugin-core/src/main/java/appland/AppMapPlugin.java
+++ b/plugin-core/src/main/java/appland/AppMapPlugin.java
@@ -3,12 +3,15 @@ package appland;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.extensions.PluginId;
+import com.intellij.util.Url;
+import com.intellij.util.Urls;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
 
 public final class AppMapPlugin {
     public static final String REMOTE_RECORDING_HELP_URL = "https://appmap.io/docs/recording-methods.html#remote-recording";
+    public static final @NotNull Url DEFAULT_SERVER_URL = Urls.newUrl("https", "getappmap.com", "");
 
     private static final String PLUGIN_ID = "appland.appmap";
 

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -138,4 +138,15 @@ public final class AppMapNotifications {
             notification.notify(project);
         });
     }
+
+    public static void showSignInNotification(@NotNull Project project) {
+        EdtInvocationManager.invokeLaterIfNeeded(() -> {
+            var notification = new AppMapFullContentNotification(
+                    GENERIC_NOTIFICATIONS_ID, null,
+                    null, null, AppMapBundle.get("notification.appMapSignIn.content"),
+                    NotificationType.INFORMATION, null
+            );
+            notification.notify(project);
+        });
+    }
 }

--- a/plugin-core/src/main/java/appland/oauth/AppMapKeyRemoteValidator.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapKeyRemoteValidator.java
@@ -1,0 +1,70 @@
+package appland.oauth;
+
+import appland.AppMapBundle;
+import appland.AppMapPlugin;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.InputValidator;
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
+import com.intellij.util.io.HttpRequests;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Validates the key by making an HTTP request to the AppLand server.
+ * <p>
+ * Because validation requires sending an HTTP request, the input validation is performed in a background thread
+ * under progress.
+ */
+class AppMapKeyRemoteValidator implements InputValidator {
+    private final @NotNull Project project;
+
+    AppMapKeyRemoteValidator(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public boolean checkInput(String inputString) {
+        if (inputString.isEmpty()) {
+            return false;
+        }
+
+        try {
+            var title = AppMapBundle.get("action.appMapLoginByKey.progressTitle");
+            var task = new Task.WithResult<Integer, Exception>(project, title, true) {
+                @Override
+                protected Integer compute(@NotNull ProgressIndicator indicator) throws Exception {
+                    return makeRemoteRequest(inputString);
+                }
+            };
+            task.queue();
+
+            var statusCode = task.getResult();
+            return statusCode < 300;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean canClose(String inputString) {
+        return checkInput(inputString);
+    }
+
+    @RequiresBackgroundThread
+    private int makeRemoteRequest(@NotNull String key) throws IOException {
+        try {
+            return HttpRequests.request(AppMapPlugin.DEFAULT_SERVER_URL.resolve("/api/api_keys/check")).tuner(connection -> {
+                        ((HttpURLConnection) connection).setRequestMethod("HEAD");
+                        connection.setRequestProperty("Accept", "application/json");
+                        connection.setRequestProperty("Authorization", "Bearer " + key);
+                    })
+                    .tryConnect();
+        } catch (HttpRequests.HttpStatusException e) {
+            return e.getStatusCode();
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/oauth/AppMapLocalKeyValidator.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLocalKeyValidator.java
@@ -1,0 +1,43 @@
+package appland.oauth;
+
+import appland.AppMapBundle;
+import com.intellij.openapi.ui.InputValidatorEx;
+import com.intellij.util.Base64;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+class AppMapLocalKeyValidator implements InputValidatorEx {
+    // email followed by the license id
+    private static final Pattern DECODED_VALUE_PATTERN = Pattern.compile("^.+@.+:.+$");
+
+    @Override
+    public boolean canClose(String inputString) {
+        // allow closing even if the local validation returned false
+        // to always delegate to the remote validation endpoint as final validation
+        return true;
+    }
+
+    @Override
+    public boolean checkInput(String inputString) {
+        // allow closing even if the local validation returned false
+        // to always delegate to the remote validation endpoint as final validation
+        return true;
+    }
+
+    @Override
+    public @Nullable String getErrorText(@NonNls String inputString) {
+        byte[] decoded;
+        try {
+            decoded = Base64.decode(inputString.trim());
+        } catch (IllegalArgumentException e) {
+            decoded = null;
+        }
+
+        var isValid = decoded != null
+                && DECODED_VALUE_PATTERN.asMatchPredicate().test(new String(decoded, StandardCharsets.UTF_8));
+        return isValid ? null : AppMapBundle.get("action.appMapLoginByKey.dialog.validation.invalidKeyError");
+    }
+}

--- a/plugin-core/src/main/java/appland/oauth/AppMapLoginByKeyAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLoginByKeyAction.java
@@ -1,0 +1,73 @@
+package appland.oauth;
+
+import appland.AppMapBundle;
+import appland.notifications.AppMapNotifications;
+import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.InputValidator;
+import com.intellij.openapi.ui.MessageMultilineInputDialog;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.ui.components.JBTextArea;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import java.util.Objects;
+
+import static com.intellij.openapi.ui.Messages.getCancelButton;
+import static com.intellij.openapi.ui.Messages.getOkButton;
+
+/**
+ * Action to sign in to AppMap by providing a license key.
+ */
+public class AppMapLoginByKeyAction extends AnAction implements DumbAware {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        var project = Objects.requireNonNull(e.getProject());
+
+        var dialog = new KeyTextInputDialog(project,
+                AppMapBundle.get("action.appMapLoginByKey.dialog.label"),
+                AppMapBundle.get("action.appMapLoginByKey.dialog.title"),
+                null, null, new AppMapLocalKeyValidator(),
+                new String[]{getOkButton(), getCancelButton()}, 0);
+        dialog.show();
+
+        var newKey = dialog.getInputString();
+        if (newKey != null) {
+            if (!new AppMapKeyRemoteValidator(project).checkInput(newKey)) {
+                var title = AppMapBundle.get("action.appMapLoginByKey.dialog.invalidKeyErrorMessage.title");
+                var message = AppMapBundle.get("action.appMapLoginByKey.dialog.invalidKeyErrorMessage.message");
+                Messages.showErrorDialog(project, message, title);
+                return;
+            }
+
+            AppMapApplicationSettingsService.getInstance().setApiKeyNotifying(newKey);
+            AppMapNotifications.showSignInNotification(project);
+        }
+    }
+
+    private static class KeyTextInputDialog extends MessageMultilineInputDialog {
+        public KeyTextInputDialog(@NotNull Project project,
+                                  @NotNull String message,
+                                  @NotNull String title,
+                                  @Nullable Icon icon,
+                                  @Nullable @NonNls String initialValue,
+                                  @Nullable InputValidator validator,
+                                  String @NotNull [] options,
+                                  int defaultOption) {
+            super(project, message, title, icon, initialValue, validator, options, defaultOption);
+        }
+
+        @Override
+        protected JTextComponent createTextFieldComponent() {
+            var area = new JBTextArea(4, 50);
+            area.setLineWrap(true);
+            return area;
+        }
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -133,6 +133,7 @@
 
     <actions>
         <action id="appMapLogin" class="appland.oauth.AppMapLoginAction"/>
+        <action id="appMapLoginByKey" class="appland.oauth.AppMapLoginByKeyAction"/>
         <action id="appMapLogout" class="appland.oauth.AppMapLogoutAction"/>
 
         <action id="showRecentAppmap" class="appland.actions.OpenRecentAppMapAction"/>
@@ -158,6 +159,7 @@
             <separator/>
             <reference ref="appMapLogin"/>
             <reference ref="appMapLogout"/>
+            <reference ref="appMapLoginByKey"/>
 
             <add-to-group group-id="ToolsMenu" anchor="last"/>
         </group>

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -25,6 +25,15 @@ action.uploadAppMap.description=Uploads the current AppMap file to the AppLand s
 action.appMapLogin.text=Sign In To AppMap Server
 action.appMapLogin.description=Open a browser window to authenticate with the AppMap server.
 
+action.appMapLoginByKey.text=Enter License Key
+action.appMapLoginByKey.description=Allows providing a license key without signing in to the AppLand remote server.
+action.appMapLoginByKey.dialog.title=Enter Your AppMap License Key
+action.appMapLoginByKey.dialog.label=License key:
+action.appMapLoginByKey.dialog.validation.invalidKeyError=License key verification failed
+action.appMapLoginByKey.dialog.invalidKeyErrorMessage.title=Sign In To AppMap Server
+action.appMapLoginByKey.dialog.invalidKeyErrorMessage.message=License key verification failed.
+action.appMapLoginByKey.progressTitle=Validating License Key...
+
 action.appMapLogout.text=Sign Out From AppMap Server
 action.appMapLogout.description=Terminate your AppMap session.
 
@@ -110,6 +119,8 @@ notification.appMapFileNotFound.message=Unfortunately, the AppMap file could not
 
 notification.firstAppMap.content=You've created your first AppMap! Congratulations.
 notification.firstAppMap.openAction=View your AppMaps
+
+notification.appMapSignIn.content=Logged into AppMap
 
 statusBar.recording.displayName=AppMap Recording
 statusBar.recording.recordingStatus=Recording...

--- a/plugin-core/src/test/java/appland/oauth/AppMapKeyRemoteValidatorTest.java
+++ b/plugin-core/src/test/java/appland/oauth/AppMapKeyRemoteValidatorTest.java
@@ -1,0 +1,12 @@
+package appland.oauth;
+
+import appland.AppMapBaseTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AppMapKeyRemoteValidatorTest extends AppMapBaseTest {
+    @Test
+    public void invalidKey() {
+        Assert.assertFalse(new AppMapKeyRemoteValidator(getProject()).checkInput("invalid-key"));
+    }
+}

--- a/plugin-core/src/test/java/appland/oauth/AppMapLocalKeyValidatorTest.java
+++ b/plugin-core/src/test/java/appland/oauth/AppMapLocalKeyValidatorTest.java
@@ -1,0 +1,26 @@
+package appland.oauth;
+
+import appland.AppMapBaseTest;
+import com.intellij.util.Base64;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class AppMapLocalKeyValidatorTest extends AppMapBaseTest {
+    @Test
+    public void invalidKey() {
+        var validator = new AppMapLocalKeyValidator();
+        Assert.assertNotNull(validator.getErrorText("invalid-key"));
+        Assert.assertTrue(validator.canClose("invalid-key"));
+        Assert.assertTrue(validator.checkInput("invalid-key"));
+    }
+
+    @Test
+    public void validKey() {
+        var validKey = Base64.encode("user@example.com:unique-id".getBytes(StandardCharsets.UTF_8));
+        var validator = new AppMapKeyRemoteValidator(getProject());
+        Assert.assertFalse(validator.canClose(validKey));
+        Assert.assertFalse(validator.checkInput(validKey));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/506

This PR adds a new action to manually sign into AppMap.
When the license key is modified in the text input box, a quick local validation is performed. It verifies that the base64-decoded key matches `user@host.com:a-license-id`. After confirming the dialog the key is validated with the remote AppLand host. 
The local validation is needed because the input dialog expects it to return quickly. The remote validation is not guaranteed to return quickly because it performing a remote HTTP request.

This PR adds tests. Testing remote validation is only possible with an invalid key because we can't store valid keys in git.

Initial view of input dialog:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/4bc7817e-3367-46c1-aaa7-35d981a217d9)

With invalid key:
![Screenshot_20231211_113030](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/af3c01ab-7732-4b89-b16d-a9aab7bf3671)

After validation with the remote endpoint:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/034f69fc-f44d-449e-b09a-79c330067ad4)

Notification after success:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/87364361-03a6-4e95-b786-059a4603a13e)