### PR TITLE
Retrieve Gradle JDK in a background thread

### DIFF
--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -170,6 +170,7 @@ appMapExecutor.verifyingJDK=Verifying JDK...
 appMapExecutor.jdkNotSupportedWithLink=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry. <a href="">Configure</a>
 appMapExecutor.jdkNotSupported=AppMap supports Java versions 8, 11, and 17. Please switch to a compatible version of Java and retry.
 appMapExecutor.executionError.message=Unable to execute the run configuration: {0}.
+appMapExecutor.validatingGradleJDK=Validating Gradle JDK...
 
 annotator.quickFixFamily=AppMap
 annotator.openQuickFix.name=Open in AppMap file

--- a/plugin-gradle/src/main/java/appland/execution/AppMapGradleAgentRunner.java
+++ b/plugin-gradle/src/main/java/appland/execution/AppMapGradleAgentRunner.java
@@ -1,5 +1,6 @@
 package appland.execution;
 
+import appland.AppMapBundle;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunnerSettings;
@@ -8,9 +9,14 @@ import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration;
 import org.jetbrains.plugins.gradle.settings.GradleSettings;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
@@ -44,14 +50,40 @@ public class AppMapGradleAgentRunner implements ProgramRunner<RunnerSettings> {
     private static void verifyJdk(@NotNull ExecutionEnvironment environment) throws ExecutionException {
         var manager = ExternalSystemApiUtil.getManager(GradleConstants.SYSTEM_ID);
         if (manager != null) {
+            var project = environment.getProject();
             var gradleProjectPath = ((GradleRunConfiguration) environment.getRunProfile()).getSettings().getExternalProjectPath();
-            var gradleProjectSettings = GradleSettings.getInstance(environment.getProject()).getLinkedProjectSettings(gradleProjectPath);
+            var gradleProjectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(gradleProjectPath);
             if (gradleProjectSettings != null) {
-                var jdk = ExternalSystemJdkUtil.getJdk(environment.getProject(), gradleProjectSettings.getGradleJvm());
+                var jdk = getGradleSdkWithProgress(project, gradleProjectSettings.getGradleJvm());
                 if (jdk != null) {
-                    AppMapJvmExecutor.verifyJDK(environment.getProject(), jdk);
+                    AppMapJvmExecutor.verifyJDK(project, jdk);
                 }
             }
+        }
+    }
+
+    /**
+     * Because @{link {@link ExternalSystemJdkUtil#getJdk(Project, String)}} is a SlowOperation in 2023.2,
+     * we need to move this into a background thread.
+     * Refer to https://github.com/getappmap/appmap-intellij-plugin/issues/566 for a stacktrace.
+     *
+     * @return The Gradle JVM SDK, if available.
+     */
+    private static @Nullable Sdk getGradleSdkWithProgress(@NotNull Project project,
+                                                          @Nullable String gradleJvmName) {
+        var title = AppMapBundle.get("appMapExecutor.validatingGradleJDK");
+        var task = new Task.WithResult<Sdk, Exception>(project, title, true) {
+            @Override
+            protected Sdk compute(@NotNull ProgressIndicator indicator) {
+                return ExternalSystemJdkUtil.getJdk(project, gradleJvmName);
+            }
+        };
+        task.queue();
+
+        try {
+            return task.getResult();
+        } catch (Exception e) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/566

The issue contains instructions how to reproduce.
The retrieval of the Gradle JDK became a "slow operation" in 2023.2 and we must not fetch it on the UI dispatch thread (i.e. the EDT).