### PR TITLE
Tests to make sure that downloads use the IDE's proxy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,11 @@ allprojects {
         if (project.name != "plugin-core") {
             testImplementation(project(":plugin-core", "testOutput"))
         }
+
+        // https://mvnrepository.com/artifact/org.mock-server/mockserver-netty
+        testImplementation("org.mock-server:mockserver-netty:5.15.0")
+        // https://mvnrepository.com/artifact/org.mock-server/mockserver-junit-rule
+        testImplementation("org.mock-server:mockserver-junit-rule:5.15.0")
     }
 
     intellij {

--- a/plugin-core/src/main/java/appland/cli/CliTool.java
+++ b/plugin-core/src/main/java/appland/cli/CliTool.java
@@ -7,12 +7,12 @@ import org.jetbrains.annotations.NotNull;
 @Getter
 public enum CliTool {
     AppMap("appmap",
-            "https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fappmap",
-            "https://registry.npmjs.org/@appland%2Fappmap/latest",
+            "https://github.com/getappmap/appmap-js/releases/download/@appland/appmap",
+            "https://registry.npmjs.org/@appland/appmap/latest",
             AppMapBundle.get("cli.appMap.name")),
     Scanner("scanner",
-            "https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fscanner",
-            "https://registry.npmjs.org/@appland%2Fscanner/latest",
+            "https://github.com/getappmap/appmap-js/releases/download/@appland/scanner",
+            "https://registry.npmjs.org/@appland/scanner/latest",
             AppMapBundle.get("cli.scanner.name"));
 
     private final String id;

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -245,7 +245,8 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         ApplicationManager.getApplication().getMessageBus().syncPublisher(AppLandDownloadListener.TOPIC).downloadFinished(type, success);
     }
 
-    private static @NotNull String currentPlatform() {
+    // package-visible for our tests
+    static @NotNull String currentPlatform() {
         if (SystemInfo.isLinux) {
             return "linux";
         }
@@ -261,7 +262,8 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         throw new IllegalStateException("Unsupported platform: " + SystemInfo.getOsNameAndVersion());
     }
 
-    private static @NotNull String currentArch() {
+    // package-visible for our tests
+    static @NotNull String currentArch() {
         return CpuArch.isArm64() ? "arm64" : "x64";
     }
 }

--- a/plugin-core/src/test/java/appland/cli/AppLandDownloadServiceTestUtil.java
+++ b/plugin-core/src/test/java/appland/cli/AppLandDownloadServiceTestUtil.java
@@ -1,0 +1,62 @@
+package appland.cli;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Helper class to share code between tests.
+ */
+final class AppLandDownloadServiceTestUtil {
+    private AppLandDownloadServiceTestUtil() {
+    }
+
+    /**
+     * Downloads the given CLI tool and asserts a successful download.
+     */
+    static void downloadLatestCliVersions(@NotNull Project project,
+                                          @NotNull CliTool toolType,
+                                          @NotNull Disposable parentDisposable) throws Exception {
+        var service = AppLandDownloadService.getInstance();
+
+        var latestVersion = service.fetchLatestRemoteVersion(toolType);
+        Assert.assertNotNull(latestVersion);
+
+        var downloadSuccessful = new AtomicBoolean();
+        var downloadException = new AtomicReference<Exception>();
+
+        var latch = new CountDownLatch(1);
+        ApplicationManager.getApplication()
+                .getMessageBus()
+                .connect(parentDisposable)
+                .subscribe(AppLandDownloadListener.TOPIC, (cliTool, success) -> {
+                    downloadSuccessful.set(success);
+                    latch.countDown();
+                });
+
+        new Task.Backgroundable(project, "Downloading", true) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                try {
+                    service.download(toolType, latestVersion, indicator);
+                } catch (Exception e) {
+                    downloadException.set(e);
+                }
+            }
+        }.queue();
+
+        var ok = latch.await(5, TimeUnit.MINUTES);
+        Assert.assertTrue("The download must finish", ok);
+        Assert.assertTrue("The download must be successful", downloadSuccessful.get());
+        Assert.assertNull("The download must not cause an exception", downloadException.get());
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/CliToolTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolTest.java
@@ -6,25 +6,25 @@ import org.junit.Test;
 public class CliToolTest extends AppMapBaseTest {
     @Test
     public void urlsAppMap() {
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fappmap-v3.32.2/appmap-linux-x64",
+        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/appmap-v3.32.2/appmap-linux-x64",
                 CliTool.AppMap.getDownloadUrl("3.32.2", "linux", "x64"));
 
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fappmap-v3.32.2/appmap-macos-arm64",
+        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/appmap-v3.32.2/appmap-macos-arm64",
                 CliTool.AppMap.getDownloadUrl("3.32.2", "macos", "arm64"));
 
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fappmap-v3.32.2/appmap-win-x64.exe",
+        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/appmap-v3.32.2/appmap-win-x64.exe",
                 CliTool.AppMap.getDownloadUrl("3.32.2", "win", "x64"));
     }
 
     @Test
     public void urlsScanner() {
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fscanner-v1.67.0/scanner-linux-x64",
+        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/scanner-v1.67.0/scanner-linux-x64",
                 CliTool.Scanner.getDownloadUrl("1.67.0", "linux", "x64"));
 
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fscanner-v1.67.0/scanner-macos-arm64",
+        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/scanner-v1.67.0/scanner-macos-arm64",
                 CliTool.Scanner.getDownloadUrl("1.67.0", "macos", "arm64"));
 
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/%40appland%2Fscanner-v1.67.0/scanner-win-x64.exe",
+        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/scanner-v1.67.0/scanner-win-x64.exe",
                 CliTool.Scanner.getDownloadUrl("1.67.0", "win", "x64"));
     }
 

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -1,0 +1,52 @@
+package appland.cli;
+
+import appland.AppMapBaseTest;
+import appland.testRules.MockServerSettingsRule;
+import appland.testRules.OverrideIdeHttpProxyRule;
+import com.intellij.util.Urls;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+import java.util.Arrays;
+
+import static appland.cli.DefaultAppLandDownloadService.currentArch;
+import static appland.cli.DefaultAppLandDownloadService.currentPlatform;
+
+public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(this);
+    @Rule
+    public MockServerSettingsRule mockServerSettingsRule = new MockServerSettingsRule();
+    @Rule
+    public OverrideIdeHttpProxyRule ideHttpProxyRule = new OverrideIdeHttpProxyRule(mockServerRule);
+
+    @Test
+    public void downloadWithHttpProxy() throws Exception {
+        var toolType = CliTool.AppMap;
+
+        var latestVersion = AppLandDownloadService.getInstance().fetchLatestRemoteVersion(toolType);
+        Assert.assertNotNull(latestVersion);
+
+        var binaryDownloadUrl = Urls.parse(toolType.getDownloadUrl(latestVersion, currentPlatform(), currentArch()), false);
+        Assert.assertNotNull(binaryDownloadUrl);
+
+        // override response body of the binary request to avoid OutOfMemory leaks with Mockserver
+        mockServerRule.getClient()
+                .when(HttpRequest.request().withMethod("GET").withPath(binaryDownloadUrl.getPath()))
+                .respond(HttpResponse.response().withBody(""));
+
+        // Perform the download using the mock HTTP proxy server
+        AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), toolType, getTestRootDisposable());
+
+        var hasDownloadRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
+                .anyMatch(request -> {
+                    var path = request.getPath().getValue();
+                    return request.containsHeader("host", binaryDownloadUrl.getAuthority()) && path.equals(binaryDownloadUrl.getPath());
+                });
+        Assert.assertTrue("AppMap CLI tools must be downloaded with the IDE's HTTP proxy", hasDownloadRequest);
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
@@ -1,9 +1,6 @@
 package appland.cli;
 
 import appland.AppMapBaseTest;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.progress.Task;
 import com.intellij.testFramework.VfsTestUtil;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
