### PR TITLE
Registry key to open webview console

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.UserDataHolderBase;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
@@ -203,6 +204,10 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
 
     private void loadApplication() {
         contentPanel.loadURL(webview.getIndexHtmlUrl());
+
+        if (Registry.is("appmap.webview.open.dev.tools", false)) {
+            ApplicationManager.getApplication().invokeLater(this::openDevTools);
+        }
     }
 
     private void initWebviewApplication() {

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -132,6 +132,11 @@
 
         <!-- webview requests -->
         <httpRequestHandler implementation="appland.webviews.webserver.AppMapWebviewRequestHandler"/>
+
+        <!-- Registry keys -->
+        <registryKey key="appmap.webview.open.dev.tools"
+                     defaultValue="false"
+                     description="Open the developer console for AppMap webviews."/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
This helps during development to quickly locate errors or warnings in our webviews. It's disabled by default.

To enable webviews:
- `Help > Find Action... > Registry`
- Type "appmap"
- Enable option `appmap.webview.open.dev.tools`
- The developer console is now automatically shown when you open a new AppMap webview