### PR TITLE
Update new CI workflow to create webview pull requests

### DIFF
--- a/.github/workflows/webview-update.yml
+++ b/.github/workflows/webview-update.yml
@@ -1,27 +1,19 @@
-name: "Update Webviews"
+name: "Update Webview"
+run-name: "Update Webview ${{ inputs.webview }}"
 on:
     workflow_dispatch:
         inputs:
-            webview_appmap:
-                description: 'Update the AppMap webview'
-                default: false
-                required: false
-                type: boolean
-            webview_findings:
-                description: 'Update the Findings webview'
-                default: false
-                required: false
-                type: boolean
-            webview_install_guide:
-                description: 'Update the Installation Guide webview'
-                default: false
-                required: false
-                type: boolean
-            webview_navie:
-                description: 'Update the Navie webview'
-                default: false
-                required: false
-                type: boolean
+            webview:
+                description: 'Webview to update to the latest version'
+                default: 'appmap'
+                required: true
+                type: choice
+                options:
+                    - appmap
+                    - findings
+                    - install-guide
+                    - navie
+                    - signin
 
 jobs:
     update_webviews:
@@ -32,29 +24,40 @@ jobs:
                 name: "Checkout Repository"
 
             -   name: "Update AppMap WebView"
-                if: inputs.webview_appmap == true
+                if: inputs.webview == 'appmap'
                 shell: bash
                 run: ./appland/rebuild.bash
 
             -   name: "Update Findings WebView"
-                if: inputs.webview_findings == true
+                if: inputs.webview == 'findings'
                 shell: bash
                 run: ./appland-findings/rebuild.bash
 
             -   name: "Update Installation Guide WebView"
-                if: inputs.webview_install_guide == true
+                if: inputs.webview == 'install-guide'
                 shell: bash
                 run: ./appland-install-guide/rebuild.bash
 
             -   name: "Update Navie WebView"
-                if: inputs.webview_navie == true
+                if: inputs.webview == 'navie'
                 shell: bash
                 run: ./appland-navie/rebuild.bash
 
+            -   name: "Update Sign-In WebView"
+                if: inputs.webview == 'signin'
+                shell: bash
+                run: ./appland-signin/rebuild.bash
+
             -   name: Create Pull Request
                 uses: peter-evans/create-pull-request@v6
-                if: inputs.webview_appmap == true || inputs.webview_findings == true || inputs.webview_install_guide == true || inputs.webview_navie == true
                 with:
-                    path: ./appland*
-                    title: "Update Webviews"
-                    commit-message: "Update webviews to latest versions"
+                    title: "Update Webview ${{ inputs.webview }}"
+                    commit-message: "feat: update webview ${{ inputs.webview }} to the latest version"
+                    body: "Automated pull request to update webview ${{ inputs.webview }}."
+                    branch: "webview-pull-request/${{ inputs.webview }}"
+                    add-paths: |
+                        appland
+                        appland-findings
+                        appland-install-guide
+                        appland-navie
+                        appland-signin

--- a/appland-findings/package.json
+++ b/appland-findings/package.json
@@ -22,6 +22,5 @@
     "url": "^0.11",
     "vue": "^2.7",
     "vue-template-compiler": "^2.7"
-  },
-  "packageManager": "yarn@2.4.2"
+  }
 }

--- a/appland-install-guide/package.json
+++ b/appland-install-guide/package.json
@@ -22,6 +22,5 @@
     "url": "^0.11",
     "vue": "^2.7",
     "vue-template-compiler": "^2.7"
-  },
-  "packageManager": "yarn@2.4.2"
+  }
 }

--- a/appland-signin/package.json
+++ b/appland-signin/package.json
@@ -22,6 +22,5 @@
     "url": "^0.11",
     "vue": "^2.7",
     "vue-template-compiler": "^2.7"
-  },
-  "packageManager": "yarn@2.4.2"
+  }
 }


### PR DESCRIPTION
Updates the new CI workflow added with #604 to only update one webview at a time and to use a unique branch per webview.

Dropping the two remaining ` "packageManager": "yarn@2.4.2"` from package.json was necessary because NPM/node available with the `ubuntu-latest` runner was complaining about incompatible settings (see https://github.com/getappmap/appmap-intellij-plugin/actions/runs/8231132338/job/22505835614#step:5:7).

Sample pull request:
- https://github.com/getappmap/appmap-intellij-plugin/pull/610 . This also includes the changes of this PR because I had to execute the CI workflow from this branch.