### PR TITLE
Refactor to control reuse of opened webview editors

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/WebviewEditorIconProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditorIconProvider.java
@@ -19,14 +19,9 @@ public class WebviewEditorIconProvider implements FileIconProvider {
             return Icons.APPMAP_FILE_SMALL;
         }
 
-        // special handling for the install guide webview until we've migrated it to WebviewEditorProvider
-        if (InstallGuideEditorProvider.isInstallGuideFile(file)) {
-            return Icons.APPMAP_FILE_SMALL;
-        }
-
         var editorProviderId = WebviewEditorProvider.WEBVIEW_EDITOR_KEY.get(file);
         if (editorProviderId != null) {
-            // we can't use FileEditorProviderManager.getInstance().getProvider(editorProviderId)
+            // We can't use FileEditorProviderManager.getInstance().getProvider(editorProviderId)
             // because it turned from class to interface in 2023.1.
             // Using it would raise an error with plugin verifier.
 


### PR DESCRIPTION
Preparation for https://github.com/getappmap/appmap-intellij-plugin/issues/533

Prepares for the Navie webview and cleans up a long-standing issue, that we were not fully implementing a WebViewEditorProvider for our Install Guide.

The code to focus on an already open, compatbiel webview editor is now reused in a better way.