### PR TITLE
Notify user if Navie isn't fully functional

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -5,25 +5,30 @@ import appland.Icons;
 import appland.cli.AppLandCommandLineService;
 import appland.notifications.AppMapNotifications;
 import appland.webviews.WebviewEditorProvider;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.ui.popup.PopupStep;
 import com.intellij.openapi.ui.popup.util.BaseListPopupStep;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -71,6 +76,12 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
             KEY_CODE_SELECTION.set(file, codeSelection);
 
             FileEditorManager.getInstance(project).openFile(file, true);
+
+            var hideMessagePropertyKey = "appmap.navie.hideIsBrokenMessage";
+            var properties = PropertiesComponent.getInstance();
+            if (isNavieWebviewSupportBroken() && !properties.getBoolean(hideMessagePropertyKey, false)) {
+                showNavieWebviewBrokenMessage(project, properties, hideMessagePropertyKey);
+            }
         });
     }
 
@@ -150,5 +161,36 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
     @FunctionalInterface
     private interface ShowNavieConsumer {
         void openNavie(@Nullable Integer indexerPort, @Nullable NavieCodeSelection codeSelection);
+    }
+
+    private static boolean isNavieWebviewSupportBroken() {
+        var buildBaseline = ApplicationInfo.getInstance().getBuild().getBaselineVersion();
+
+        // Linux <= 2023.1 is broken,
+        // https://youtrack.jetbrains.com/issue/JBR-5348/JCEF-OSR-Keyboard-doesnt-work-on-Linux
+        if (SystemInfo.isLinux && buildBaseline <= 231) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @SuppressWarnings("removal")
+    private static void showNavieWebviewBrokenMessage(@NotNull Project project, PropertiesComponent properties, String hideMessagePropertyKey) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Messages.showDialog(project,
+                    AppMapBundle.get("webview.navie.webviewBroken.message"),
+                    AppMapBundle.get("webview.navie.webviewBroken.title"),
+                    new String[]{Messages.getOkButton()},
+                    0,
+                    Messages.getWarningIcon(),
+                    // already deprecated in 2022.1, but there's no alternative API in Messages.
+                    new DialogWrapper.DoNotAskOption.Adapter() {
+                        @Override
+                        public void rememberChoice(boolean isSelected, int exitCode) {
+                            properties.setValue(hideMessagePropertyKey, isSelected, false);
+                        }
+                    });
+        }, ModalityState.any());
     }
 }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -197,6 +197,8 @@ webview.findingDetails.appMapNotFound.message=The AppMap file could not be found
 
 webview.navie.title=AppMap AI: Explain
 webview.navie.chooseAppMapModule.title=Choose AppMap module
+webview.navie.webviewBroken.title=AppMap Navie
+webview.navie.webviewBroken.message=Your IDE has a known issue that typing into text input fields in the Navie is broken.\nPlease update to 2023.2 or later to fix this.
 
 codeObjects.codeTopLevel.label=Code
 codeObjects.navigation.locatingFiles=Locating AppMaps....

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -198,7 +198,7 @@ webview.findingDetails.appMapNotFound.message=The AppMap file could not be found
 webview.navie.title=AppMap AI: Explain
 webview.navie.chooseAppMapModule.title=Choose AppMap module
 webview.navie.webviewBroken.title=AppMap Navie
-webview.navie.webviewBroken.message=Your IDE has a known issue that typing into text input fields in the Navie is broken.\nPlease update to 2023.2 or later to fix this.
+webview.navie.webviewBroken.message=Please update your IDE to version 2023.2 or later.\nNavie will not work with versions prior to 2023.2 because there is an IDE issue that prevents typing into input fields.
 
 codeObjects.codeTopLevel.label=Code
 codeObjects.navigation.locatingFiles=Locating AppMaps....


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/571

If the current IDE's webview JCEF isn't suitable for Navie, then show a notification to ask the user to update. If the user chose "don't show again", then the message is never shown again in any of the user's projects.

We're showing the message on top of the Navie editor tab, but because JCEF rendering is async the message is shown before the webview is fully visible.
If this is a problem, we could inject the message more deeply into the editor, e.g. when the webview's message that it's ready is received.

![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/dd6913ff-4c07-4c1f-bcdd-a0ad39b6e8c2)
