### PR TITLE
Fix exception 'Read access is allowed from inside read-action' with 2023.3

### DIFF
--- a/plugin-core/src/main/java/appland/index/AppMapIndexedRootsSetContributor.java
+++ b/plugin-core/src/main/java/appland/index/AppMapIndexedRootsSetContributor.java
@@ -1,5 +1,7 @@
 package appland.index;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.indexing.IndexableSetContributor;
@@ -22,7 +24,10 @@ public class AppMapIndexedRootsSetContributor extends IndexableSetContributor {
 
     @Override
     public @NotNull Set<VirtualFile> getAdditionalProjectRootsToIndex(@NotNull Project project) {
-        // in 2023.2, getAdditionalProjectRootsToIndex is executed in a com.intellij.openapi.application.NonBlockingReadAction
-        return IndexUtil.findAppMapIndexDirectories(project);
+        // in 2023.2, getAdditionalProjectRootsToIndex is executed in a NonBlockingReadAction.
+        // in 2023.3, the ReadAction doesn't seem always available.
+        return ApplicationManager.getApplication().isReadAccessAllowed()
+                ? IndexUtil.findAppMapIndexDirectories(project)
+                : ReadAction.compute(() -> IndexUtil.findAppMapIndexDirectories(project));
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/503
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/507
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/509
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/510
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/511

This PR fixes the required read accerss. It's unclear if the SDK is supposed to handle this or not, but we're safe-guarding it now to work with the changed behavior of 2023.3