### PR TITLE
Add auth token to AppMap webview requests

### DIFF
--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -10,6 +10,7 @@ import appland.oauth.AppMapLoginAction;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.settings.AppMapSettingsListener;
+import appland.webviews.OpenExternalLinksHandler;
 import appland.webviews.WebviewEditor;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
 import appland.webviews.webserver.AppMapWebview;
@@ -236,7 +237,7 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
 
     private void handleMessageClickLink(@NotNull JsonObject message) {
         if (message.has("uri")) {
-            openExternalLink(message.getAsJsonPrimitive("uri").getAsString());
+            OpenExternalLinksHandler.openExternalLink(message.getAsJsonPrimitive("uri").getAsString());
         }
     }
 

--- a/plugin-core/src/main/java/appland/toolwindow/signInView/SignInViewPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/signInView/SignInViewPanel.java
@@ -4,6 +4,7 @@ import appland.oauth.AppMapLoginAction;
 import appland.toolwindow.AppMapToolWindowContent;
 import appland.utils.GsonUtils;
 import appland.webviews.ConsoleInitMessageHandler;
+import appland.webviews.OpenExternalLinksHandler;
 import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.JsonObject;
 import com.intellij.ide.BrowserUtil;
@@ -60,22 +61,13 @@ public class SignInViewPanel extends SimpleToolWindowPanel implements Disposable
     }
 
     private void loadWebView() throws MalformedURLException {
+        htmlPanel.getJBCefClient().addRequestHandler(new OpenExternalLinksHandler(), htmlPanel.getCefBrowser());
+
+        // Disable navigation to / of the built-in webserver, which is used by the webview when "Sign in" is clicked.
         htmlPanel.getJBCefClient().addRequestHandler(new CefRequestHandlerAdapter() {
             @Override
             public boolean onBeforeBrowse(CefBrowser browser, CefFrame frame, CefRequest request, boolean user_gesture, boolean is_redirect) {
-                // Disable navigation to / of the built-in webserver,
-                // which is used by the webview when "Sign in" is clicked.
-                if (AppMapWebview.getBaseUrl().equals(StringUtil.trimEnd(request.getURL(), "/"))) {
-                    return true;
-                }
-
-                // open link in the external browser
-                if (user_gesture) {
-                    BrowserUtil.browse(request.getURL());
-                    return true;
-                }
-
-                return false;
+                return AppMapWebview.getBaseUrl().equals(StringUtil.trimEnd(request.getURL(), "/"));
             }
         }, htmlPanel.getCefBrowser());
 

--- a/plugin-core/src/main/java/appland/webviews/OpenExternalLinksHandler.java
+++ b/plugin-core/src/main/java/appland/webviews/OpenExternalLinksHandler.java
@@ -1,0 +1,59 @@
+package appland.webviews;
+
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.Urls;
+import com.intellij.util.io.URLUtil;
+import org.cef.browser.CefBrowser;
+import org.cef.browser.CefFrame;
+import org.cef.handler.CefRequestHandlerAdapter;
+import org.cef.network.CefRequest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Request handler to open external links a user clicked on in the system's native browser.
+ */
+public class OpenExternalLinksHandler extends CefRequestHandlerAdapter {
+    @Override
+    public boolean onBeforeBrowse(CefBrowser browser,
+                                  CefFrame frame,
+                                  CefRequest request,
+                                  boolean user_gesture,
+                                  boolean is_redirect) {
+        // JavaDoc says: "True to cancel the navigation or false to continue."
+        return user_gesture && openExternalLink(request.getURL());
+    }
+
+    /**
+     * Open the given URL in an external browser if it's a http:// or https:// link.
+     *
+     * @param url URL to open
+     * @return {@code true} if the link was opened in an external window.
+     */
+    public static boolean openExternalLink(@Nullable String url) {
+        if (url != null && isExternalUrl(url)) {
+            BrowserUtil.browse(url);
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isExternalUrl(@NotNull String url) {
+        var parsed = Urls.parseEncoded(url);
+        if (parsed == null) {
+            return false;
+        }
+
+        var scheme = parsed.getScheme();
+        var host = parsed.getAuthority();
+        host = host != null && host.contains(":") ? host.substring(0, host.indexOf(':')) : host;
+
+        var isValidProtocol = URLUtil.HTTP_PROTOCOL.equalsIgnoreCase(scheme)
+                || URLUtil.HTTPS_PROTOCOL.equalsIgnoreCase(scheme)
+                || "mailto".equalsIgnoreCase(scheme);
+        var isValidHost = !StringUtil.equalsIgnoreCase(host, "localhost")
+                && !StringUtil.equalsIgnoreCase(host, "127.0.0.1");
+        return isValidProtocol && isValidHost;
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -3,10 +3,10 @@ package appland.webviews;
 import appland.AppMapBundle;
 import appland.utils.GsonUtils;
 import appland.webviews.webserver.AppMapWebview;
+import appland.webviews.webserver.WebviewAuthTokenRequestHandler;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditor;
@@ -178,6 +178,8 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     private void setupJCEF() {
         // open links to https://appmap.io in the external browser
         contentPanel.getJBCefClient().addRequestHandler(new OpenExternalLinksHandler(), contentPanel.getCefBrowser());
+        // add auth tokens to our localhost requests
+        contentPanel.getJBCefClient().addRequestHandler(new WebviewAuthTokenRequestHandler(), contentPanel.getCefBrowser());
 
         contentPanel.setErrorPage(new DefaultWebviewErrorPage(navigating));
         contentPanel.getJBCefClient().addDisplayHandler(new ConsoleInitMessageHandler(this::initWebviewApplication), contentPanel.getCefBrowser());

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -24,10 +24,6 @@ import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import com.intellij.ui.jcef.JCEFHtmlPanel;
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
-import org.cef.browser.CefBrowser;
-import org.cef.browser.CefFrame;
-import org.cef.handler.CefRequestHandlerAdapter;
-import org.cef.network.CefRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -175,21 +171,6 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
         contentPanel.getCefBrowser().executeJavaScript("window.postMessage(" + gson.toJson(json) + ")", "", 0);
     }
 
-    /**
-     * Open the given URL in an external browser if it's a http:// or https:// link.
-     *
-     * @param url URL to open
-     * @return {@code true} if the link was opened in an external window.
-     */
-    protected boolean openExternalLink(@Nullable String url) {
-        if (url != null && (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("mailto:"))) {
-            navigating.set(true);
-            BrowserUtil.browse(url);
-            return true;
-        }
-        return false;
-    }
-
     protected boolean isWebViewReady() {
         return isWebViewReady.get();
     }
@@ -265,16 +246,5 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     private String createCallbackJS(JBCefJSQuery query, @NotNull String functionName) {
         return "if (!window.AppLand) window.AppLand={}; window.AppLand." + functionName + "=function(name) {" +
                 query.inject("name") + "};";
-    }
-
-    private class OpenExternalLinksHandler extends CefRequestHandlerAdapter {
-        @Override
-        public boolean onBeforeBrowse(CefBrowser browser,
-                                      CefFrame frame,
-                                      CefRequest request,
-                                      boolean user_gesture,
-                                      boolean is_redirect) {
-            return user_gesture && openExternalLink(request.getURL());
-        }
     }
 }

--- a/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebview.java
+++ b/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebview.java
@@ -26,6 +26,10 @@ public enum AppMapWebview {
         return "http://localhost:" + BuiltInServerOptions.getInstance().getEffectiveBuiltInServerPort();
     }
 
+    public static @NotNull String getBaseUrlWithPath() {
+        return getBaseUrl() + APPMAP_SERVER_BASE_PATH;
+    }
+
     private final @NotNull String webviewAssetsDirectoryName;
 
     /**
@@ -39,6 +43,6 @@ public enum AppMapWebview {
      * @return HTTP URL of the IDE's built-in webserver for this webview's index.html file.
      */
     public @NotNull String getIndexHtmlUrl() {
-        return getBaseUrl() + APPMAP_SERVER_BASE_PATH + "/" + webviewAssetsDirectoryName + "/index.html";
+        return getBaseUrlWithPath() + "/" + webviewAssetsDirectoryName + "/index.html";
     }
 }

--- a/plugin-core/src/main/java/appland/webviews/webserver/WebviewAuthTokenRequestHandler.java
+++ b/plugin-core/src/main/java/appland/webviews/webserver/WebviewAuthTokenRequestHandler.java
@@ -1,0 +1,58 @@
+package appland.webviews.webserver;
+
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.Urls;
+import org.cef.browser.CefBrowser;
+import org.cef.browser.CefFrame;
+import org.cef.handler.CefRequestHandlerAdapter;
+import org.cef.handler.CefResourceRequestHandler;
+import org.cef.handler.CefResourceRequestHandlerAdapter;
+import org.cef.misc.BoolRef;
+import org.cef.network.CefRequest;
+import org.jetbrains.builtInWebServer.BuiltInWebServerKt;
+import org.jetbrains.ide.BuiltInServerManager;
+
+/**
+ * Adds auth tokens to requests to webview resources to bypass any filtering of the built-in webserver.
+ * Without auth tokens the IDE's built-in webserver only accepts URLs prefixed with a project name.
+ */
+public final class WebviewAuthTokenRequestHandler extends CefRequestHandlerAdapter {
+    @Override
+    public CefResourceRequestHandler getResourceRequestHandler(CefBrowser browser,
+                                                               CefFrame frame,
+                                                               CefRequest request,
+                                                               boolean isNavigation,
+                                                               boolean isDownload,
+                                                               String requestInitiator,
+                                                               BoolRef disableDefaultHandling) {
+
+        if (isUnsignedWebViewRequest(request)) {
+            return new CefResourceRequestHandlerAdapter() {
+                @Override
+                public boolean onBeforeResourceLoad(CefBrowser browser, CefFrame frame, CefRequest request) {
+                    var url = Urls.parseEncoded(request.getURL());
+                    if (url != null) {
+                        request.setURL(BuiltInServerManager.getInstance().addAuthToken(url).toExternalForm());
+                    }
+
+                    // false to continue with the request
+                    return false;
+                }
+            };
+        }
+
+        // fallback to default handling of JCEF
+        return null;
+    }
+
+    /**
+     * @return true if the request is for a webview asset, but not yet signed with an auth token
+     */
+    private static boolean isUnsignedWebViewRequest(CefRequest request) {
+        var url = Urls.parseEncoded(request.getURL());
+        var params = StringUtil.defaultIfEmpty(url != null ? url.getParameters() : null, "");
+        return request.getURL().startsWith(AppMapWebview.getBaseUrlWithPath())
+                && !params.contains("?" + BuiltInWebServerKt.TOKEN_PARAM_NAME + "=")
+                && !params.contains("&" + BuiltInWebServerKt.TOKEN_PARAM_NAME + "=");
+    }
+}

--- a/plugin-core/src/test/java/appland/webviews/OpenExternalLinksHandlerTest.java
+++ b/plugin-core/src/test/java/appland/webviews/OpenExternalLinksHandlerTest.java
@@ -1,0 +1,32 @@
+package appland.webviews;
+
+import appland.AppMapBaseTest;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static appland.webviews.OpenExternalLinksHandler.isExternalUrl;
+
+public class OpenExternalLinksHandlerTest extends AppMapBaseTest {
+    @Test
+    public void isExternalUrlTest() {
+        var testData = Map.of(
+                // external
+                "http://example.com", true,
+                "https://example.com", true,
+                // not external
+                "http://localhost", false,
+                "https://127.0.0.1", false
+        );
+
+        testData.forEach((url, isExternal) -> {
+            assertEquals(isExternal.booleanValue(), isExternalUrl(url));
+            assertEquals(isExternal.booleanValue(), isExternalUrl(url + ":1234"));
+            assertEquals(isExternal.booleanValue(), isExternalUrl(url + ":1234/index.html"));
+            assertEquals(isExternal.booleanValue(), isExternalUrl(url + ":1234/index.html?param=value"));
+            assertEquals(isExternal.booleanValue(), isExternalUrl(url + ":1234/index.html?param=value#anchor"));
+        });
+
+        assertFalse(isExternalUrl("file:///home/user/test.html"));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/549

A recent changed made use of the IDE's built-in webserver to server html and css for our webviews.
More recent versions of the IDEs validate requests and reject requests, which don't have an auth token query parameter and which don't have the a project name in the path. 
We're now hooking into the webview to enrich requests to our http://localhost:.../ AppMap urls with an auth token.

The alternative would be to launch and manage our own, built-in HTTP server to server webview assets.