### PR TITLE
Support JetBrains 2024.1 EAP releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 pluginVersion=0.50.0
 
 sinceBuild=213.0
-untilBuild=233.*
+untilBuild=241.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2021.3.3,IC-2023.3.2
+ideVersionVerifier=IC-2021.3.3,IC-2023.3.2,IC-241.10840.26
 
 lombokVersion=1.18.24
 
@@ -16,6 +16,7 @@ ideVersion=IC-2021.3.3
 #ideVersion=IC-2023.1.1
 #ideVersion=IC-2023.2
 #ideVersion=IC-2023.3.2
+#ideVersion=IC-241.10840.26-EAP-SNAPSHOT
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=false


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/535

This adds compatibility with 2024.1 eap. Compilation did not show problems and all tests passed.
I'm waiting for 2024.1 eap3 to be fully published before making this PR available for review.