### PR TITLE
Allow users to specify their own OpenAI key in the settings

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -5,6 +5,7 @@ import appland.config.AppMapConfigFileListener;
 import appland.files.AppMapFiles;
 import appland.files.AppMapVfsUtils;
 import appland.settings.AppMapApplicationSettingsService;
+import appland.settings.AppMapSecureApplicationSettingsService;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.PtyCommandLine;
@@ -39,9 +40,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static com.intellij.openapi.util.text.StringUtil.isNotEmpty;
 
 public class DefaultCommandLineService implements AppLandCommandLineService {
     private static final Logger LOG = Logger.getInstance(DefaultCommandLineService.class);
@@ -220,7 +224,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return null;
         }
 
-        return AppMapApplicationSettingsService.getInstance().applyServiceEnvironment(cmd);
+        return applyServiceEnvironment(cmd);
     }
 
     // We're not synchronizing, because some IDE threads display or use the result of toString
@@ -480,8 +484,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         var command = new GeneralCommandLine(commandLine)
                 .withWorkDirectory(workingDir.toString());
 
-        return new KillableProcessHandler(AppMapApplicationSettingsService.getInstance()
-                .applyServiceEnvironment(command)) {
+        return new KillableProcessHandler(applyServiceEnvironment(command)) {
             @Override
             protected BaseOutputReader.@NotNull Options readerOptions() {
                 return BaseOutputReader.Options.BLOCKING;
@@ -552,6 +555,24 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
 
         LOG.debug("AppMap CLI command line " + cmd.getCommandLineString());
         return cmd;
+    }
+
+    /**
+     * Configure the environment settings of the command line with the user-defined settings.
+     */
+    private static GeneralCommandLine applyServiceEnvironment(@NotNull GeneralCommandLine commandLine) {
+        var settings = AppMapApplicationSettingsService.getInstance();
+        var appMapKey = settings.getApiKey();
+        var openAIKey = AppMapSecureApplicationSettingsService.getInstance().getOpenAIKey();
+
+        var environmentType = settings.isCliPassParentEnv()
+                ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
+                : GeneralCommandLine.ParentEnvironmentType.NONE;
+
+        return commandLine.withParentEnvironmentType(environmentType)
+                .withEnvironment(settings.getCliEnvironment())
+                .withEnvironment(isNotEmpty(appMapKey) ? Map.of("APPMAP_API_KEY", appMapKey) : Map.of())
+                .withEnvironment(isNotEmpty(openAIKey) ? Map.of("OPENAI_API_KEY", openAIKey) : Map.of());
     }
 
     /**

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +28,7 @@ public final class AppMapNotifications {
     public static final String REMOTE_RECORDING_ID = "appmap.remoteRecording";
     public static final String TELEMETRY_ID = "appmap.telemetry";
     public static final String GENERIC_NOTIFICATIONS_ID = "appmap.generic";
+    public static final String SETTINGS_NOTIFICATIONS_ID = "appmap.settings";
 
     public static void showExpiringRecordingNotification(@NotNull Project project,
                                                          @Nullable String title,
@@ -167,6 +169,18 @@ public final class AppMapNotifications {
                     GENERIC_NOTIFICATIONS_ID, null,
                     null, null, AppMapBundle.get("notification.exportAppMapJson.content", error),
                     NotificationType.ERROR, null
+            );
+            notification.notify(project);
+        });
+    }
+
+    public static void showReloadProjectNotification(@NotNull Project project) {
+        EdtInvocationManager.invokeLaterIfNeeded(() -> {
+            var notification = new AppMapFullContentNotification(
+                    SETTINGS_NOTIFICATIONS_ID, null,
+                    null, null,
+                    AppMapBundle.get("notification.reloadProject.content"),
+                    NotificationType.INFORMATION, null
             );
             notification.notify(project);
         });

--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -64,6 +64,11 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
             1_000,
             this,
             Alarm.ThreadToUse.POOLED_THREAD);
+    // debounce requests to restart the JSON-RPC server process
+    private final SingleAlarm restartServerAlarm = new SingleAlarm(this::restartServerAsync,
+            1_000,
+            this,
+            Alarm.ThreadToUse.POOLED_THREAD);
 
     // flag to help avoid starting the server if we're already disposed
     private volatile boolean isDisposed;
@@ -245,11 +250,15 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
 
     @Override
     public void apiKeyChanged() {
-        restartServerAsync();
+        triggerRestartServer();
     }
 
     private void triggerSendConfigurationSet() {
         sendConfigurationAlarm.cancelAndRequest();
+    }
+
+    private void triggerRestartServer() {
+        restartServerAlarm.cancelAndRequest();
     }
 
     /**

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -60,19 +60,6 @@ public class AppMapApplicationSettings {
         this.cliEnvironment = Map.copyOf(environment);
     }
 
-    /**
-     * Apply environment variables and API key to the command line.
-     */
-    public GeneralCommandLine applyServiceEnvironment(@NotNull GeneralCommandLine commandLine) {
-        var key = apiKey;
-        var environmentType = cliPassParentEnv
-                ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
-                : GeneralCommandLine.ParentEnvironmentType.NONE;
-        return commandLine.withParentEnvironmentType(environmentType)
-                .withEnvironment(cliEnvironment)
-                .withEnvironment(isNotEmpty(key) ? Map.of("APPMAP_API_KEY", key) : Map.of());
-    }
-
     public void setApiKeyNotifying(@Nullable String apiKey) {
         var changed = !Objects.equals(apiKey, this.apiKey);
         this.apiKey = apiKey;

--- a/plugin-core/src/main/java/appland/settings/AppMapSecureApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSecureApplicationSettings.java
@@ -1,0 +1,10 @@
+package appland.settings;
+
+import org.jetbrains.annotations.Nullable;
+
+public interface AppMapSecureApplicationSettings {
+    @Nullable
+    String getOpenAIKey();
+
+    void setOpenAIKey(@Nullable String key);
+}

--- a/plugin-core/src/main/java/appland/settings/AppMapSecureApplicationSettingsService.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSecureApplicationSettingsService.java
@@ -1,0 +1,41 @@
+package appland.settings;
+
+import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.CredentialAttributesKt;
+import com.intellij.ide.passwordSafe.PasswordSafe;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.Service;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+@Service(Service.Level.APP)
+public final class AppMapSecureApplicationSettingsService implements AppMapSecureApplicationSettings {
+    public static @NotNull AppMapSecureApplicationSettings getInstance() {
+        return ApplicationManager.getApplication().getService(AppMapSecureApplicationSettingsService.class);
+    }
+
+    @Override
+    public @Nullable String getOpenAIKey() {
+        return PasswordSafe.getInstance().getPassword(createOpenAIKey());
+    }
+
+    @Override
+    public void setOpenAIKey(@Nullable String key) {
+        var oldValue = getOpenAIKey();
+        try {
+            PasswordSafe.getInstance().setPassword(createOpenAIKey(), key);
+        } finally {
+            if (!Objects.equals(oldValue, key)) {
+                ApplicationManager.getApplication().getMessageBus()
+                        .syncPublisher(AppMapSettingsListener.TOPIC)
+                        .openAIKeyChange();
+            }
+        }
+    }
+
+    private @NotNull CredentialAttributes createOpenAIKey() {
+        return new CredentialAttributes(CredentialAttributesKt.generateServiceName("AppMap", "OpenAI"));
+    }
+}

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -23,4 +23,7 @@ public interface AppMapSettingsListener {
 
     default void appMapWebViewFiltersChanged() {
     }
+
+    default void openAIKeyChange() {
+    }
 }

--- a/plugin-core/src/main/java/appland/settings/OpenAIReloadProjectListener.java
+++ b/plugin-core/src/main/java/appland/settings/OpenAIReloadProjectListener.java
@@ -1,0 +1,21 @@
+package appland.settings;
+
+import appland.notifications.AppMapNotifications;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.ProjectManager;
+
+/**
+ * Displays a notification in each of the opened projects to reload the project when the OpenAI key changes.
+ */
+public class OpenAIReloadProjectListener implements AppMapSettingsListener {
+    @Override
+    public void openAIKeyChange() {
+        ReadAction.run(() -> {
+            for (var project : ProjectManager.getInstance().getOpenProjects()) {
+                if (!project.isDisposed() && !project.isDefault()) {
+                    AppMapNotifications.showReloadProjectNotification(project);
+                }
+            }
+        });
+    }
+}

--- a/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
+++ b/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
@@ -2,7 +2,10 @@ package appland.settings
 
 import appland.AppMapBundle
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
+import com.intellij.openapi.util.text.Strings
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.RowLayout
 import com.intellij.ui.dsl.builder.panel
 import java.awt.BorderLayout
 import javax.swing.JCheckBox
@@ -11,27 +14,42 @@ import javax.swing.JPanel
 class AppMapProjectSettingsPanel {
     private lateinit var enableTelemetry: JCheckBox
     private lateinit var cliEnvironment: EnvironmentVariablesComponent
+    private lateinit var openAIKey: JBTextField
 
-    fun loadSettingsFrom(applicationSettings: AppMapApplicationSettings) {
+    fun loadSettingsFrom(
+        applicationSettings: AppMapApplicationSettings,
+        secureApplicationSettings: AppMapSecureApplicationSettings
+    ) {
         enableTelemetry.isSelected = applicationSettings.isEnableTelemetry
         cliEnvironment.envs = applicationSettings.cliEnvironment
         cliEnvironment.isPassParentEnvs = applicationSettings.isCliPassParentEnv
+
+        openAIKey.text = Strings.notNullize(secureApplicationSettings.openAIKey)
     }
 
-    fun applySettingsTo(applicationSettings: AppMapApplicationSettings) {
+    fun applySettingsTo(
+        applicationSettings: AppMapApplicationSettings,
+        secureApplicationSettings: AppMapSecureApplicationSettings
+    ) {
         applicationSettings.isEnableTelemetry = enableTelemetry.isSelected
         applicationSettings.cliEnvironment = cliEnvironment.envs
         applicationSettings.isCliPassParentEnv = cliEnvironment.isPassParentEnvs
+
+        secureApplicationSettings.openAIKey = Strings.nullize(openAIKey.text)
     }
 
     fun getMainPanel(): JPanel {
         cliEnvironment = EnvironmentVariablesComponent()
         cliEnvironment.labelLocation = BorderLayout.WEST
+
         return panel {
             row {
                 enableTelemetry = checkBox(AppMapBundle.get("projectSettings.enableTelemetry.title")).component
             }
             group(AppMapBundle.get("projectSettings.appMapServices")) {
+                row(AppMapBundle.get("projectSettings.openAIKey.title")) {
+                    openAIKey = textField().align(AlignX.FILL).component
+                }.layout(RowLayout.INDEPENDENT)
                 row {
                     cell(cliEnvironment).align(AlignX.FILL)
                 }

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -25,6 +25,9 @@
         <listener topic="appland.settings.AppMapSettingsListener"
                   class="appland.cli.RestartServicesAfterApiChangeListener"
                   activeInTestMode="false"/>
+        <listener topic="appland.settings.AppMapSettingsListener"
+                  class="appland.settings.OpenAIReloadProjectListener"
+                  activeInTestMode="false"/>
     </applicationListeners>
 
     <projectListeners>
@@ -109,6 +112,8 @@
                            key="telemetry.permission.title"/>
         <notificationGroup id="appmap.generic" displayType="BALLOON"
                            key="notification.groupGeneric.title"/>
+        <notificationGroup id="appmap.settings" displayType="STICKY_BALLOON"
+                           key="notification.groupSettings.title"/>
 
         <projectConfigurable groupId="tools" nonDefaultProject="true" order="first"
                              key="projectSettings.displayName"

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -118,6 +118,7 @@ notification.recordingStarted.content=<html>Recording has started at <a href="{0
 notification.recordingStopFailed.title=Failed to stop recording
 notification.recordingStopFailed.content=<html>The recording at <a href="{0}">{0}</a> could not be stopped.</html>
 notification.groupGeneric.title=AppMap notifications
+notification.groupSettings.title=AppMap Settings
 
 notification.appMapFileNotFound.title=AppMap
 notification.appMapFileNotFound.message=Unfortunately, the AppMap file could not be found.
@@ -133,6 +134,8 @@ notification.appMapSignIn.content=Logged into AppMap
 notification.navieUnavailable.content=AppMap Explain is not ready yet. Please try again in a few seconds.
 
 notification.exportAppMapJson.content=An error occurred while exporting AppMap JSON data: {0}.
+
+notification.reloadProject.content=Please reload your project because the AppMap settings changed.
 
 statusBar.recording.displayName=AppMap Recording
 statusBar.recording.recordingStatus=Recording...
@@ -153,6 +156,7 @@ projectSettings.confirmUpload=Confirm upload of AppMaps
 projectSettings.enableFindings.title=Enable findings (experimental, requires restart)
 projectSettings.enableTelemetry.title=Enable telemetry
 projectSettings.appMapServices=AppMap Services
+projectSettings.openAIKey.title=OpenAI key:
 
 installGuide.editor.title=Using AppMap
 installGuide.pageInstallAgent.title=Add AppMap to your project


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/675

This PR adds a new setting to configure a custom OpenAI key.
There's currently no additonal action (e.g. `AppMap: Set OpenAPI key`), but it could be added if it's needed.

Settings are persisted in the IDE's password safe.

When the OpenAI key changed, a notification is displayed in each open project to allow the user to reload it. 
The application-wide JSON-RPC process **is NOT restarted** immediately after the change of the OpenAI key. A restart would invalidate the port used by open Navie webviews.

The notification is sticky, which means that it won't hide automatically. Otherwise the user might miss the required reload.

This PR is moving `applyServiceEnvironment` from the application settings class to the command line handler class, because it's now using both ApplicationSettings and the new `SecureApplicationSettings`.

https://github.com/getappmap/appmap-intellij-plugin/pull/628 is needed, because "Reopen project" added by this PR is triggering the bug fixed by #628 .

**Testing**:
- I've tested this on Linux and macOS Sonoma with the secure storage of the OpenAI key. I haven't seen any weird prompts or behavior.

Updated settings UI:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/8157d119-b288-4f6f-a657-c0a0430ec167)

Notification:
![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/06625d55-eaa6-4d5e-babc-333cd716df8a)
