### PR TITLE
Send project content roots to local AppLand JSON-RPC service

### DIFF
--- a/plugin-core/src/main/java/appland/rpcService/AppLandJsonRpcListener.java
+++ b/plugin-core/src/main/java/appland/rpcService/AppLandJsonRpcListener.java
@@ -2,6 +2,7 @@ package appland.rpcService;
 
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
@@ -14,5 +15,6 @@ public interface AppLandJsonRpcListener {
 
     void serverRestarted();
 
-    void serverConfigurationUpdated(Collection<VirtualFile> appMapConfigFiles);
+    void serverConfigurationUpdated(@NotNull Collection<VirtualFile> contentRoots,
+                                    @NotNull Collection<VirtualFile> appMapConfigFiles);
 }

--- a/plugin-core/src/main/java/appland/rpcService/AppLandJsonRpcListenerAdapter.java
+++ b/plugin-core/src/main/java/appland/rpcService/AppLandJsonRpcListenerAdapter.java
@@ -1,6 +1,7 @@
 package appland.rpcService;
 
 import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
@@ -21,6 +22,7 @@ public abstract class AppLandJsonRpcListenerAdapter implements AppLandJsonRpcLis
     }
 
     @Override
-    public void serverConfigurationUpdated(Collection<VirtualFile> appMapConfigFiles) {
+    public void serverConfigurationUpdated(@NotNull Collection<VirtualFile> contentRoots,
+                                           @NotNull Collection<VirtualFile> appMapConfigFiles) {
     }
 }

--- a/plugin-core/src/main/java/appland/rpcService/SetConfigurationV1Params.java
+++ b/plugin-core/src/main/java/appland/rpcService/SetConfigurationV1Params.java
@@ -1,0 +1,18 @@
+package appland.rpcService;
+
+import com.google.gson.annotations.SerializedName;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+/**
+ * JSON-RPC parameters for message "v1.configuration.set".
+ */
+class SetConfigurationV1Params {
+    @SerializedName("appmapConfigFiles")
+    public final Collection<String> appmapConfigFiles;
+
+    SetConfigurationV1Params(@NotNull Collection<String> appmapConfigFiles) {
+        this.appmapConfigFiles = appmapConfigFiles;
+    }
+}

--- a/plugin-core/src/main/java/appland/rpcService/SetConfigurationV2Params.java
+++ b/plugin-core/src/main/java/appland/rpcService/SetConfigurationV2Params.java
@@ -1,0 +1,22 @@
+package appland.rpcService;
+
+import com.google.gson.annotations.SerializedName;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+/**
+ * JSON-RPC parameters for message "v2.configuration.set".
+ */
+class SetConfigurationV2Params {
+    @SerializedName("projectDirectories")
+    public final Collection<String> projectDirectories;
+    @SerializedName("appmapConfigFiles")
+    public final Collection<String> appmapConfigFiles;
+
+    SetConfigurationV2Params(@NotNull Collection<@NotNull String> projectDirectories,
+                             @NotNull Collection<@NotNull String> appmapConfigFiles) {
+        this.appmapConfigFiles = appmapConfigFiles;
+        this.projectDirectories = projectDirectories;
+    }
+}

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -38,7 +38,8 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
                 .subscribe(AppLandJsonRpcListener.TOPIC,
                         new AppLandJsonRpcListenerAdapter() {
                             @Override
-                            public void serverConfigurationUpdated(Collection<VirtualFile> appMapConfigFiles) {
+                            public void serverConfigurationUpdated(@NotNull Collection<VirtualFile> contentRoots,
+                                                                   @NotNull Collection<VirtualFile> appMapConfigFiles) {
                                 serverConfigFiles.set(appMapConfigFiles);
                                 latch.countDown();
                             }
@@ -47,7 +48,9 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
         var appMapConfig = myFixture.copyFileToProject("appmap-config/appmap.yml");
 
         assertTrue("An AppMap config update must be sent to the JSON-RPC server", latch.await(30, TimeUnit.SECONDS));
-        assertArrayEquals("The updated config file path must be sent", new VirtualFile[]{appMapConfig}, serverConfigFiles.get().toArray());
+        assertArrayEquals("The updated config file path must be sent",
+                new VirtualFile[]{appMapConfig},
+                serverConfigFiles.get().toArray());
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/667

This PR implements JSON-RPC message `v2.configuration.set`. 
It send the project's content roots as property `projectDirectories`. Nested content roots are removed from the list sent to the JSON-RPC service.

For spring-petclinic the following message is generated:
```json
{
  "jsonrpc": "2.0",
  "method": "v2.configuration.set",
  "params": {
    "projectDirectories": [
      "/sources/spring-petclinic-2023-08-31"
    ],
    "appmapConfigFiles": [
      "/sources/spring-petclinic-2023-08-31/appmap.yml"
    ]
  }
}
```

Only appmap-analysis is failing on CI, I don't know what's causing this failure.