### PR TITLE
Fix GitHub Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,6 +193,9 @@ allprojects {
             onlyIf { this.project == rootProject }
             mustRunAfter("check")
 
+            // 1.365 is broken,
+            // remove this version as soon as https://youtrack.jetbrains.com/issue/MP-6438 is fixed.
+            verifierVersion.set("1.364")
             ideVersions.set(prop("ideVersionVerifier").split(","))
             failureLevel.set(listOf(
                 FailureLevel.INTERNAL_API_USAGES,

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=221.0
 untilBuild=241.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2022.1.3,IC-2023.3.2,IC-241.14024.14
+ideVersionVerifier=IC-2022.1.3,IC-2023.3.2,IC-241.14494.127
 
 lombokVersion=1.18.24
 
@@ -15,7 +15,7 @@ ideVersion=IC-2022.1.3
 #ideVersion=IC-2023.1.1
 #ideVersion=IC-2023.2
 #ideVersion=IC-2023.3.2
-#ideVersion=IC-241.14024.14-EAP-SNAPSHOT
+#ideVersion=IC-241.14494.127-EAP-SNAPSHOT
 
 kotlin.stdlib.default.dependency = false
 


### PR DESCRIPTION
In other PRs the build was failing due to the plugin verifier reports.
By default, the build setup uses the latest version of the plugin verifier. Today a new version was released, which incorrectly flags our code.
I've reported this at
https://youtrack.jetbrains.com/issue/MP-6438/Plugin-verifier-1.365-incorrectly-flags-overridden-methods-of-OverrideOnly

This PR uses the previous version of the plugin verifier to make our build work again.