### PR TITLE
Update actions to avoid exception "ActionUpdateThread.OLD_EDT is deprecated and going to be removed soon." with 2024.1 eap

### DIFF
--- a/plugin-core/src/main/java/appland/actions/AppMapDocumentationAction.java
+++ b/plugin-core/src/main/java/appland/actions/AppMapDocumentationAction.java
@@ -4,12 +4,13 @@ import appland.Icons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
-public class AppMapDocumentationAction extends AnAction implements DumbAware {
+public class AppMapDocumentationAction extends AnAction implements DumbAware, UpdateInBackground {
     public AppMapDocumentationAction() {
         super(Icons.APPMAP_DOCS);
     }

--- a/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
+++ b/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
@@ -9,6 +9,7 @@ import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.ide.actions.OpenInRightSplitAction;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Generates an OpenAPI file using the CLI tool.
  */
-public class GenerateOpenApiAction extends AnAction implements DumbAware {
+public class GenerateOpenApiAction extends AnAction implements DumbAware, UpdateInBackground {
     private static final Logger LOG = Logger.getInstance(GenerateOpenApiAction.class);
     private static final String APPMAP_OPENAPI_FILENAME = "appmap-openapi.yml";
 

--- a/plugin-core/src/main/java/appland/actions/OpenAppMapNavieAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenAppMapNavieAction.java
@@ -3,6 +3,7 @@ package appland.actions;
 import appland.webviews.navie.NavieEditorProvider;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
  * Action to open the AppMap Navie webview.
  */
 @SuppressWarnings("ComponentNotRegistered")
-public class OpenAppMapNavieAction extends AnAction implements DumbAware {
+public class OpenAppMapNavieAction extends AnAction implements DumbAware, UpdateInBackground {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         var project = e.getProject();

--- a/plugin-core/src/main/java/appland/actions/OpenInstallGuideAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenInstallGuideAction.java
@@ -4,11 +4,13 @@ import appland.installGuide.InstallGuideEditorProvider;
 import appland.installGuide.InstallGuideViewPage;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
+import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class OpenInstallGuideAction extends AnAction {
+public class OpenInstallGuideAction extends AnAction implements DumbAware, UpdateInBackground {
     @Override
     public void update(@NotNull AnActionEvent e) {
         e.getPresentation().setEnabled(InstallGuideEditorProvider.isSupported());

--- a/plugin-core/src/main/java/appland/actions/OpenRecentAppMapAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenRecentAppMapAction.java
@@ -4,6 +4,7 @@ import appland.AppMapBundle;
 import appland.index.AppMapSearchScopes;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.ui.Messages;
@@ -18,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
  * If two files have the same modification timestamp, then the returned file is randomly chosen,
  * depending on the order in the index.
  */
-public class OpenRecentAppMapAction extends AnAction {
+public class OpenRecentAppMapAction extends AnAction implements UpdateInBackground {
     private static final Logger LOG = Logger.getInstance("#appmap.action");
 
     static VirtualFile findMostRecentlyModifiedAppMap(com.intellij.openapi.project.Project project) {

--- a/plugin-core/src/main/java/appland/actions/StartAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StartAppMapRecordingAction.java
@@ -8,6 +8,7 @@ import appland.remote.StartRemoteRecordingDialog;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbAware;
@@ -15,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 
 import static appland.AppMapBundle.get;
 
-public class StartAppMapRecordingAction extends AnAction implements DumbAware {
+public class StartAppMapRecordingAction extends AnAction implements DumbAware, UpdateInBackground {
     public StartAppMapRecordingAction() {
         super(Icons.START_RECORDING_ACTION);
     }

--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -10,6 +10,7 @@ import appland.settings.AppMapProjectSettingsService;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.ReadAction;
@@ -33,7 +34,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class StopAppMapRecordingAction extends AnAction implements DumbAware {
+public class StopAppMapRecordingAction extends AnAction implements DumbAware, UpdateInBackground {
     private static final Logger LOG = Logger.getInstance(StopAppMapRecordingAction.class);
 
     public StopAppMapRecordingAction() {

--- a/plugin-core/src/main/java/appland/actions/ThrowTestException.java
+++ b/plugin-core/src/main/java/appland/actions/ThrowTestException.java
@@ -2,9 +2,10 @@ package appland.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import org.jetbrains.annotations.NotNull;
 
-public class ThrowTestException extends AnAction {
+public class ThrowTestException extends AnAction implements UpdateInBackground {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         throw new IllegalStateException("AppMap test exception, " + Math.random());

--- a/plugin-core/src/main/java/appland/oauth/AppMapLoginAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLoginAction.java
@@ -3,12 +3,14 @@ package appland.oauth;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class AppMapLoginAction extends AnAction {
+public class AppMapLoginAction extends AnAction implements DumbAware, UpdateInBackground {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         authenticate();

--- a/plugin-core/src/main/java/appland/oauth/AppMapLoginByKeyAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLoginByKeyAction.java
@@ -5,6 +5,7 @@ import appland.notifications.AppMapNotifications;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.InputValidator;
@@ -25,7 +26,7 @@ import static com.intellij.openapi.ui.Messages.getOkButton;
 /**
  * Action to sign in to AppMap by providing a license key.
  */
-public class AppMapLoginByKeyAction extends AnAction implements DumbAware {
+public class AppMapLoginByKeyAction extends AnAction implements DumbAware, UpdateInBackground {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         var project = Objects.requireNonNull(e.getProject());

--- a/plugin-core/src/main/java/appland/oauth/AppMapLogoutAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLogoutAction.java
@@ -3,10 +3,12 @@ package appland.oauth;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.UpdateInBackground;
+import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class AppMapLogoutAction extends AnAction {
+public class AppMapLogoutAction extends AnAction implements DumbAware, UpdateInBackground {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         logout();

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
@@ -3,10 +3,7 @@ package appland.toolwindow.appmap;
 import appland.AppMapBundle;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.DeleteProvider;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.fileChooser.actions.VirtualFileDeleteProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Action to delete all AppMaps displayed in the AppMap panel.
  */
-final class DeleteAllMapsAction extends AnAction {
+final class DeleteAllMapsAction extends AnAction implements UpdateInBackground {
     private final DeleteProvider deleteHandler = new VirtualFileDeleteProvider();
 
     public DeleteAllMapsAction() {


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/596

2024.1 eap added an annoying error if an `AnAction` does not specify the thread, where its presentation is updated.
All our actions are now implementing `UpdateInBackground`, because that is the only way I'm aware of which is available in all our supported SDKs.