### PR TITLE
Pass IDE proxy settings to the AppMap CLI tools

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -244,9 +244,13 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
     private static void notifyDownloadFinished(@NotNull CliTool type, boolean success) {
         var application = ApplicationManager.getApplication();
         if (!application.isDisposed()) {
-            application.getMessageBus()
-                    .syncPublisher(AppLandDownloadListener.TOPIC)
-                    .downloadFinished(type, success);
+            application.executeOnPooledThread(() -> {
+                if (!application.isDisposed()) {
+                    application.getMessageBus()
+                            .syncPublisher(AppLandDownloadListener.TOPIC)
+                            .downloadFinished(type, success);
+                }
+            });
         }
     }
 

--- a/plugin-core/src/test/java/appland/testRules/ResetIdeHttpProxyRule.java
+++ b/plugin-core/src/test/java/appland/testRules/ResetIdeHttpProxyRule.java
@@ -1,0 +1,27 @@
+package appland.testRules;
+
+import com.intellij.util.net.HttpConfigurable;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public final class ResetIdeHttpProxyRule implements TestRule {
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                var oldProxySettings = HttpConfigurable.getInstance().getState();
+                if (oldProxySettings == null) {
+                    oldProxySettings = new HttpConfigurable();
+                }
+
+                try {
+                    statement.evaluate();
+                } finally {
+                    HttpConfigurable.getInstance().loadState(oldProxySettings);
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/700

With this PR, the IDE's HTTP proxy settings are passed as environment variables to all AppMap CLI processes launched by the plugin. This include the JSON-RPC server, scanner and indexer.

The following variables are added to the environment of AppMap processes, but only if HTTP proxy settings of the IDE are enabled:
- `http_proxy`
- `https_proxy` 
- `no_proxy` 

If the IDE configured username and password for proxy authentication, then both are included in the proxy URL values, e.g. `http://myUser:secure_password@my.proxy:1234`.

I'm not aware of a way to listen to changes of the IDE's proxy settings.

For unknown reasons the download tests started to fail, https://github.com/getappmap/appmap-intellij-plugin/pull/703/commits/27acefa43e65fbe6a3ba025d852f376489172675 is fixing this. I don't know how this could be related to AppMap proxy settings, I think it's either slow(er) runners or a change in another component used by CI.