### PR TITLE
Drop support for 2022.1 up to 2023.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AppMap for JetBrains IDEs
 
 ## System Requirements
-**IntelliJ IDEA 2022.1 or later** is required to use this plugin.
+**IntelliJ IDEA 2023.2 or later** is required to use this plugin.
 
 Only installations, which use the bundled JetBrains Java runtime, support the JCEF engine for rendering.
 
 ## Build
-Please make sure that a **Java JDK, version 11 or later** is installed. Building the plugin is only supported with Java 11 or later.
+Please make sure that a **Java JDK, version 17 or later** is installed.
 
 ```bash
 ./gradlew clean build

--- a/description.md
+++ b/description.md
@@ -16,8 +16,7 @@ AppMap and Navie will help you:
 
 ## Requirements and Use
 
-**2021.3** and newer JetBrains IDEs are required to use this plugin.  
-**2023+** is recommended.
+**2023.2** and newer JetBrains IDEs are required to use this plugin.  
 
 Supported web applications and API frameworks: Ruby on Rails, Django, Flask, Express, Nest.js, Next.js, and Spring, Kotlin, and Scala
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,23 +1,19 @@
 pluginVersion=0.61.0
 
-sinceBuild=221.0
+sinceBuild=232.0
 untilBuild=241.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2022.1.3,IC-2023.3.2,IC-2024.1
+ideVersionVerifier=IC-2023.3.2,IC-2024.1
 
 lombokVersion=1.18.24
 
 # alternative versions to simplify development and testing
-ideVersion=IC-2022.1.3
-#ideVersion=IC-2022.2.3
-#ideVersion=IC-2022.3
-#ideVersion=IC-2023.1.1
-#ideVersion=IC-2023.2
+ideVersion=IC-2023.2
 #ideVersion=IC-2023.3.2
 #ideVersion=IC-2024.1
 
-kotlin.stdlib.default.dependency = false
+kotlin.stdlib.default.dependency=false
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=232.0
 untilBuild=241.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.3.2,IC-2024.1
+ideVersionVerifier=IC-2023.2,IC-2024.1
 
 lombokVersion=1.18.24
 

--- a/plugin-core/src/main/java/appland/actions/AppMapDocumentationAction.java
+++ b/plugin-core/src/main/java/appland/actions/AppMapDocumentationAction.java
@@ -2,13 +2,18 @@ package appland.actions;
 
 import appland.Icons;
 import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
-public class AppMapDocumentationAction extends AnAction implements DumbAware, UpdateInBackground {
+public class AppMapDocumentationAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     public AppMapDocumentationAction() {
         super(Icons.APPMAP_DOCS);
     }

--- a/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
+++ b/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
@@ -7,9 +7,9 @@ import appland.telemetry.TelemetryService;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.ide.actions.OpenInRightSplitAction;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -33,9 +33,14 @@ import java.util.concurrent.TimeUnit;
 /**
  * Generates an OpenAPI file using the CLI tool.
  */
-public class GenerateOpenApiAction extends AnAction implements DumbAware, UpdateInBackground {
+public class GenerateOpenApiAction extends AnAction implements DumbAware {
     private static final Logger LOG = Logger.getInstance(GenerateOpenApiAction.class);
     private static final String APPMAP_OPENAPI_FILENAME = "appmap-openapi.yml";
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {

--- a/plugin-core/src/main/java/appland/actions/OpenAppMapNavieAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenAppMapNavieAction.java
@@ -1,9 +1,9 @@
 package appland.actions;
 
 import appland.webviews.navie.NavieEditorProvider;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,7 +11,12 @@ import org.jetbrains.annotations.NotNull;
  * Action to open the AppMap Navie webview.
  */
 @SuppressWarnings("ComponentNotRegistered")
-public class OpenAppMapNavieAction extends AnAction implements DumbAware, UpdateInBackground {
+public class OpenAppMapNavieAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         var project = e.getProject();

--- a/plugin-core/src/main/java/appland/actions/OpenInstallGuideAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenInstallGuideAction.java
@@ -2,15 +2,20 @@ package appland.actions;
 
 import appland.installGuide.InstallGuideEditorProvider;
 import appland.installGuide.InstallGuideViewPage;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class OpenInstallGuideAction extends AnAction implements DumbAware, UpdateInBackground {
+public class OpenInstallGuideAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     @Override
     public void update(@NotNull AnActionEvent e) {
         e.getPresentation().setEnabled(InstallGuideEditorProvider.isSupported());

--- a/plugin-core/src/main/java/appland/actions/OpenRecentAppMapAction.java
+++ b/plugin-core/src/main/java/appland/actions/OpenRecentAppMapAction.java
@@ -2,9 +2,9 @@ package appland.actions;
 
 import appland.AppMapBundle;
 import appland.index.AppMapSearchScopes;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.ui.Messages;
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
  * If two files have the same modification timestamp, then the returned file is randomly chosen,
  * depending on the order in the index.
  */
-public class OpenRecentAppMapAction extends AnAction implements UpdateInBackground {
+public class OpenRecentAppMapAction extends AnAction {
     private static final Logger LOG = Logger.getInstance("#appmap.action");
 
     static VirtualFile findMostRecentlyModifiedAppMap(com.intellij.openapi.project.Project project) {
@@ -33,6 +33,11 @@ public class OpenRecentAppMapAction extends AnAction implements UpdateInBackgrou
             if (delta > 0) return 1;
             return 0;
         }).orElse(null);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/actions/StartAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StartAppMapRecordingAction.java
@@ -6,9 +6,9 @@ import appland.remote.RemoteRecordingService;
 import appland.remote.RemoteRecordingStatusService;
 import appland.remote.StartRemoteRecordingDialog;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbAware;
@@ -16,9 +16,14 @@ import org.jetbrains.annotations.NotNull;
 
 import static appland.AppMapBundle.get;
 
-public class StartAppMapRecordingAction extends AnAction implements DumbAware, UpdateInBackground {
+public class StartAppMapRecordingAction extends AnAction implements DumbAware {
     public StartAppMapRecordingAction() {
         super(Icons.START_RECORDING_ACTION);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -5,12 +5,15 @@ import appland.Icons;
 import appland.files.AppMapFiles;
 import appland.files.AppMapVfsUtils;
 import appland.notifications.AppMapNotifications;
-import appland.remote.*;
+import appland.remote.RemoteRecordingService;
+import appland.remote.RemoteRecordingStatusService;
+import appland.remote.StopRemoteRecordingDialog;
+import appland.remote.StopRemoteRecordingForm;
 import appland.settings.AppMapProjectSettingsService;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.ReadAction;
@@ -34,11 +37,16 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class StopAppMapRecordingAction extends AnAction implements DumbAware, UpdateInBackground {
+public class StopAppMapRecordingAction extends AnAction implements DumbAware {
     private static final Logger LOG = Logger.getInstance(StopAppMapRecordingAction.class);
 
     public StopAppMapRecordingAction() {
         super(Icons.STOP_RECORDING_ACTION);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/actions/ThrowTestException.java
+++ b/plugin-core/src/main/java/appland/actions/ThrowTestException.java
@@ -1,11 +1,16 @@
 package appland.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import org.jetbrains.annotations.NotNull;
 
-public class ThrowTestException extends AnAction implements UpdateInBackground {
+public class ThrowTestException extends AnAction {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         throw new IllegalStateException("AppMap test exception, " + Math.random());

--- a/plugin-core/src/main/java/appland/cli/AppLandProjectManagerListener.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandProjectManagerListener.java
@@ -6,13 +6,9 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Stops CLI processes of opened and closed projects.
+ * {@link AppLandProjectOpenActivity} will start the CLI processes for opened projects.
  */
 public class AppLandProjectManagerListener implements ProjectManagerListener {
-    @Override
-    public void projectOpened(@NotNull Project project) {
-        AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
-    }
-
     @Override
     public void projectClosed(@NotNull Project project) {
         AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();

--- a/plugin-core/src/main/java/appland/cli/AppLandProjectOpenActivity.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandProjectOpenActivity.java
@@ -1,0 +1,13 @@
+package appland.cli;
+
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import org.jetbrains.annotations.NotNull;
+
+public class AppLandProjectOpenActivity implements StartupActivity, DumbAware {
+    @Override
+    public void runActivity(@NotNull Project project) {
+        AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -242,7 +242,12 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
     }
 
     private static void notifyDownloadFinished(@NotNull CliTool type, boolean success) {
-        ApplicationManager.getApplication().getMessageBus().syncPublisher(AppLandDownloadListener.TOPIC).downloadFinished(type, success);
+        var application = ApplicationManager.getApplication();
+        if (!application.isDisposed()) {
+            application.getMessageBus()
+                    .syncPublisher(AppLandDownloadListener.TOPIC)
+                    .downloadFinished(type, success);
+        }
     }
 
     // package-visible for our tests

--- a/plugin-core/src/main/java/appland/cli/DownloadToolsStartupActivity.java
+++ b/plugin-core/src/main/java/appland/cli/DownloadToolsStartupActivity.java
@@ -2,6 +2,7 @@ package appland.cli;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Executed in a background thread.
  * The download is only performed on the first opened project.
  */
-public class DownloadToolsStartupActivity implements StartupActivity.Background {
+public class DownloadToolsStartupActivity implements StartupActivity, DumbAware {
     private static final Logger LOG = Logger.getInstance(DownloadToolsStartupActivity.class);
     private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
 

--- a/plugin-core/src/main/java/appland/execution/UnsupportedJdkException.java
+++ b/plugin-core/src/main/java/appland/execution/UnsupportedJdkException.java
@@ -34,10 +34,6 @@ public class UnsupportedJdkException extends ExecutionException implements Hyper
 
     @NotNull
     private static String findMessage() {
-        // 2021.3 and earlier don't support link handlers of ExecutionException when the exception is shown as message dialog.
-        // 2022.1 and later display a notification instead of a message dialog and thus support the link handler.
-        return ApplicationInfo.getInstance().getBuild().getBaselineVersion() <= 213
-                ? AppMapBundle.get("appMapExecutor.jdkNotSupported")
-                : AppMapBundle.get("appMapExecutor.jdkNotSupportedWithLink");
+        return AppMapBundle.get("appMapExecutor.jdkNotSupportedWithLink");
     }
 }

--- a/plugin-core/src/main/java/appland/notifications/AppMapFullContentNotification.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapFullContentNotification.java
@@ -14,6 +14,7 @@ import javax.swing.*;
  * Notification, which implements {@link NotificationFullContent} to show all of its content.
  */
 class AppMapFullContentNotification extends Notification implements NotificationFullContent {
+    @SuppressWarnings("deprecation")
     public AppMapFullContentNotification(@NotNull @NonNls String groupId,
                                          @Nullable Icon icon,
                                          @Nullable String title,
@@ -26,6 +27,7 @@ class AppMapFullContentNotification extends Notification implements Notification
         setSubtitle(subtitle);
         setIcon(icon);
         if (listener != null) {
+            // There's currently no alternative to handle clickable URL links in html content.
             setListener(listener);
         }
     }

--- a/plugin-core/src/main/java/appland/oauth/AppMapLocalKeyValidator.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLocalKeyValidator.java
@@ -2,11 +2,11 @@ package appland.oauth;
 
 import appland.AppMapBundle;
 import com.intellij.openapi.ui.InputValidatorEx;
-import com.intellij.util.Base64;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.regex.Pattern;
 
 class AppMapLocalKeyValidator implements InputValidatorEx {
@@ -31,7 +31,7 @@ class AppMapLocalKeyValidator implements InputValidatorEx {
     public @Nullable String getErrorText(@NonNls String inputString) {
         byte[] decoded;
         try {
-            decoded = Base64.decode(inputString.trim());
+            decoded = Base64.getDecoder().decode(inputString.trim());
         } catch (IllegalArgumentException e) {
             decoded = null;
         }

--- a/plugin-core/src/main/java/appland/oauth/AppMapLoginAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLoginAction.java
@@ -1,16 +1,21 @@
 package appland.oauth;
 
 import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class AppMapLoginAction extends AnAction implements DumbAware, UpdateInBackground {
+public class AppMapLoginAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         authenticate();

--- a/plugin-core/src/main/java/appland/oauth/AppMapLoginByKeyAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLoginByKeyAction.java
@@ -3,9 +3,9 @@ package appland.oauth;
 import appland.AppMapBundle;
 import appland.notifications.AppMapNotifications;
 import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.InputValidator;
@@ -26,7 +26,12 @@ import static com.intellij.openapi.ui.Messages.getOkButton;
 /**
  * Action to sign in to AppMap by providing a license key.
  */
-public class AppMapLoginByKeyAction extends AnAction implements DumbAware, UpdateInBackground {
+public class AppMapLoginByKeyAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         var project = Objects.requireNonNull(e.getProject());

--- a/plugin-core/src/main/java/appland/oauth/AppMapLogoutAction.java
+++ b/plugin-core/src/main/java/appland/oauth/AppMapLogoutAction.java
@@ -1,14 +1,19 @@
 package appland.oauth;
 
 import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class AppMapLogoutAction extends AnAction implements DumbAware, UpdateInBackground {
+public class AppMapLogoutAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         logout();

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -78,7 +78,7 @@ public class AppMapToolWindowFactory implements ToolWindowFactory, DumbAware {
             }
         });
 
-        var content = ContentFactory.SERVICE.getInstance().createContent(null, null, false);
+        var content = ContentFactory.getInstance().createContent(null, null, false);
         content.setComponent(panel);
         toolWindow.getContentManager().addContent(content);
 

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
@@ -136,8 +136,8 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
             return null;
         }
 
-        if (PlatformCoreDataKeys.SLOW_DATA_PROVIDERS.is(dataId)) {
-            return List.of((DataProvider) this::getDataImpl);
+        if (PlatformCoreDataKeys.BGT_DATA_PROVIDER.is(dataId)) {
+            return (DataProvider) this::getDataImpl;
         }
         return getDataImpl(dataId);
     }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
@@ -11,11 +11,16 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Action to delete all AppMaps displayed in the AppMap panel.
  */
-final class DeleteAllMapsAction extends AnAction implements UpdateInBackground {
+final class DeleteAllMapsAction extends AnAction {
     private final DeleteProvider deleteHandler = new VirtualFileDeleteProvider();
 
     public DeleteAllMapsAction() {
         super(AppMapBundle.get("toolwindow.appmap.actions.deleteAllAppMaps.title"), null, AllIcons.General.Remove);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/toolwindow/codeObjects/CodeObjectsPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/codeObjects/CodeObjectsPanel.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.pom.Navigatable;
 import com.intellij.ui.ScrollPaneFactory;
-import com.intellij.ui.TreeSpeedSearch;
+import com.intellij.ui.TreeUIHelper;
 import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.RestoreSelectionListener;
 import com.intellij.ui.treeStructure.Tree;
@@ -49,7 +49,7 @@ public class CodeObjectsPanel extends JPanel implements Disposable, DataProvider
         tree.setVisibleRowCount(8);
         tree.getSelectionModel().setSelectionMode(SINGLE_TREE_SELECTION);
         tree.addTreeSelectionListener(new RestoreSelectionListener());
-        new TreeSpeedSearch(tree);
+        TreeUIHelper.getInstance().installTreeSpeedSearch(tree);
         EditSourceOnDoubleClickHandler.install(tree);
         EditSourceOnEnterKeyHandler.install(tree);
         return tree;

--- a/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisPanel.java
@@ -9,7 +9,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.pom.Navigatable;
 import com.intellij.ui.ScrollPaneFactory;
-import com.intellij.ui.TreeSpeedSearch;
+import com.intellij.ui.TreeUIHelper;
 import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.RestoreSelectionListener;
 import com.intellij.ui.treeStructure.Tree;
@@ -83,7 +83,7 @@ public class RuntimeAnalysisPanel extends JPanel implements Disposable, DataProv
         tree.setVisibleRowCount(8);
         tree.getSelectionModel().setSelectionMode(SINGLE_TREE_SELECTION);
         tree.addTreeSelectionListener(new RestoreSelectionListener());
-        new TreeSpeedSearch(tree);
+        TreeUIHelper.getInstance().installTreeSpeedSearch(tree);
         EditSourceOnDoubleClickHandler.install(tree);
         EditSourceOnEnterKeyHandler.install(tree);
 

--- a/plugin-core/src/main/java/appland/webviews/appMap/AppMapNotificationProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/appMap/AppMapNotificationProvider.java
@@ -5,32 +5,28 @@ import appland.files.AppMapFiles;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
-import com.intellij.ui.EditorNotifications;
+import com.intellij.ui.EditorNotificationProvider;
 import com.intellij.ui.LightColors;
 import com.intellij.ui.jcef.JBCefApp;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AppMapNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
-    private static final Key<EditorNotificationPanel> KEY = Key.create("appland.jcefEditor");
+import javax.swing.*;
+import java.util.function.Function;
 
+public class AppMapNotificationProvider implements EditorNotificationProvider, DumbAware {
     @Override
-    public @NotNull Key<EditorNotificationPanel> getKey() {
-        return KEY;
-    }
+    public @Nullable Function<? super @NotNull FileEditor, ? extends @Nullable JComponent> collectNotificationData(@NotNull Project project, @NotNull VirtualFile file) {
+        return editor -> {
+            if (AppMapFiles.isAppMap(file) && !JBCefApp.isSupported()) {
+                var panel = new EditorNotificationPanel(LightColors.RED);
+                panel.setText(AppMapBundle.get("appmap.editor.unavailableWarning"));
+                return panel;
+            }
 
-    @Nullable
-    @Override
-    public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor fileEditor, @NotNull Project project) {
-        if (AppMapFiles.isAppMap(file) && !JBCefApp.isSupported()) {
-            var panel = new EditorNotificationPanel(LightColors.RED);
-            panel.setText(AppMapBundle.get("appmap.editor.unavailableWarning"));
-            return panel;
-        }
-
-        return null;
+            return null;
+        };
     }
 }

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -6,23 +6,16 @@ import appland.notifications.AppMapNotifications;
 import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.webviews.WebviewEditorProvider;
-import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DataKey;
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
@@ -105,12 +98,6 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
 
             AppMapProjectSettingsService.getState(project).setExplainWithNavieOpened(true);
             FileEditorManager.getInstance(project).openFile(file, true);
-
-            var hideMessagePropertyKey = "appmap.navie.hideIsBrokenMessage";
-            var properties = PropertiesComponent.getInstance();
-            if (isNavieWebviewSupportBroken() && !properties.getBoolean(hideMessagePropertyKey, false)) {
-                showNavieWebviewBrokenMessage(project, properties, hideMessagePropertyKey);
-            }
         });
     }
 
@@ -158,32 +145,5 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
     @FunctionalInterface
     private interface ShowNavieConsumer {
         void openNavie(@Nullable Integer indexerPort, @Nullable NavieCodeSelection codeSelection);
-    }
-
-    private static boolean isNavieWebviewSupportBroken() {
-        var buildBaseline = ApplicationInfo.getInstance().getBuild().getBaselineVersion();
-
-        // Linux <= 2023.1 is broken,
-        // https://youtrack.jetbrains.com/issue/JBR-5348/JCEF-OSR-Keyboard-doesnt-work-on-Linux
-        return SystemInfo.isLinux && buildBaseline <= 231;
-    }
-
-    @SuppressWarnings("removal")
-    private static void showNavieWebviewBrokenMessage(@NotNull Project project, PropertiesComponent properties, String hideMessagePropertyKey) {
-        ApplicationManager.getApplication().invokeLater(() -> {
-            Messages.showDialog(project,
-                    AppMapBundle.get("webview.navie.webviewBroken.message"),
-                    AppMapBundle.get("webview.navie.webviewBroken.title"),
-                    new String[]{Messages.getOkButton()},
-                    0,
-                    Messages.getWarningIcon(),
-                    // already deprecated in 2022.1, but there's no alternative API in Messages.
-                    new DialogWrapper.DoNotAskOption.Adapter() {
-                        @Override
-                        public void rememberChoice(boolean isSelected, int exitCode) {
-                            properties.setValue(hideMessagePropertyKey, isSelected, false);
-                        }
-                    });
-        }, ModalityState.any());
     }
 }

--- a/plugin-core/src/main/kotlin/appland/remote/StartRemoteRecordingForm.kt
+++ b/plugin-core/src/main/kotlin/appland/remote/StartRemoteRecordingForm.kt
@@ -2,11 +2,10 @@ package appland.remote
 
 import appland.AppMapBundle
 import com.intellij.ui.TextFieldWithHistory
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import javax.swing.JPanel
 
-@Suppress("UnstableApiUsage")
 class StartRemoteRecordingForm(recentUrls: List<String>) {
     lateinit var urlComboBox: TextFieldWithHistory
         private set
@@ -19,9 +18,9 @@ class StartRemoteRecordingForm(recentUrls: List<String>) {
     val mainPanel: JPanel = panel {
         row(label = AppMapBundle.get("appMapRemoteRecording.urlLabel")) {
             urlComboBox = textFieldWithHistory(recentUrls)
-                    .horizontalAlign(HorizontalAlign.FILL)
-                    .focused()
-                    .component
+                .align(AlignX.FILL)
+                .focused()
+                .component
         }
         row {
             comment(AppMapBundle.get("appMapRemoteRecording.message"))

--- a/plugin-core/src/main/kotlin/appland/remote/StopRemoteRecordingForm.kt
+++ b/plugin-core/src/main/kotlin/appland/remote/StopRemoteRecordingForm.kt
@@ -3,10 +3,9 @@ package appland.remote
 import appland.AppMapBundle
 import com.intellij.ui.TextFieldWithHistory
 import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 
-@Suppress("UnstableApiUsage")
 class StopRemoteRecordingForm(activeRecordingUrl: String?, recentUrls: List<String>) {
     lateinit var urlComboBox: TextFieldWithHistory
         private set
@@ -15,14 +14,14 @@ class StopRemoteRecordingForm(activeRecordingUrl: String?, recentUrls: List<Stri
 
     val mainPanel = panel {
         row(AppMapBundle.get("appMapRemoteRecording.urlLabel")) {
-            urlComboBox = textFieldWithHistory(recentUrls).horizontalAlign(HorizontalAlign.FILL).component
+            urlComboBox = textFieldWithHistory(recentUrls).align(AlignX.FILL).component
             if (!activeRecordingUrl.isNullOrEmpty()) {
                 urlComboBox.text = activeRecordingUrl
             }
         }
 
         row(AppMapBundle.get("appMapRemoteRecording.appMapNameLabel")) {
-            appMapNameInput = textField().horizontalAlign(HorizontalAlign.FILL).component
+            appMapNameInput = textField().align(AlignX.FILL).component
         }
     }
 

--- a/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
+++ b/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
@@ -2,8 +2,8 @@ package appland.settings
 
 import appland.AppMapBundle
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import java.awt.BorderLayout
 import javax.swing.JCheckBox
 import javax.swing.JPanel
@@ -33,7 +33,7 @@ class AppMapProjectSettingsPanel {
             }
             group(AppMapBundle.get("projectSettings.appMapServices")) {
                 row {
-                    cell(cliEnvironment).horizontalAlign(HorizontalAlign.FILL)
+                    cell(cliEnvironment).align(AlignX.FILL)
                 }
             }
         }

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -48,6 +48,7 @@
         <postStartupActivity implementation="appland.cli.RegisterContentRootsActivity"/>
         <postStartupActivity implementation="appland.cli.DownloadToolsStartupActivity"/>
         <postStartupActivity implementation="appland.rpcService.AppMapJsonRpcServerStartupActivity"/>
+        <postStartupActivity implementation="appland.cli.AppLandProjectOpenActivity"/>
 
         <fileEditorProvider implementation="appland.webviews.appMap.AppMapFileEditorProvider"/>
         <editorNotificationProvider implementation="appland.webviews.appMap.AppMapNotificationProvider"/>

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -196,8 +196,6 @@ webview.findingDetails.appMapNotFound.message=The AppMap file could not be found
 
 webview.navie.title=AppMap AI: Explain
 webview.navie.chooseAppMapModule.title=Choose AppMap module
-webview.navie.webviewBroken.title=AppMap Navie
-webview.navie.webviewBroken.message=Please update your IDE to version 2023.2 or later.\nNavie will not work with versions prior to 2023.2 because there is an IDE issue that prevents typing into input fields.
 webview.navie.updatingMostRecentAppMaps=Locating most recent AppMaps...
 
 codeObjects.codeTopLevel.label=Code

--- a/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadActivity.java
+++ b/plugin-java/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadActivity.java
@@ -2,13 +2,14 @@ package appland.javaAgent;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class AppMapJavaAgentDownloadActivity implements StartupActivity.Background {
+public class AppMapJavaAgentDownloadActivity implements StartupActivity, DumbAware {
     private static final Logger LOG = Logger.getInstance(AppMapJavaAgentDownloadActivity.class);
     private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
 


### PR DESCRIPTION
Closes #655 

Drops supports for the older IDEs and replaces deprecated API with the now available alternatives.
For 2023.1 (the earliest supported version) the plugin verifier is now only reporting one use of deprecated. We're unable to drop it because we're supporting clickable links in notifications and there's no other way to achieve this.

Questions / open:
- [ ] I was unable to test "Sign in with Key" because I don't have a valid key at hand