### PR TITLE
Improve support for multi-module Maven projects

### DIFF
--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -80,6 +80,33 @@ public final class AppMapFiles {
     }
 
     /**
+     * Locate an existing appmap.yml file, searching in context and all its parent directories.
+     * This method does not use indexes, but needs to be invoked in a {@link ReadAction}.
+     * Only files on the local filesystem are considered.
+     *
+     * @param context     The file or directory to search from
+     * @param searchScope Scope to restrict the search for the appmap configuration file
+     * @return The appmap.yml file in the directory or its ancestors, if available
+     */
+    @RequiresReadLock
+    public static @Nullable VirtualFile findAppMapConfigFile(@NotNull VirtualFile context,
+                                                             @NotNull GlobalSearchScope searchScope) {
+        if (!context.isInLocalFileSystem()) {
+            return null;
+        }
+
+        var directory = context.isDirectory() ? context : context.getParent();
+        while (directory != null && directory.isValid() && searchScope.contains(directory)) {
+            var configFile = directory.findChild(APPMAP_YML);
+            if (configFile != null && !configFile.isDirectory()) {
+                return configFile;
+            }
+            directory = directory.getParent();
+        }
+        return null;
+    }
+
+    /**
      * @param appMapConfigFile appmap.yml file
      * @return The "appmap_dir" property value, if it's configured in the file
      */

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -141,6 +141,9 @@
         <registryKey key="appmap.webview.open.dev.tools"
                      defaultValue="false"
                      description="Open the developer console for AppMap webviews."/>
+        <registryKey key="appmap.agent.debug"
+                     defaultValue="false"
+                     description="Enable debug logging of the AppMap Java agent"/>
     </extensions>
 
     <actions>

--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -7,8 +7,6 @@ import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.util.text.StringUtil;
@@ -17,14 +15,12 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
-import com.intellij.util.ThrowableRunnable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4TestCase {
     @Override
@@ -140,28 +136,6 @@ public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4Tes
             ModuleRootModificationUtil.updateExcludedFolders(getModule(), excludedFolder.getParent(),
                     Collections.singletonList(excludedFolder.getUrl()),
                     Collections.emptyList());
-        }
-    }
-
-    protected void withContentRoot(@NotNull Module module, @NotNull VirtualFile contentRoot, @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
-        assertTrue(contentRoot.isDirectory());
-
-        var contentEntryRef = new AtomicReference<ContentEntry>();
-        try {
-            // hack to use ModuleRootModificationUtil and to keep a reference to the new entry
-            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
-                contentEntryRef.set(modifiableRootModel.addContentEntry(contentRoot));
-            });
-
-            runnable.run();
-        } finally {
-            // remove again to avoid breaking follow-up tests
-            var newEntry = contentEntryRef.get();
-            assertNotNull(newEntry);
-
-            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
-                modifiableRootModel.removeContentEntry(newEntry);
-            });
         }
     }
 

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -3,6 +3,7 @@ package appland.cli;
 import appland.AppMapBaseTest;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
+import appland.utils.ModuleTestUtils;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.PtyCommandLine;
 import com.intellij.execution.process.KillableProcessHandler;
@@ -216,7 +217,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         var projectDir = myFixture.copyDirectoryToProject("projects/without_existing_index", "test-project");
 
         var refreshCondition = TestCommandLineService.newVfsRefreshCondition(getProject(), getTestRootDisposable());
