### PR TITLE
Fix flaky Windows CI

### DIFF
--- a/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandCommandLineService.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public interface AppLandCommandLineService extends Disposable {
     static @NotNull AppLandCommandLineService getInstance() {
@@ -75,6 +76,14 @@ public interface AppLandCommandLineService extends Disposable {
      * @param waitForTermination Wait for process termination. This is mostly useful for test cases.
      */
     void stopAll(boolean waitForTermination);
+
+    /**
+     * Stop all processes.
+     *
+     * @param timeout Length of timeout to wait for process termination. 0 disables the waiting for termination.
+     * @param timeUnit Unit of timeout.
+     */
+    void stopAll(int timeout, @NotNull TimeUnit timeUnit);
 
     /**
      * Creates the command line to install AppMap in the given directory.

--- a/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
+++ b/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
@@ -12,6 +12,8 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.testFramework.EdtTestUtil;
 import com.intellij.testFramework.JavaPsiTestCase;
 
+import java.util.concurrent.TimeUnit;
+
 public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
     @Override
     protected void setUp() throws Exception {
@@ -29,7 +31,7 @@ public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
     @Override
     protected void tearDown() throws Exception {
         try {
-            AppLandCommandLineService.getInstance().stopAll(true);
+            AppLandCommandLineService.getInstance().stopAll(10_000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             addSuppressedException(e);
         } finally {


### PR DESCRIPTION
This fixes our flaky tests on the Windows runner of GitHub Actions.
The problem was an incorrect shutdown or the AppLand processes launched by tests. The first shutdown attempt cleared the processes and only waited for 1.0s, which isn't enough for slow Windows CI. The next shutdown attempts only got the empty list of processes and stopped early.

This PR updates the shutdown timeout to 10s and passes it into the service implementation handling the shutdown instead of attempting to be clever with several (incorrect) attempts.