### PR TITLE
Add keyboard shortcut open the Navie webview

### DIFF
--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -160,7 +160,12 @@
 
         <action id="appmap.generateOpenAPI" class="appland.actions.GenerateOpenApiAction"/>
 
-        <action id="appmap.openNavie" class="appland.actions.OpenAppMapNavieAction"/>
+        <action id="appmap.openNavie" class="appland.actions.OpenAppMapNavieAction">
+            <keyboard-shortcut keymap="$default"
+                               first-keystroke="alt A" second-keystroke="N"/>
+            <keyboard-shortcut replace-all="true"
+                               keymap="Mac OS X" first-keystroke="meta A" second-keystroke="N"/>
+        </action>
         <action id="appmap.navie.openAIKey" class="appland.actions.SetNavieOpenAiKeyAction"/>
 
         <action id="appmap.pluginStatus" class="appland.actions.PluginStatus"/>


### PR DESCRIPTION
This PR adds a shortcut for "Explain with Navie":
- Linux/Windows: `ALT + A, N`
- macOS: `Option + A, N`

AFAIK the VSCode plugin uses `Ctrl + A, N` on macOS. But `Ctrl+A` is already used in JetBrains IDEs. `Ctrl + A` is already assigned on macOS (action "go to start of line") and this action overrides our own shortcut.
`Option + A, N` is working fine on my setup of macOS.