### PR TITLE
Improve loading of AppMaps in AppMap tool window

### DIFF
--- a/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/RootNode.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/nodes/RootNode.java
@@ -77,11 +77,14 @@ public class RootNode extends Node {
     }
 
     @RequiresBackgroundThread
-    private List<AppMapMetadata> getCachedAppMaps() {
+    private @NotNull List<AppMapMetadata> getCachedAppMaps() {
         if (needAppMapRefresh.compareAndSet(true, false)) {
             cachedAppMaps.set(loadAppMaps());
         }
-        return cachedAppMaps.get();
+
+        // a null value is possible for concurrent calls to this method
+        var result = cachedAppMaps.get();
+        return result == null ? Collections.emptyList() : result;
     }
 
     private List<AppMapMetadata> loadAppMaps() {


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/541

- Fixes a NullPointerException I got when testing the plugin
- Fixes the exception about slow operations when loading AppMaps. It must have been thrown when status of the "Delete All AppMaps" action is updated. I was unable to reproduce, though. But the stacktrace was clear enough.
- Fixes a minor issue with nested ReadActions.

I don't think that manual QA testing is needed for this. @ahtrotta it would be great if you tested this on your machine.