### PR TITLE
Bundle the AppMap Java agent with plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ group = "appland.appmap"
 version = pluginVersion
 
 val isCI = System.getenv("CI") == "true"
-val agentOutputPath = rootProject.buildDir.resolve("appmap-agent.jar")
+val agentOutputPath = rootProject.buildDir.resolve("appmap-java-agent").resolve("appmap-agent.jar")
 val githubToken = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() }
 
 allprojects {
@@ -225,7 +225,10 @@ project(":") {
 
     tasks {
         task<Copy>("copyPluginAssets") {
+            dependsOn(":downloadAppMapAgent")
+
             inputs.file("${project.rootDir}/NOTICE.txt")
+            inputs.file(agentOutputPath)
             inputs.dir("${project.rootDir}/appland")
             inputs.dir("${project.rootDir}/appland-install-guide")
             inputs.dir("${project.rootDir}/appland-findings")
@@ -235,6 +238,10 @@ project(":") {
             from(project.rootDir) {
                 into("appmap-assets")
                 include("NOTICE.txt")
+            }
+            from(agentOutputPath.parentFile) {
+                into("appmap-assets/appmap-java-agent")
+                include("*.jar")
             }
             from("${project.rootDir}/appland") {
                 into("appmap-assets/appmap")

--- a/plugin-core/src/main/java/appland/AppMapPlugin.java
+++ b/plugin-core/src/main/java/appland/AppMapPlugin.java
@@ -18,8 +18,7 @@ public final class AppMapPlugin {
     private AppMapPlugin() {
     }
 
-    @NotNull
-    public static Path getPluginPath() {
+    public static @NotNull Path getPluginPath() {
         var plugin = getDescriptor();
         var basePath = plugin.getPluginPath();
         assert basePath != null;
@@ -27,10 +26,13 @@ public final class AppMapPlugin {
         return basePath;
     }
 
-    @NotNull
-    public static PluginDescriptor getDescriptor() {
+    public static @NotNull PluginDescriptor getDescriptor() {
         var plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));
         assert plugin != null;
         return plugin;
+    }
+
+    public static @NotNull Path getAppMapJavaAgentPath() {
+        return getPluginPath().resolve("appmap-java-agent").resolve("appmap-agent.jar");
     }
 }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -206,7 +206,7 @@ codeObjects.requestTopLevel.label=HTTP server requests
 codeObjects.queryTopLevel.label=Queries
 
 javaAgent.download.title=Downloading AppMap Java agent...
-javaAgent.run.missingJar=Unable to execute because the AppMap Java agent file is unavailable
+javaAgent.run.unavailableJar=The AppMap Java agent JAR file could not be found.
 
 appMapConfig.creatingConfig=Setting Up appmap.yml...
 runtimeAnalysis.node.findingsTable.label=Findings Table

--- a/plugin-core/src/test/java/appland/AppMapPluginTest.java
+++ b/plugin-core/src/test/java/appland/AppMapPluginTest.java
@@ -11,4 +11,10 @@ public class AppMapPluginTest extends LightPlatformCodeInsightFixture4TestCase {
         assertNotNull(AppMapPlugin.getPluginPath());
         assertTrue(Files.exists(AppMapPlugin.getPluginPath()));
     }
+
+    @Test
+    public void appMapAgentPath() {
+        assertNotNull(AppMapPlugin.getAppMapJavaAgentPath());
+        assertTrue(Files.isRegularFile(AppMapPlugin.getAppMapJavaAgentPath()));
+    }
 }

--- a/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
@@ -1,11 +1,13 @@
 package appland.execution;
 
 import appland.AppMapBundle;
+import appland.AppMapPlugin;
 import appland.javaAgent.AppMapJavaAgentDownloadService;
 import com.intellij.execution.CantRunException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
@@ -25,7 +27,10 @@ public final class AppMapJvmCommandLinePatcher {
 
         var agentJarPath = AppMapJavaAgentDownloadService.getInstance().getJavaAgentPathIfExists();
         if (agentJarPath == null) {
-            throw new CantRunException(AppMapBundle.get("javaAgent.run.missingJar"));
+            agentJarPath = AppMapPlugin.getAppMapJavaAgentPath();
+        }
+        if (!Files.isReadable(agentJarPath)) {
+            throw new CantRunException(AppMapBundle.get("javaAgent.run.unavailableJar"));
         }
 
         var jvmParams = new LinkedList<String>();


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/624

Our Gradle setup was already downloading the latest version to run the tests with the AppMap Java agent.
We're reusing this to bundle the downloaded agent jar into the plugin.zip.

The bundled files is used as a fallback if the download of the remote agent JAR failed.