### PR TITLE
Do not remove the process reference if it's not the terminated process

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -636,12 +636,19 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
                 synchronized (DefaultCommandLineService.this) {
                     var entry = processes.get(directory);
                     if (entry != null) {
+                        // We're only resetting the process entry if it was referencing the terminated process
+                        // For example, if process shutdown takes a long time, then closing and reopening a project
+                        // must not reset the processes incorrectly.
                         switch (type) {
                             case Indexer:
-                                entry.indexer = null;
+                                if (process.equals(entry.indexer)) {
+                                    entry.indexer = null;
+                                }
                                 break;
                             case Scanner:
-                                entry.scanner = null;
+                                if (process.equals(entry.scanner)) {
+                                    entry.scanner = null;
+                                }
                                 break;
                         }
 

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -471,7 +471,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
     }
 
     static @NotNull KillableProcessHandler startProcess(@NotNull Path workingDir,
-                                                                @NotNull String... commandLine) throws ExecutionException {
+                                                        @NotNull String... commandLine) throws ExecutionException {
 
         if (!Files.isDirectory(workingDir)) {
             throw new IllegalStateException("Directory does not exist: " + workingDir);
@@ -499,6 +499,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             var shutdownRunnable = new Runnable() {
                 @Override
                 public void run() {
+                    process.setShouldKillProcessSoftly(false);
                     process.destroyProcess();
                     process.waitFor(500);
 
@@ -661,6 +662,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             }
 
             // schedule next restart
+            LOG.debug("Scheduling AppMap process restart. Type: " + type + ", command line: " + process.getCommandLine());
             AppExecutorUtil.getAppScheduledExecutorService().schedule(() -> {
                 try {
                     var nextRestartDelay = (long) ((double) currentRestartDelay * NEXT_RESTART_FACTOR);

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -1,6 +1,7 @@
 package appland.cli;
 
 import appland.AppMapBaseTest;
+import appland.files.AppMapFiles;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.utils.ModuleTestUtils;
@@ -8,6 +9,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.PtyCommandLine;
 import com.intellij.execution.process.KillableProcessHandler;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.util.SystemInfo;
@@ -29,6 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -71,38 +74,34 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         var parentDir = myFixture.createFile("test.txt", "").getParent();
         assertNotNull(parentDir);
 
-        var nestedDir = myFixture.addFileToProject("parent/child/file.txt", "").getParent().getVirtualFile();
-        assertNotNull(nestedDir);
+        ModuleTestUtils.withContentRoot(getModule(), parentDir, () -> {
+            assertFalse("Service must not execute for a directory without appmap.yaml", service.isRunning(parentDir, false));
 
-        // creating an appmap.yml file must trigger the launch of the matching AppMap processes
-        createAppMapYaml(nestedDir);
-        addContentRootAndLaunchService(nestedDir);
-        assertActiveRoots(nestedDir);
+            // creating an appmap.yml file must trigger the launch of the matching AppMap processes
+            var nestedDir = myFixture.addFileToProject("parent/child/file.txt", "").getParent().getVirtualFile();
+            assertNotNull(nestedDir);
+            createAppMapYaml(nestedDir, "tmp/appmap");
+            waitForProcessStatus(true, nestedDir, true);
+            assertActiveRoots(nestedDir);
 
-        addContentRootAndLaunchService(parentDir);
-        assertFalse("Service must not execute for a directory without appmap.yaml", service.isRunning(parentDir, false));
+            createAppMapYaml(parentDir, "tmp/appmap");
+            waitForProcessStatus(true, parentDir, true);
+            assertTrue("Service must launch with appmap.yaml present", service.isRunning(parentDir, true));
+            assertTrue("Service must launch with appmap.yaml present", service.isRunning(parentDir, false));
+            assertActiveRoots(parentDir, nestedDir);
 
-        createAppMapYaml(parentDir);
-        assertTrue("Service must launch with appmap.yaml present", service.isRunning(parentDir, true));
-        assertTrue("Service must launch with appmap.yaml present", service.isRunning(parentDir, false));
-        assertActiveRoots(parentDir, nestedDir);
+            assertTrue("Processes of child directories must keep running", service.isRunning(nestedDir, true));
+            assertTrue(service.isRunning(nestedDir, false));
+            assertActiveRoots(parentDir, nestedDir);
 
-        assertTrue("Processes of child directories must keep running", service.isRunning(nestedDir, true));
-        assertTrue(service.isRunning(nestedDir, false));
-        assertActiveRoots(parentDir, nestedDir);
+            service.stop(parentDir, true);
+            service.stop(nestedDir, true);
 
-        service.stop(parentDir, true);
-        service.stop(nestedDir, true);
-
-        // forced sleep on CI until we find the cause breaking this test
-        if (System.getenv("CI") != null) {
-            Thread.sleep(4_000);
-        }
-
-        waitForProcessStatus(false, parentDir, true);
-        waitForProcessStatus(false, parentDir, false);
-        waitForProcessStatus(false, nestedDir, true);
-        waitForProcessStatus(false, nestedDir, false);
+            waitForProcessStatus(false, parentDir, true);
+            waitForProcessStatus(false, parentDir, false);
+            waitForProcessStatus(false, nestedDir, true);
+            waitForProcessStatus(false, nestedDir, false);
+        });
     }
 
     @Test
@@ -112,18 +111,20 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         Assume.assumeTrue(SystemInfo.isUnix);
 
         var tempDir = myFixture.createFile("test.txt", "").getParent();
-        createAppMapYaml(tempDir);
+        ModuleTestUtils.withContentRoot(getModule(), tempDir, () -> {
+            var service = AppLandCommandLineService.getInstance();
+            createAppMapYaml(tempDir, "tmp/appmaps");
+            waitForProcessStatus(true, tempDir, true);
+            assertActiveRoots(tempDir);
 
-        var service = AppLandCommandLineService.getInstance();
-        createAppMapYaml(tempDir, "tmp/appmaps");
-        addContentRootAndLaunchService(tempDir);
-        assertActiveRoots(tempDir);
+            assertTrue(service.isRunning(tempDir, false));
 
-        assertTrue(service.isRunning(tempDir, false));
-        var tempDirNioPath = LocalFileSystem.getInstance().getNioPath(tempDir);
-        assertNotNull(tempDirNioPath);
-        var appMapDirNioPath = tempDirNioPath.resolve("tmp/appmaps");
-        assertTrue("Configured AppMap dir must be created: " + appMapDirNioPath, Files.isDirectory(appMapDirNioPath));
+            var tempDirNioPath = LocalFileSystem.getInstance().getNioPath(tempDir);
+            assertNotNull(tempDirNioPath);
+
+            var appMapDirNioPath = tempDirNioPath.resolve("tmp/appmaps");
+            assertTrue("Configured AppMap dir must be created: " + appMapDirNioPath, Files.isDirectory(appMapDirNioPath));
+        });
     }
 
     @Test
@@ -182,26 +183,29 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     }
 
     @Test
-    public void contentRootUpdates() throws InterruptedException {
+    public void contentRootUpdates() throws Exception {
         Assume.assumeFalse("On windows, it fails with java.io.IOException: Cannot delete ...", SystemInfo.isWindows);
 
+        var topLevelDir = myFixture.addFileToProject("file.txt", "").getParent().getVirtualFile();
         var newRootA = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
         var nestedRootA = myFixture.addFileToProject("parentA/subDir/file.txt", "").getParent().getVirtualFile();
         var newRootB = myFixture.addFileToProject("parentB/file.txt", "").getParent().getVirtualFile();
 
-        createAppMapYaml(newRootA);
-        createAppMapYaml(newRootB);
+        ModuleTestUtils.withContentRoot(getModule(), topLevelDir, () -> {
+            createAppMapYaml(newRootA);
+            waitForProcessStatus(true, newRootA, true);
 
-        // add new roots and assert that the new processes are launched
-        var condition = ProjectRefreshUtil.newProjectRefreshCondition(getTestRootDisposable());
-        ModuleRootModificationUtil.updateModel(getModule(), model -> {
-            model.addContentEntry(newRootA);
-            model.addContentEntry(nestedRootA);
-            model.addContentEntry(newRootB);
+            createAppMapYaml(newRootB);
+            waitForProcessStatus(true, newRootB, true);
+
+            // add new roots and assert that the new processes are launched
+            var condition = ProjectRefreshUtil.newProjectRefreshCondition(getTestRootDisposable());
+            ModuleTestUtils.withContentRoots(getModule(), List.of(newRootA, nestedRootA, newRootB), () -> {
+                assertTrue(condition.await(30, TimeUnit.SECONDS));
+
+                assertActiveRoots(newRootA, newRootB);
+            });
         });
-        assertTrue(condition.await(30, TimeUnit.SECONDS));
-
-        assertActiveRoots(newRootA, newRootB);
     }
 
     @Test
@@ -246,21 +250,23 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
                 .subscribe(AppMapSettingsListener.TOPIC, new RestartServicesAfterApiChangeListener());
 
         var tempDir = myFixture.createFile("test.txt", "").getParent();
-        createAppMapYaml(tempDir);
-        addContentRootAndLaunchService(tempDir);
-        assertActiveRoots(tempDir);
+        ModuleTestUtils.withContentRoot(getModule(), tempDir, () -> {
+            createAppMapYaml(tempDir, "tmp/appmap");
+            waitForProcessStatus(true, tempDir, true);
+            assertActiveRoots(tempDir);
 
-        // restart after change
-        waitForProcessRestart(tempDir, getIndexerFunction, processHandler -> {
-            AppMapApplicationSettingsService.getInstance().setApiKeyNotifying("new-api-key");
-        });
-        assertActiveRoots(tempDir);
+            // restart after change
+            waitForProcessRestart(tempDir, getIndexerFunction, processHandler -> {
+                AppMapApplicationSettingsService.getInstance().setApiKeyNotifying("new-api-key");
+            });
+            assertActiveRoots(tempDir);
 
-        // restart after sign out
-        waitForProcessRestart(tempDir, getIndexerFunction, processHandler -> {
-            AppMapApplicationSettingsService.getInstance().setApiKeyNotifying(null);
+            // restart after sign out
+            waitForProcessRestart(tempDir, getIndexerFunction, processHandler -> {
+                AppMapApplicationSettingsService.getInstance().setApiKeyNotifying(null);
+            });
+            assertActiveRoots(tempDir);
         });
-        assertActiveRoots(tempDir);
     }
 
     @Test
@@ -288,26 +294,30 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
     private void setupAndAssertProcessRestart(@NotNull Function<VirtualFile, KillableProcessHandler> processForRoot) throws Exception {
         var root = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
-        createAppMapYaml(root);
+        ModuleTestUtils.withContentRoot(getModule(), root, () -> {
+            createAppMapYaml(root);
+            waitForProcessStatus(true, root, true);
+            assertActiveRoots(root);
 
-        // add new roots and assert that the new processes are launched
-        var condition = ProjectRefreshUtil.newProjectRefreshCondition(getTestRootDisposable());
-        ModuleRootModificationUtil.updateModel(getModule(), model -> model.addContentEntry(root));
-        assertTrue(condition.await(30, TimeUnit.SECONDS));
-        assertActiveRoots(root);
+            // if one of the two processes is killed, it has to restart
+            waitForProcessRestart(root, processForRoot, DefaultCommandLineServiceTest::terminateProcess);
 
-        // if one of the two processes is killed, it has to restart
-        waitForProcessRestart(root, processForRoot, DefaultCommandLineServiceTest::terminateProcess);
-
-        // the restarted process must be restarted again when terminated
-        waitForProcessRestart(root, processForRoot, DefaultCommandLineServiceTest::terminateProcess);
+            // the restarted process must be restarted again when terminated
+            waitForProcessRestart(root, processForRoot, DefaultCommandLineServiceTest::terminateProcess);
+        });
     }
 
     private @NotNull VirtualFile createAppMapYaml(@NotNull VirtualFile directory) throws InterruptedException {
         return createAppMapYaml(directory, null);
     }
 
-    private @NotNull VirtualFile createAppMapYaml(@NotNull VirtualFile directory, @Nullable String appMapPath) throws InterruptedException {
+    private @NotNull VirtualFile createAppMapYaml(@NotNull VirtualFile directory,
+                                                  @Nullable String appMapPath) throws InterruptedException {
+        // a change to an appmap.yml is only applied if it's located in a content root
+        assertNotNull("appmap.yml must be located in a content root", ReadAction.compute(() -> {
+            return AppMapFiles.findTopLevelContentRoot(getProject(), directory);
+        }));
+
         var refreshLatch = new CountDownLatch(1);
         var bus = ApplicationManager.getApplication().getMessageBus().connect(getTestRootDisposable());
         bus.subscribe(AppLandCommandLineListener.TOPIC, refreshLatch::countDown);
@@ -378,8 +388,10 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
      * @param strict            If a strict check should be performed
      */
     private void waitForProcessStatus(boolean expectedIsRunning, @NotNull VirtualFile directory, boolean strict) throws Exception {
+        LOG.info("waitForProcessStatus: " + directory);
+
         var service = AppLandCommandLineService.getInstance();
-        var deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        var deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
         while (System.currentTimeMillis() < deadline) {
             if (expectedIsRunning == service.isRunning(directory, strict)) {
                 break;

--- a/plugin-core/src/test/java/appland/utils/ModuleTestUtils.java
+++ b/plugin-core/src/test/java/appland/utils/ModuleTestUtils.java
@@ -5,30 +5,64 @@ import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ThrowableRunnable;
-import junit.framework.TestCase;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ModuleTestUtils {
-    public static void withContentRoot(@NotNull Module module, @NotNull VirtualFile contentRoot, @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
-        TestCase.assertTrue(contentRoot.isDirectory());
+    /**
+     * Adds a content root to a module, runs the given runnable, and then removes the content root again.
+     *
+     * @param module      Module to add the content root to
+     * @param contentRoot Content root to add
+     * @param runnable    Runnable to run
+     */
+    public static void withContentRoot(@NotNull Module module,
+                                       @NotNull VirtualFile contentRoot,
+                                       @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
+        withContentRoots(module, List.of(contentRoot), runnable);
+    }
 
-        var contentEntryRef = new AtomicReference<ContentEntry>();
+
+    /**
+     * Adds content roots at once to a module, runs the given runnable, and then removes the registered content roots again.
+     *
+     * @param module       Module to add the content roots to
+     * @param contentRoots Content roots to add
+     * @param runnable     Runnable to run
+     */
+    public static void withContentRoots(@NotNull Module module,
+                                        @NotNull Collection<VirtualFile> contentRoots,
+                                        @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
+        for (var contentRoot : contentRoots) {
+            Assert.assertTrue(contentRoot.isDirectory());
+        }
+
+        var contentEntriesRef = new AtomicReference<Collection<ContentEntry>>();
         try {
             // hack to use ModuleRootModificationUtil and to keep a reference to the new entry
             ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
-                contentEntryRef.set(modifiableRootModel.addContentEntry(contentRoot));
+                var contentEntries = new ArrayList<ContentEntry>();
+                for (var contentRoot : contentRoots) {
+                    contentEntries.add(modifiableRootModel.addContentEntry(contentRoot));
+                }
+                contentEntriesRef.set(contentEntries);
             });
 
             runnable.run();
         } finally {
             // remove again to avoid breaking follow-up tests
-            var newEntry = contentEntryRef.get();
-            TestCase.assertNotNull(newEntry);
+            var newEntries = contentEntriesRef.get();
+            Assert.assertNotNull(newEntries);
 
             ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
-                modifiableRootModel.removeContentEntry(newEntry);
+                for (var contentEntry : newEntries) {
+                    modifiableRootModel.removeContentEntry(contentEntry);
+                }
             });
         }
     }


### PR DESCRIPTION
When I was debugging https://github.com/getappmap/appmap-intellij-plugin/issues/597 I noticed that processes were left running. This happened when I closed and reopened a project quickly.

Terminating AppMap processes takes a few seconds on this system. If there's already a new process for an AppMap directory when a process terminates and calls its termination listener, then the reference to the new process was removed and it was left running.
This is now fixed by this PR.

After the change CI become even more unstable. I've patched a few problems of process termination and the test setup code. This PR is required for https://github.com/getappmap/appmap-intellij-plugin/pull/679, because in that PR "Reopen project" is triggering the bug fixed by this PR.