### PR TITLE
fix: set language property in default config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 on:
     pull_request:
     push:
@@ -39,16 +41,12 @@ jobs:
 
             - name: Run Linters and Test (Linux and macOS)
               if: runner.os != 'Windows'
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: ./gradlew check
 
             # Termination of AppMap CLI processes is failing with IC-2021.3 for unknown reasons (process.destroy() etc.)
             - name: Run Linters and Test with 2023.2 (Windows)
               if: runner.os == 'Windows'
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: ./gradlew check -PideVersion=IC-2023.2.1
 

--- a/plugin-core/src/main/java/appland/config/AppMapConfigFile.java
+++ b/plugin-core/src/main/java/appland/config/AppMapConfigFile.java
@@ -31,11 +31,14 @@ public class AppMapConfigFile {
     private static final String NAME_PROPERTY = "name";
     private static final String APPMAP_DIR_PROPERTY = "appmap_dir";
     private static final String PACKAGES_PROPERTY = "packages";
+    private static final String LANGUAGE_PROPERTY = "language";
+    private static final String LANGUAGE_VALUE = "java";
 
     private final @NotNull ObjectNode yamlData;
 
     public AppMapConfigFile() {
         this(new ObjectNode(JsonNodeFactory.instance));
+        yamlData.set(LANGUAGE_PROPERTY, new TextNode(LANGUAGE_VALUE));
     }
 
     public @Nullable String getName() {
@@ -102,6 +105,13 @@ public class AppMapConfigFile {
                 .map(Package::new)
                 .collect(Collectors.toList());
         yamlData.set(PACKAGES_PROPERTY, YamlUtils.YAML.valueToTree(packageNodes));
+    }
+
+    public @Nullable String getLanguage() {
+        if (yamlData.hasNonNull(LANGUAGE_PROPERTY)) {
+            return yamlData.get(LANGUAGE_PROPERTY).asText();
+        }
+        return null;
     }
 
     public void writeTo(@NotNull Path filePath) throws IOException {

--- a/plugin-core/src/test/java/appland/config/AppMapConfigFileTest.java
+++ b/plugin-core/src/test/java/appland/config/AppMapConfigFileTest.java
@@ -111,4 +111,10 @@ public class AppMapConfigFileTest extends AppMapBaseTest {
         config.setName("my AppMap name");
         assertEquals("my AppMap name", config.getName());
     }
+
+    @Test
+    public void languageProperty() {
+        var config = new AppMapConfigFile();
+        assertEquals(config.getLanguage(), "java");
+    }
 }


### PR DESCRIPTION
When generating the default config file, set the language property.

Fixes #689 .