### PR TITLE
Serve webview files with built-in HTTP server

### DIFF
--- a/plugin-core/src/main/java/appland/AppMapPlugin.java
+++ b/plugin-core/src/main/java/appland/AppMapPlugin.java
@@ -27,22 +27,6 @@ public final class AppMapPlugin {
         return basePath;
     }
 
-    public static Path getAppMapHTMLPath() {
-        return getPluginPath().resolve("appmap").resolve("index.html");
-    }
-
-    public static Path getInstallGuideHTMLPath() {
-        return getPluginPath().resolve("appland-install-guide").resolve("index.html");
-    }
-
-    public static Path getFindingsAppHTMLPath() {
-        return getPluginPath().resolve("appland-findings").resolve("index.html");
-    }
-
-    public static Path getSignInHTMLPath() {
-        return getPluginPath().resolve("appland-signin").resolve("index.html");
-    }
-
     @NotNull
     public static PluginDescriptor getDescriptor() {
         var plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -1,7 +1,6 @@
 package appland.installGuide;
 
 import appland.AppMapBundle;
-import appland.AppMapPlugin;
 import appland.cli.AppLandCommandLineService;
 import appland.index.AppMapMetadata;
 import appland.index.IndexedFileListenerUtil;
@@ -13,6 +12,7 @@ import appland.settings.AppMapProjectSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.webviews.WebviewEditor;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
+import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -40,7 +40,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.datatransfer.StringSelection;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
     public InstallGuideEditor(@NotNull Project project,
                               @NotNull VirtualFile file,
                               @NotNull InstallGuideViewPage page) {
-        super(project, file, Set.of("click-link", "open-file", "open-page", "open-findings-overview", "clipboard",
+        super(project, AppMapWebview.InstallGuide, file, Set.of("click-link", "open-file", "open-page", "open-findings-overview", "clipboard",
                 "perform-install", "perform-auth", "generate-openapi"));
         this.currentPage = page;
     }
@@ -126,11 +125,6 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
     @Override
     public @Nls(capitalization = Nls.Capitalization.Title) @NotNull String getName() {
         return AppMapBundle.get("installGuide.editor.title");
-    }
-
-    @Override
-    protected @NotNull Path getApplicationFile() {
-        return AppMapPlugin.getInstallGuideHTMLPath();
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/toolwindow/signInView/SignInViewPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/signInView/SignInViewPanel.java
@@ -1,16 +1,17 @@
 package appland.toolwindow.signInView;
 
-import appland.AppMapPlugin;
 import appland.oauth.AppMapLoginAction;
 import appland.toolwindow.AppMapToolWindowContent;
 import appland.utils.GsonUtils;
 import appland.webviews.ConsoleInitMessageHandler;
+import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.JsonObject;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import com.intellij.ui.jcef.JCEFHtmlPanel;
@@ -62,8 +63,9 @@ public class SignInViewPanel extends SimpleToolWindowPanel implements Disposable
         htmlPanel.getJBCefClient().addRequestHandler(new CefRequestHandlerAdapter() {
             @Override
             public boolean onBeforeBrowse(CefBrowser browser, CefFrame frame, CefRequest request, boolean user_gesture, boolean is_redirect) {
-                // disable navigation to / on the file system, which is used by the webview as fallback link
-                if ("file:///".equals(request.getURL())) {
+                // Disable navigation to / of the built-in webserver,
+                // which is used by the webview when "Sign in" is clicked.
+                if (AppMapWebview.getBaseUrl().equals(StringUtil.trimEnd(request.getURL(), "/"))) {
                     return true;
                 }
 
@@ -90,11 +92,11 @@ public class SignInViewPanel extends SimpleToolWindowPanel implements Disposable
         }, htmlPanel.getCefBrowser());
 
         htmlPanel.getJBCefClient().addDisplayHandler(new ConsoleInitMessageHandler(this::initWebView), htmlPanel.getCefBrowser());
-        htmlPanel.loadURL(AppMapPlugin.getSignInHTMLPath().toUri().toURL().toString());
+
+        htmlPanel.loadURL(AppMapWebview.SignIn.getIndexHtmlUrl());
     }
 
     private void initWebView() {
-
         // add handler for messages sent by the JS application
         postMessageQuery.addHandler(request -> {
             try {

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -2,6 +2,7 @@ package appland.webviews;
 
 import appland.AppMapBundle;
 import appland.utils.GsonUtils;
+import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -31,9 +32,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.beans.PropertyChangeListener;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,6 +44,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     private static final Logger LOG = Logger.getInstance(WebviewEditor.class);
 
     protected final @NotNull Project project;
+    protected final @NotNull AppMapWebview webview;
     protected final @NotNull VirtualFile file;
     private final @NotNull Set<String> supportedMessages;
     protected final @NotNull Gson gson;
@@ -56,8 +55,12 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     // queries must be created before the webview is initialized
     private final @NotNull JBCefJSQuery postMessageQuery = JBCefJSQuery.create((JBCefBrowserBase) contentPanel);
 
-    public WebviewEditor(@NotNull Project project, @NotNull VirtualFile file, @NotNull Set<String> supportedMessages) {
+    public WebviewEditor(@NotNull Project project,
+                         @NotNull AppMapWebview webview,
+                         @NotNull VirtualFile file,
+                         @NotNull Set<String> supportedMessages) {
         this.project = project;
+        this.webview = webview;
         this.file = file;
         this.supportedMessages = supportedMessages;
         this.gson = Objects.requireNonNullElse(createCustomizedGson(), GsonUtils.GSON);
@@ -93,11 +96,6 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
      */
     @RequiresBackgroundThread
     protected abstract void afterInit(@Nullable T initData);
-
-    /**
-     * @return {@code java.nio.file.Path} to the HTML file to load into the webview.
-     */
-    protected abstract @NotNull Path getApplicationFile();
 
     /**
      * @throws Exception If an error occurred while handling the message
@@ -191,14 +189,6 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
         return false;
     }
 
-    protected String getBaseUrl() {
-        try {
-            return getApplicationFile().toUri().toURL().toString();
-        } catch (MalformedURLException e) {
-            return "";
-        }
-    }
-
     protected boolean isWebViewReady() {
         return isWebViewReady.get();
     }
@@ -212,11 +202,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     }
 
     private void loadApplication() {
-        try {
-            contentPanel.loadURL(getApplicationFile().toUri().toURL().toString());
-        } catch (IOException e) {
-            LOG.error(e);
-        }
+        contentPanel.loadURL(webview.getIndexHtmlUrl());
     }
 
     private void initWebviewApplication() {

--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapFileEditor.java
@@ -1,14 +1,12 @@
 package appland.webviews.appMap;
 
 import appland.AppMapBundle;
-import appland.AppMapPlugin;
 import appland.files.AppMapFiles;
 import appland.files.FileLocation;
 import appland.files.FileLookup;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.FindingsUtil;
 import appland.problemsView.ResolvedStackLocation;
-import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.settings.AppMapWebViewFilter;
@@ -16,6 +14,7 @@ import appland.telemetry.TelemetryService;
 import appland.upload.AppMapUploader;
 import appland.utils.GsonUtils;
 import appland.webviews.WebviewEditor;
+import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -37,7 +36,6 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -60,7 +58,7 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
     private final AtomicBoolean isModified = new AtomicBoolean(false);
 
     public AppMapFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
-        super(project, file, Set.of("webviewMounted", "uploadAppMap", "clearSelection", "viewSource",
+        super(project, AppMapWebview.AppMap, file, Set.of("webviewMounted", "uploadAppMap", "clearSelection", "viewSource",
                 "sidebarSearchFocused", "clickFilterButton", "clickTab", "selectObjectInSidebar", "resetDiagram",
                 "exportSVG", "saveFilter", "defaultFilter", "deleteFilter"));
         setupVfsListener(file);
@@ -136,11 +134,6 @@ public class AppMapFileEditor extends WebviewEditor<JsonObject> {
                 applyWebViewFilters();
             }
         });
-    }
-
-    @Override
-    protected @NotNull Path getApplicationFile() {
-        return AppMapPlugin.getAppMapHTMLPath();
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
@@ -1,7 +1,6 @@
 package appland.webviews.findingDetails;
 
 import appland.AppMapBundle;
-import appland.AppMapPlugin;
 import appland.files.FileLocation;
 import appland.problemsView.FindingsUtil;
 import appland.problemsView.ResolvedStackLocation;
@@ -10,6 +9,7 @@ import appland.webviews.WebviewEditor;
 import appland.webviews.appMap.AppMapFileEditor;
 import appland.webviews.appMap.AppMapFileEditorState;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
+import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -26,24 +26,18 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Path;
 import java.util.Set;
 
 import static appland.utils.GsonUtils.singlePropertyObject;
 
 public class FindingDetailsEditor extends WebviewEditor<Void> {
     public FindingDetailsEditor(@NotNull Project project, @NotNull VirtualFile file) {
-        super(project, file, Set.of("open-findings-overview", "open-in-source-code", "open-map"));
+        super(project, AppMapWebview.Findings, file, Set.of("open-findings-overview", "open-in-source-code", "open-map"));
     }
 
     @Override
     public @Nls(capitalization = Nls.Capitalization.Title) @NotNull String getName() {
         return AppMapBundle.get("webview.findingDetails.title");
-    }
-
-    @Override
-    protected @NotNull Path getApplicationFile() {
-        return AppMapPlugin.getFindingsAppHTMLPath();
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
@@ -1,13 +1,13 @@
 package appland.webviews.findings;
 
 import appland.AppMapBundle;
-import appland.AppMapPlugin;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.FindingsViewTab;
 import appland.problemsView.model.ScannerFinding;
 import appland.utils.GsonUtils;
 import appland.webviews.WebviewEditor;
 import appland.webviews.findingDetails.FindingDetailsEditorProvider;
+import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
@@ -18,18 +18,12 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 
 public class FindingsOverviewEditor extends WebviewEditor<List<ScannerFinding>> {
     public FindingsOverviewEditor(@NotNull Project project, @NotNull VirtualFile file) {
-        super(project, file, Set.of("open-problems-tab", "open-finding-info"));
-    }
-
-    @Override
-    protected @NotNull Path getApplicationFile() {
-        return AppMapPlugin.getFindingsAppHTMLPath();
+        super(project, AppMapWebview.Findings, file, Set.of("open-problems-tab", "open-finding-info"));
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebview.java
+++ b/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebview.java
@@ -1,0 +1,43 @@
+package appland.webviews.webserver;
+
+import appland.AppMapPlugin;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.builtInWebServer.BuiltInServerOptions;
+
+import java.nio.file.Path;
+
+import static appland.webviews.webserver.AppMapWebviewRequestHandler.APPMAP_SERVER_BASE_PATH;
+
+/**
+ * Webviews available in the AppMap plugin.
+ */
+@RequiredArgsConstructor
+@Getter
+public enum AppMapWebview {
+    AppMap("appmap"),
+    InstallGuide("appland-install-guide"),
+    Findings("appland-findings"),
+    SignIn("appland-signin");
+
+    public static @NotNull String getBaseUrl() {
+        return "http://localhost:" + BuiltInServerOptions.getInstance().getEffectiveBuiltInServerPort();
+    }
+
+    private final @NotNull String webviewAssetsDirectoryName;
+
+    /**
+     * @return Directory on the local filesystem, where this webview's data is stored.
+     */
+    public @NotNull Path getBaseDirPath() {
+        return AppMapPlugin.getPluginPath().resolve(webviewAssetsDirectoryName);
+    }
+
+    /**
+     * @return HTTP URL of the IDE's built-in webserver for this webview's index.html file.
+     */
+    public @NotNull String getIndexHtmlUrl() {
+        return getBaseUrl() + APPMAP_SERVER_BASE_PATH + "/" + webviewAssetsDirectoryName + "/index.html";
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebviewRequestHandler.java
+++ b/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebviewRequestHandler.java
@@ -1,0 +1,65 @@
+package appland.webviews.webserver;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.ide.HttpRequestHandler;
+import org.jetbrains.io.FileResponses;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Request handler to server AppMap's webview files through the IDE's built-in webserver.
+ */
+public class AppMapWebviewRequestHandler extends HttpRequestHandler {
+    static final String APPMAP_SERVER_BASE_PATH = "/_appmap-webviews";
+
+    @Override
+    public boolean process(@NotNull QueryStringDecoder queryStringDecoder,
+                           @NotNull FullHttpRequest fullHttpRequest,
+                           @NotNull ChannelHandlerContext channelHandlerContext) throws IOException {
+        var requestPath = queryStringDecoder.path();
+        if (!requestPath.startsWith(APPMAP_SERVER_BASE_PATH + "/")) {
+            return false;
+        }
+
+        var webviewPath = requestPath.substring(APPMAP_SERVER_BASE_PATH.length() + 1);
+        var slashIndex = webviewPath.indexOf('/');
+        if (slashIndex == -1) {
+            return false;
+        }
+
+        var webviewDirName = webviewPath.substring(0, slashIndex);
+        var relativeFilePath = slashIndex + 1 < webviewPath.length() ? webviewPath.substring(slashIndex + 1) : null;
+        if (relativeFilePath == null) {
+            return false;
+        }
+
+        var localFile = findLocalWebviewFile(webviewDirName, relativeFilePath);
+        if (localFile == null) {
+            return false;
+        }
+
+        FileResponses.INSTANCE.sendFile(fullHttpRequest,
+                channelHandlerContext.channel(),
+                localFile,
+                EmptyHttpHeaders.INSTANCE);
+        return true;
+    }
+
+    private @Nullable Path findLocalWebviewFile(@NotNull String webviewDirName, @NotNull String relativeFilePath) {
+        for (var webview : AppMapWebview.values()) {
+            if (webview.getWebviewAssetsDirectoryName().equals(webviewDirName)) {
+                var baseDirPath = webview.getBaseDirPath();
+                var filePath = baseDirPath.resolve(relativeFilePath).toAbsolutePath().normalize();
+                return filePath.startsWith(baseDirPath) ? filePath : null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -129,6 +129,9 @@
         <!-- OAuth authentication -->
         <httpRequestHandler implementation="appland.oauth.AppMapOAuthRequestHandler"/>
         <applicationService serviceImplementation="appland.oauth.AppMapOAuthService"/>
+
+        <!-- webview requests -->
+        <httpRequestHandler implementation="appland.webviews.webserver.AppMapWebviewRequestHandler"/>
     </extensions>
 
     <actions>

--- a/plugin-core/src/test/java/appland/AppMapPluginTest.java
+++ b/plugin-core/src/test/java/appland/AppMapPluginTest.java
@@ -10,8 +10,5 @@ public class AppMapPluginTest extends LightPlatformCodeInsightFixture4TestCase {
     public void pluginPath() {
         assertNotNull(AppMapPlugin.getPluginPath());
         assertTrue(Files.exists(AppMapPlugin.getPluginPath()));
-
-        assertNotNull(AppMapPlugin.getAppMapHTMLPath());
-        assertTrue(Files.exists(AppMapPlugin.getAppMapHTMLPath()));
     }
 }

--- a/plugin-core/src/test/java/appland/webviews/webserver/AppMapWebviewTest.java
+++ b/plugin-core/src/test/java/appland/webviews/webserver/AppMapWebviewTest.java
@@ -1,0 +1,42 @@
+package appland.webviews.webserver;
+
+import appland.AppMapBaseTest;
+import com.intellij.util.io.HttpRequests;
+import org.jetbrains.builtInWebServer.BuiltInServerOptions;
+import org.jetbrains.ide.BuiltInServerManager;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AppMapWebviewTest extends AppMapBaseTest {
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
+    @Test
+    public void baseUrl() {
+        var port = BuiltInServerOptions.getInstance().getEffectiveBuiltInServerPort();
+        var baseUrl = AppMapWebview.getBaseUrl();
+        assertEquals("The base URL must not contain a trailing slash", "http://localhost:" + port, baseUrl);
+    }
+
+    @Test
+    public void webviewUrl() {
+        var port = BuiltInServerOptions.getInstance().getEffectiveBuiltInServerPort();
+        assertEquals("A webview base URL must not contain a double slash",
+                "http://localhost:" + port + "/_appmap-webviews/appland-signin/index.html",
+                AppMapWebview.SignIn.getIndexHtmlUrl());
+    }
+
+    @Test
+    public void webViewIndexHtmlUrls() throws IOException {
+        var serverManager = BuiltInServerManager.getInstance();
+        serverManager.waitForStart();
+
+        for (var webview : AppMapWebview.values()) {
+            // throws an exception if the URL is unavailable
+            HttpRequests.request(webview.getIndexHtmlUrl()).readString();
+        }
+    }
+}


### PR DESCRIPTION
Preparation for https://github.com/getappmap/appmap-intellij-plugin/issues/533

Webviews, which interact with http:// or https:// urls, can't be served from a local `file://` URL because it would be incapable of sending preflight requests with a valid `origin` request header. A JCEF webview has to be served from a http:// URLs to support this.

This PR refactors the webview URL handling and also adds tests to ensure that the IDE's built-in webserver is properly serving the index.html files of all our webviews.