-        withContentRoot(getModule(), projectDir, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), projectDir, () -> {
             assertTrue(refreshCondition.await(30, TimeUnit.SECONDS));
 
             var refreshedFiles = TestCommandLineService.getInstance().getRefreshedFiles();
@@ -267,7 +268,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         var newRootA = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
 
         final var rootRefreshCondition = ProjectRefreshUtil.newProjectRefreshCondition(getTestRootDisposable());
-        withContentRoot(getModule(), newRootA, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), newRootA, () -> {
             assertTrue(rootRefreshCondition.await(30, TimeUnit.SECONDS));
 
             // no watched roots because there's no appmap.yml

--- a/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
@@ -1,6 +1,7 @@
 package appland.index;
 
 import appland.AppMapBaseTest;
+import appland.utils.ModuleTestUtils;
 import com.intellij.openapi.application.WriteAction;
 import org.junit.Test;
 
@@ -19,7 +20,7 @@ public class AppMapSearchScopesTest extends AppMapBaseTest {
         try {
             assertFalse("scope must not contain folders, which are outside content roots", scope.contains(topLevelDir));
 
-            withContentRoot(getModule(), topLevelDir, () -> {
+            ModuleTestUtils.withContentRoot(getModule(), topLevelDir, () -> {
                 assertTrue("scope must contain content roots", scope.contains(topLevelDir));
 
                 withExcludedFolder(topLevelDir, () -> {

--- a/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
@@ -3,6 +3,7 @@ package appland.problemsView.listener;
 import appland.AppMapBaseTest;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.TestFindingsManager;
+import appland.utils.ModuleTestUtils;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Test;
@@ -29,7 +30,7 @@ public class ScannerFilesAsyncListenerContentRootTest extends AppMapBaseTest {
         // create src/root to add it as content root to the current module
         // the file listener is using a project scope, which needs a properly set up content root
         var rootDir = myFixture.getTempDirFixture().findOrCreateDir("root");
-        withContentRoot(getModule(), rootDir, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), rootDir, () -> {
             var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
             // adding an appmap-findings.json file must trigger a refresh via the file watcher
             myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");

--- a/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
@@ -1,6 +1,7 @@
 package appland.toolwindow.appmap;
 
 import appland.AppMapBaseTest;
+import appland.utils.ModuleTestUtils;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
@@ -41,7 +42,7 @@ public class AppMapModelTest extends AppMapBaseTest {
                 "request_recording1.appmap.json",
                 "request_recording2.appmap.json");
 
-        withContentRoot(getModule(), rootOne, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
             var model = new AppMapModel(getProject());
             var expected = "-AppMaps\n" +
                     " -root_one\n" +
@@ -56,7 +57,7 @@ public class AppMapModelTest extends AppMapBaseTest {
                 "request_recording2.appmap.json",
                 "request_recording1.appmap.json");
 
-        withContentRoot(getModule(), rootOne, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
             var model = new AppMapModel(getProject());
             var expected = "-AppMaps\n" +
                     " -root_one\n" +
@@ -72,7 +73,7 @@ public class AppMapModelTest extends AppMapBaseTest {
         // copy into parent dir, because the default location is "src/", which already is a content root
         var rootOne = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_one"));
 
-        withContentRoot(getModule(), rootOne, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
             var model = new AppMapModel(getProject());
             var expected = "-AppMaps\n" +
                     " -root_one\n" +
@@ -91,8 +92,8 @@ public class AppMapModelTest extends AppMapBaseTest {
         var rootOne = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_one"));
         var rootTwo = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_two"));
 
-        withContentRoot(getModule(), rootOne, () -> {
-            withContentRoot(getModule(), rootTwo, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
+            ModuleTestUtils.withContentRoot(getModule(), rootTwo, () -> {
                 var model = new AppMapModel(getProject());
                 var expected = "-AppMaps\n" +
                         " -root_one\n" +

--- a/plugin-core/src/test/java/appland/utils/ModuleTestUtils.java
+++ b/plugin-core/src/test/java/appland/utils/ModuleTestUtils.java
@@ -1,0 +1,35 @@
+package appland.utils;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.roots.ContentEntry;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.ThrowableRunnable;
+import junit.framework.TestCase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ModuleTestUtils {
+    public static void withContentRoot(@NotNull Module module, @NotNull VirtualFile contentRoot, @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
+        TestCase.assertTrue(contentRoot.isDirectory());
+
+        var contentEntryRef = new AtomicReference<ContentEntry>();
+        try {
+            // hack to use ModuleRootModificationUtil and to keep a reference to the new entry
+            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
+                contentEntryRef.set(modifiableRootModel.addContentEntry(contentRoot));
+            });
+
+            runnable.run();
+        } finally {
+            // remove again to avoid breaking follow-up tests
+            var newEntry = contentEntryRef.get();
+            TestCase.assertNotNull(newEntry);
+
+            ModuleRootModificationUtil.updateModel(module, modifiableRootModel -> {
+                modifiableRootModel.removeContentEntry(newEntry);
+            });
+        }
+    }
+}

--- a/plugin-java/src/main/java/appland/execution/AppMapJavaAgentRunner.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJavaAgentRunner.java
@@ -1,9 +1,7 @@
 package appland.execution;
 
-import com.intellij.execution.ExecutionException;
 import com.intellij.execution.JavaRunConfigurationBase;
 import com.intellij.execution.configurations.RunProfile;
-import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.project.DumbService;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -16,11 +14,6 @@ public class AppMapJavaAgentRunner extends AbstractAppMapJavaAgentRunner {
     @Override
     public @NotNull @NonNls String getRunnerId() {
         return "appmap.runner.java";
-    }
-
-    @Override
-    public void execute(@NotNull ExecutionEnvironment environment) throws ExecutionException {
-        super.execute(environment);
     }
 
     @Override

--- a/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJvmCommandLinePatcher.java
@@ -4,6 +4,7 @@ import appland.AppMapBundle;
 import appland.AppMapPlugin;
 import appland.javaAgent.AppMapJavaAgentDownloadService;
 import com.intellij.execution.CantRunException;
+import com.intellij.openapi.util.registry.Registry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +37,9 @@ public final class AppMapJvmCommandLinePatcher {
         var jvmParams = new LinkedList<String>();
         jvmParams.add("-Dappmap.config.file=" + appMapConfig);
         jvmParams.add("-javaagent:" + agentJarPath);
+        if (Registry.is("appmap.agent.debug")) {
+            jvmParams.add("-Dappmap.disableLogFile=false");
+        }
         return jvmParams;
     }
 }

--- a/plugin-java/src/main/java/appland/execution/AppMapProgramPatcher.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapProgramPatcher.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Our own extension to patch Java program parameters.
  * We can't use {@link com.intellij.execution.runners.JavaProgramPatcher}, because its patch method
- * is always executed in a ReadAction. Our own patching must outside a ReadAction, because we need to run
+ * is always executed in a ReadAction. Our own patching must happen outside a ReadAction, because we need to run
  * tasks.
  */
 public interface AppMapProgramPatcher {

--- a/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigHeavyTest.java
+++ b/plugin-java/src/test/java/appland/execution/AppMapJavaPackageConfigHeavyTest.java
@@ -1,0 +1,28 @@
+package appland.execution;
+
+import appland.files.AppMapFiles;
+import appland.index.AppMapSearchScopes;
+import appland.utils.ModuleTestUtils;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.testFramework.HeavyPlatformTestCase;
+
+import java.nio.charset.StandardCharsets;
+
+// heavy test because light tests can't create modules
+public class AppMapJavaPackageConfigHeavyTest extends HeavyPlatformTestCase {
+    // Tests that appmap.yml in a top-level directory is found
+    // if search starts in a different module and a directory nested inside appmap.yml's parent.
+    public void testFindAppConfigInTopLevelModule() throws Exception {
+        var appMapConfig = createTempVirtualFile(AppMapFiles.APPMAP_YML, null, "", StandardCharsets.UTF_8);
+        ModuleTestUtils.withContentRoot(myModule, appMapConfig.getParent(), () -> {
+            var nestedModule = createModule("nested-module");
+            var nestedModuleContentRoot = WriteAction.compute(() -> appMapConfig.getParent().createChildDirectory(this, "nested-module-root"));
+
+            ModuleTestUtils.withContentRoot(nestedModule, nestedModuleContentRoot, () -> {
+                var projectScope = AppMapSearchScopes.appMapConfigSearchScope(getProject());
+                var locatedConfigFile = AppMapJavaPackageConfig.findAndUpdateAppMapConfig(nestedModuleContentRoot, projectScope);
+                assertEquals("The top-level config file must be found", appMapConfig.toNioPath(), locatedConfigFile);
+            });
+        });
+    }
+}

--- a/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
+++ b/plugin-maven/src/main/java/appland/execution/AppMapMavenProgramPatcher.java
@@ -2,6 +2,7 @@ package appland.execution;
 
 import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.configurations.RunProfile;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.util.text.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.execution.MavenRunConfiguration;
@@ -20,6 +21,12 @@ public class AppMapMavenProgramPatcher extends AbstractAppMapJavaProgramPatcher 
 
         // delegate to Maven child processes via argLine. It follows the implementation of the Maven surefire plugin
         // https://github.com/apache/maven-surefire/blob/78805045bb90d7cc5692b6a388e3605d648146d2/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java#L372
-        javaParameters.getVMParametersList().add("-DargLine=" + Strings.join(jvmParams, " "));
+        var existingArgLine = StringUtil.defaultIfEmpty(javaParameters.getVMParametersList().getPropertyValue("argLine"), "");
+        var appMapArgLine = Strings.join(jvmParams, " ");
+        if (!existingArgLine.isEmpty()) {
+            appMapArgLine = existingArgLine + " " + appMapArgLine;
+        }
+
+        javaParameters.getVMParametersList().add("-DargLine=" + appMapArgLine);
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/659
This PR is based on https://github.com/getappmap/appmap-intellij-plugin/pull/661, which must be merged first.

This PR improves the support for projects with multiple modules.

Sample project structure:
- `/project`: Root directory of the project and content root of a module
- `/project/appmap.yml`: Existing AppMap config file
- `/project/submodule`: Content root of module `submodule`

Starting (maven) tests inside `submodule`:
Without this PR, a new config file was created at `/project/submodule/appmap.yml` instead of reusing the existing `/project/appmap.yml` file.

This PR fixes the search so that the top-level `appmap.yml` file is used instead and no new appmap configuration file is created. 
Only directories, which are included in a content root of the project are considered. 
Allowing `appmap.yml` files located outside the project would create a lot of problems, e.g. undetected changes to `appmap.yml` file or undetected changes to `.appmap.json` files.

Other changes:
- Property `appmap_dir` of an existing `appmap.yml` is only updated to `tmp/appmap` if it's missing. Before, it was always overridden, which could have set a wrong path for some edge-cases.
- New tests to verify the lookup of the appmap.yml file for nested modules
- Don't override an existing `-Dargline=...` but append out arguments instead.
- Add a new IDE registry key to enable the debug log of the agent. By default, the agent does not create log files anymore. If this registry key is enabled, log files are created and allow debugging issues with the Java agent on a user's system.