@@ -12,8 +9,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
@@ -40,38 +35,10 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     }
 
     @Test
-    public void downloadBinary() throws IOException, InterruptedException {
-        var type = CliTool.AppMap;
-        var service = AppLandDownloadService.getInstance();
-
-        var latestVersion = service.fetchLatestRemoteVersion(type);
-        assertNotNull(latestVersion);
-
-        var latch = new CountDownLatch(1);
-        ApplicationManager.getApplication().getMessageBus().connect(getTestRootDisposable())
-                .subscribe(AppLandDownloadListener.TOPIC, (cliTool, success) -> {
-                    if (!success) {
-                        addSuppressedException(new IllegalStateException("CLI download failed: " + cliTool));
-                    }
-                    latch.countDown();
-                });
-
-        new Task.Backgroundable(getProject(), "Downloading", true) {
-            @Override
-            public void run(@NotNull ProgressIndicator indicator) {
-                try {
-                    service.download(type, latestVersion, indicator);
-                } catch (Exception e) {
-                    addSuppressedException(e);
-                }
-            }
-        }.queue();
-
-        var ok = latch.await(5, TimeUnit.MINUTES);
-        assertTrue("Download must succeed", ok);
-
-        assertTrue(service.isDownloaded(type, latestVersion, ApplicationManager.getApplication().isUnitTestMode()));
-        assertTrue(service.isDownloaded(type));
+    public void downloadAppMapBinary() throws Exception {
+        // We're only testing the download of the AppMap tool and not of the scanner
+        // because they work in the same way, and we don't want to extend the test duration unnecessarily.
+        AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), CliTool.AppMap, getTestRootDisposable());
     }
 
     @Test

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -51,7 +51,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     @Override
     protected void tearDown() throws Exception {
         try {
-            AppLandCommandLineService.getInstance().stopAll(10_000, TimeUnit.MILLISECONDS);
+            AppLandCommandLineService.getInstance().stopAll(30_000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             addSuppressedException(e);
         } finally {

--- a/plugin-core/src/test/java/appland/testRules/MockServerSettingsRule.java
+++ b/plugin-core/src/test/java/appland/testRules/MockServerSettingsRule.java
@@ -1,0 +1,23 @@
+package appland.testRules;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockserver.configuration.ConfigurationProperties;
+
+/**
+ * Modifies the default settings of MockServer to be more suitable for this project.
+ */
+public final class MockServerSettingsRule implements TestRule {
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                ConfigurationProperties.disableSystemOut(true);
+
+                statement.evaluate();
+            }
+        };
+    }
+}

