### PR TITLE
Exception "java.lang.IllegalArgumentException: invalid hex byte"

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebviewRequestHandler.java
+++ b/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebviewRequestHandler.java
@@ -22,7 +22,14 @@ public class AppMapWebviewRequestHandler extends HttpRequestHandler {
     public boolean process(@NotNull QueryStringDecoder queryStringDecoder,
                            @NotNull FullHttpRequest fullHttpRequest,
                            @NotNull ChannelHandlerContext channelHandlerContext) throws IOException {
-        var requestPath = queryStringDecoder.path();
+        String requestPath;
+        try {
+            requestPath = queryStringDecoder.path();
+        } catch (IllegalArgumentException e) {
+            // https://github.com/getappmap/appmap-intellij-plugin/issues/579, for example
+            return false;
+        }
+
         if (!requestPath.startsWith(APPMAP_SERVER_BASE_PATH + "/")) {
             return false;
         }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/579

The preview JetBrains Markdown is opening URLs, which don't work with `path()`.
Our request handler is only suitable for our own URLs, so we can safely skip URLs we're unable to parse.