### PR TITLE
Update an opened Navie view when appmap.yml or new AppMap are created

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -36,10 +36,6 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
      */
     static final Key<NavieCodeSelection> KEY_CODE_SELECTION = Key.create("appland.navie.codeSelection");
     /**
-     * The AppMap directory selected to open this Navie editor.
-     */
-    static final Key<VirtualFile> KEY_APPMAP_DIRECTORY = Key.create("appland.navie.appMapDir");
-    /**
      * The port of the matching indexer's JSON-RPC service.
      */
     static final Key<Integer> KEY_INDEXER_RPC_PORT = Key.create("appland.navie.rpcPort");


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/695

The most recent AppMaps were already supposed to be updated, but a bug prevented that (the update code still assumed that there's an AppMap directory).
This PR fixes the bug and also adds that Navie's property `appmapYmlPresent` is updated when there's a change to `appmap.yml` in the project.