### PR TITLE
Wait longer for AppMap process shutdown in Windows tests

### DIFF
--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -51,7 +51,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     @Override
     protected void tearDown() throws Exception {
         try {
-            AppLandCommandLineService.getInstance().stopAll(true);
+            AppLandCommandLineService.getInstance().stopAll(10_000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             addSuppressedException(e);
         } finally {
@@ -147,7 +147,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
         assertActiveRoots(dirA, dirB);
 
-        service.stopAll(true);
+        service.stopAll(10_000, TimeUnit.MILLISECONDS);
 
         var debugInfo = service.toString();
         assertFalse("No services expected for parentA: " + debugInfo, service.isRunning(dirA, true));


### PR DESCRIPTION
CI failed on `develop`: https://github.com/getappmap/appmap-intellij-plugin/actions/runs/8116975781/job/22188160161

This PR is extending the timeout for process shutdown in our tests. It's using the new method added by #594 