### PR TITLE
feat: Allow configuring environment for AppMap services

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -476,18 +476,23 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
                 || SystemInfo.isWindows && CpuArch.isIntel64();
     }
 
-    private static @NotNull KillableProcessHandler startProcess(@NotNull Path workingDir,
+    public static @NotNull KillableProcessHandler startProcess(@NotNull Path workingDir,
                                                                 @NotNull String... commandLine) throws ExecutionException {
+
+        final var settings = AppMapApplicationSettingsService.getInstance();
 
         if (!Files.isDirectory(workingDir)) {
             throw new IllegalStateException("Directory does not exist: " + workingDir);
         }
 
-        var command = new GeneralCommandLine(commandLine);
-        command.withWorkDirectory(workingDir.toString());
-        command.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
+        var command = new GeneralCommandLine(commandLine)
+                .withWorkDirectory(workingDir.toString())
+                .withParentEnvironmentType(settings.isCliPassParentEnv()
+                        ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
+                        : GeneralCommandLine.ParentEnvironmentType.NONE)
+                .withEnvironment(settings.getCliEnvironment());
 
-        var apiKey = AppMapApplicationSettingsService.getInstance().getApiKey();
+        var apiKey = settings.getApiKey();
         if (apiKey != null && !apiKey.isEmpty()) {
             command.withEnvironment("APPMAP_API_KEY", apiKey);
         }

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -476,7 +476,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
                 || SystemInfo.isWindows && CpuArch.isIntel64();
     }
 
-    public static @NotNull KillableProcessHandler startProcess(@NotNull Path workingDir,
+    static @NotNull KillableProcessHandler startProcess(@NotNull Path workingDir,
                                                                 @NotNull String... commandLine) throws ExecutionException {
 
         final var settings = AppMapApplicationSettingsService.getInstance();

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -53,6 +53,10 @@ public class AppMapApplicationSettings {
         this.cliPassParentEnv = settings.cliPassParentEnv;
     }
 
+    public void setCliEnvironment(@NotNull Map<String, String> environment) {
+        this.cliEnvironment = Map.copyOf(environment);
+    }
+
     public void setApiKeyNotifying(@Nullable String apiKey) {
         var changed = !Objects.equals(apiKey, this.apiKey);
         this.apiKey = apiKey;

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -8,6 +8,8 @@ import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -31,6 +33,13 @@ public class AppMapApplicationSettings {
      */
     private volatile boolean showFirstAppMapNotification = false;
 
+    /**
+     * Map of environment variables to be set when starting AppMap services
+     * The key is the name of the environment variable and the value is the value of the environment variable.
+     */
+    private volatile Map<String, String> cliEnvironment = new HashMap<>();
+    private volatile boolean cliPassParentEnv = true;
+
     public AppMapApplicationSettings() {
     }
 
@@ -40,6 +49,8 @@ public class AppMapApplicationSettings {
         this.apiKey = settings.apiKey;
         this.installInstructionsViewed = settings.installInstructionsViewed;
         this.showFirstAppMapNotification = settings.showFirstAppMapNotification;
+        this.cliEnvironment.putAll(settings.cliEnvironment);
+        this.cliPassParentEnv = settings.cliPassParentEnv;
     }
 
     public void setApiKeyNotifying(@Nullable String apiKey) {

--- a/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
+++ b/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
@@ -1,26 +1,40 @@
 package appland.settings
 
 import appland.AppMapBundle
+import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import java.awt.BorderLayout
 import javax.swing.JCheckBox
 import javax.swing.JPanel
 
-@Suppress("UnstableApiUsage")
 class AppMapProjectSettingsPanel {
     private lateinit var enableTelemetry: JCheckBox
+    private lateinit var cliEnvironment: EnvironmentVariablesComponent
 
     fun loadSettingsFrom(applicationSettings: AppMapApplicationSettings) {
         enableTelemetry.isSelected = applicationSettings.isEnableTelemetry
+        cliEnvironment.envs = applicationSettings.cliEnvironment
+        cliEnvironment.isPassParentEnvs = applicationSettings.isCliPassParentEnv
     }
 
     fun applySettingsTo(applicationSettings: AppMapApplicationSettings) {
         applicationSettings.isEnableTelemetry = enableTelemetry.isSelected
+        applicationSettings.cliEnvironment = cliEnvironment.envs
+        applicationSettings.isCliPassParentEnv = cliEnvironment.isPassParentEnvs
     }
 
     fun getMainPanel(): JPanel {
+        cliEnvironment = EnvironmentVariablesComponent()
+        cliEnvironment.labelLocation = BorderLayout.WEST
         return panel {
             row {
                 enableTelemetry = checkBox(AppMapBundle.get("projectSettings.enableTelemetry.title")).component
+            }
+            group(AppMapBundle.get("projectSettings.appMapServices")) {
+                row {
+                    cell(cliEnvironment).horizontalAlign(HorizontalAlign.FILL)
+                }
             }
         }
     }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -147,6 +147,7 @@ projectSettings.serverName=URL of AppMap Cloud for AppMaps uploading:
 projectSettings.confirmUpload=Confirm upload of AppMaps
 projectSettings.enableFindings.title=Enable findings (experimental, requires restart)
 projectSettings.enableTelemetry.title=Enable telemetry
+projectSettings.appMapServices=AppMap Services
 
 installGuide.editor.title=Using AppMap
 installGuide.pageInstallAgent.title=Add AppMap to your project


### PR DESCRIPTION
Fixes #646

Followups:
- documentation,
- restart services on config change,
- use credential storage for OpenAI key.