--- a/plugin-core/src/test/java/appland/testRules/OverrideIdeHttpProxyRule.java
+++ b/plugin-core/src/test/java/appland/testRules/OverrideIdeHttpProxyRule.java
@@ -1,0 +1,41 @@
+package appland.testRules;
+
+import com.intellij.util.net.HttpConfigurable;
+import org.jetbrains.annotations.NotNull;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockserver.junit.MockServerRule;
+
+public final class OverrideIdeHttpProxyRule implements TestRule {
+    private final @NotNull MockServerRule mockServerRule;
+
+    public OverrideIdeHttpProxyRule(@NotNull MockServerRule mockServerRule) {
+        this.mockServerRule = mockServerRule;
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                var settings = HttpConfigurable.getInstance();
+                var wasHttpProxy = settings.USE_HTTP_PROXY;
+                var wasProxyHost = settings.PROXY_HOST;
+                var wasProxyPort = settings.PROXY_PORT;
+
+                try {
+                    settings.USE_HTTP_PROXY = true;
+                    settings.PROXY_HOST = "127.0.0.1";
+                    settings.PROXY_PORT = mockServerRule.getPort();
+
+                    statement.evaluate();
+                } finally {
+                    settings.USE_HTTP_PROXY = wasHttpProxy;
+                    settings.PROXY_HOST = wasProxyHost;
+                    settings.PROXY_PORT = wasProxyPort;
+                }
+            }
+        };
+    }
+}

--- a/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
+++ b/plugin-java/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
@@ -4,13 +4,11 @@ import appland.AppMapBaseTest;
 import appland.utils.SystemProperties;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.io.NioFiles;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.junit.runners.model.Statement;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,14 +19,7 @@ import java.time.temporal.ChronoUnit;
 
 public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
     @Rule
-    public final TestRule systemPropertyUpdate = (statement, description) -> new Statement() {
-        @Override
-        public void evaluate() throws Throwable {
-            var path = Paths.get(myFixture.getTempDirFixture().getTempDirPath()).resolve("appmap-agent");
-            NioFiles.deleteRecursively(path);
-            SystemProperties.withPropertyValue(SystemProperties.USER_HOME, path.toString(), statement::evaluate);
-        }
-    };
+    public TestRule agentDownloadRule = new OverrideJavaAgentLocationRule(() -> this.myFixture);
 
     @Override
     protected TempDirTestFixture createTempDirTestFixture() {

--- a/plugin-java/src/test/java/appland/javaAgent/OverrideJavaAgentLocationRule.java
+++ b/plugin-java/src/test/java/appland/javaAgent/OverrideJavaAgentLocationRule.java
@@ -1,0 +1,32 @@
+package appland.javaAgent;
+
+import appland.utils.SystemProperties;
+import com.intellij.openapi.util.io.NioFiles;
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
+import org.jetbrains.annotations.NotNull;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.nio.file.Paths;
+import java.util.function.Supplier;
+
+public class OverrideJavaAgentLocationRule implements TestRule {
+    private final @NotNull Supplier<CodeInsightTestFixture> fixtureSupplier;
+
+    public OverrideJavaAgentLocationRule(@NotNull Supplier<CodeInsightTestFixture> fixtureSupplier) {
+        this.fixtureSupplier = fixtureSupplier;
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                var path = Paths.get(fixtureSupplier.get().getTempDirFixture().getTempDirPath()).resolve("appmap-agent");
+                NioFiles.deleteRecursively(path);
+                SystemProperties.withPropertyValue(SystemProperties.USER_HOME, path.toString(), statement::evaluate);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/621

Tests downloads of AppMap binaries and of the Java agent JAR.
The only change (except the new tests) is a change to the AppMap CLI URLs to unescape unnecessarily escaped `@` and `/` characters of the URL to make it work with the Mockserver.