### PR TITLE
Build and test against 2023.3 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=213.0
 untilBuild=233.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2021.3.3,IC-233.10527.20
+ideVersionVerifier=IC-2021.3.3,IC-2023.3.2
 
 lombokVersion=1.18.24
 
@@ -15,7 +15,7 @@ ideVersion=IC-2021.3.3
 #ideVersion=IC-2022.3
 #ideVersion=IC-2023.1.1
 #ideVersion=IC-2023.2
-#ideVersion=IC-233.6745.305-EAP-SNAPSHOT
+#ideVersion=IC-2023.3
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=false


### PR DESCRIPTION
This updates the build to run the JetBrains plugin verifier against the final 2023.3 release.

gradle.properties has been updated to refer to the release version, as well. This is most useful during development, e.g. when testing against a later version than the default.