### PR TITLE
Enable JSON-RPC of AppMap indexer and pass API key

### DIFF
--- a/plugin-core/src/main/java/appland/cli/AppLandCommandLineListener.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandCommandLineListener.java
@@ -2,6 +2,7 @@ package appland.cli;
 
 import com.intellij.util.messages.Topic;
 
+@FunctionalInterface
 public interface AppLandCommandLineListener {
     Topic<AppLandCommandLineListener> TOPIC = Topic.create("appland.cli", AppLandCommandLineListener.class);
 

--- a/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
@@ -59,6 +59,13 @@ public interface AppLandCommandLineService extends Disposable {
     @NotNull List<VirtualFile> getActiveRoots();
 
     /**
+     * @param contextFile Context file to locate the matching indexer service.
+     * @return The port, where the indexer process is serving for JSON-RPC requests.
+     * {@code null} is returned if there's no matching indexer process or if the indexer did not yet launch its JSON-RPC server.
+     */
+    @Nullable Integer getIndexerRpcPort(@NotNull VirtualFile contextFile);
+
+    /**
      * Stop all processes.
      *
      * @param waitForTermination Wait for process termination. This is mostly useful for test cases.

--- a/plugin-core/src/main/java/appland/cli/AppLandIndexerJsonRpcListener.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandIndexerJsonRpcListener.java
@@ -1,0 +1,16 @@
+package appland.cli;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Notifies when the JSON-RPC service of an AppMap indexer is available.
+ */
+@FunctionalInterface
+public interface AppLandIndexerJsonRpcListener {
+    @Topic.AppLevel
+    Topic<AppLandIndexerJsonRpcListener> TOPIC = Topic.create("appland.indexer.jsonRpc", AppLandIndexerJsonRpcListener.class);
+
+    void indexerServiceAvailable(@NotNull VirtualFile directory);
+}


### PR DESCRIPTION
Part of https://github.com/getappmap/appmap-intellij-plugin/issues/533

This PR updates the command line service to add `--port 0` for the indexer command and updates a new property with the port retrieved from the indexer's STDOUT.
An existing AppMap API key is passed as environment variable to both indexer and scanner.