### PR TITLE
Create appmap.yml in the correct directory when used with Gradle

### DIFF
--- a/plugin-core/src/main/java/appland/execution/ProgramParameterUtils.java
+++ b/plugin-core/src/main/java/appland/execution/ProgramParameterUtils.java
@@ -1,6 +1,8 @@
 package appland.execution;
 
+import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.SimpleProgramParameters;
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -11,11 +13,25 @@ import org.jetbrains.annotations.Nullable;
 import java.nio.file.Paths;
 
 public final class ProgramParameterUtils {
-    public static @Nullable VirtualFile findWorkingDir(@NotNull Project project, @NotNull SimpleProgramParameters programParameters) {
-        // seems to be a native path
+    public static @Nullable VirtualFile findWorkingDir(@NotNull Project project,
+                                                       @NotNull SimpleProgramParameters programParameters,
+                                                       @NotNull RunProfile configuration) {
         var workingDir = programParameters.getWorkingDirectory();
-        return workingDir == null
-                ? ProjectUtil.guessProjectDir(project)
-                : LocalFileSystem.getInstance().findFileByNioFile(Paths.get(workingDir));
+        if (workingDir != null) {
+            // seems to be a native path
+            return LocalFileSystem.getInstance().findFileByNioFile(Paths.get(workingDir));
+        }
+
+        // External run configurations define the working directory based on the selected project
+        if (configuration instanceof ExternalSystemRunConfiguration) {
+            var externalPath = ((ExternalSystemRunConfiguration) configuration).getSettings().getExternalProjectPath();
+            if (externalPath != null) {
+                // Seems to be used as native path by the SDK,
+                // e.g. by org.jetbrains.plugins.gradle.execution.build.TasksExecutionSettingsBuilder#build.
+                return LocalFileSystem.getInstance().findFileByNioFile(Paths.get(externalPath));
+            }
+        }
+
+        return ProjectUtil.guessProjectDir(project);
     }
 }

--- a/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
@@ -52,7 +52,7 @@ public final class AppMapPatcherUtil {
     private static List<String> prepareUnderProgress(@NotNull Project project,
                                                      @NotNull RunProfile configuration,
                                                      @NotNull SimpleJavaParameters javaParameters) throws CantRunException, IOException {
-        var workingDir = ProgramParameterUtils.findWorkingDir(project, javaParameters);
+        var workingDir = ProgramParameterUtils.findWorkingDir(project, javaParameters, configuration);
         if (workingDir == null) {
             throw new CantRunException("Unable to locate working directory to store AppMap files");
         }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/546

Previously, the file was created in the guessed project base directory, which doesn't always match the project root of a Gradle project
Previously, with the setup below and when executing `test` in Gradle sub-module `junit5/platform-tests`, `appmap.yml`  was created in `multi-module-setup/project-files` and not in `multi-module-setup/junit5`.

This PR fixes this by  looking at the "external project path" of Gradle run configurations. It's used as a fallback if there's not more specific working directory specified in the run configuration.

### Project setup to test this:
Run this:
```
mkdir multi-module-setup
cd multi-module-setup
mkdir project-files
git clone https://github.com/junit-team/junit5.git
git clone https://github.com/spring-projects/spring-petclinic.git
```

Then create a new project inside `multi-module-setup/project-files` and then register a new Gradle module for `junit5` and a  Maven module for `spring-petclinic`. Add new modules via `File > New... > Module from existing source`

Then run Gradle and maven tasks inside one of the modules.
