### PR TITLE
Don't pollute project dir with log files of the AppMap Java agent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,6 +165,7 @@ allprojects {
             // attach AppMap agent, but only if Gradle is online
             jvmArgs("-javaagent:$agentOutputPath",
                     "-Dappmap.config.file=${rootProject.file("appmap.yml")}",
+                    "-Dappmap.debug.file=${project.buildDir.resolve("appmap-agent-${System.currentTimeMillis()}.log")}",
                     "-Dappmap.output.directory=${rootProject.file("tmp/appmap")}")
             systemProperty("appmap.test.withAgent", "true")
 


### PR DESCRIPTION
Our tests are executed with the AppMap Java agent attached.
By default, the agent is creating log files in the working directory, which is the project directory in our case.
We're now enforcing that logs are written into the build directory.