### PR TITLE
Pass code editor to Navie JSON-RPC server

### DIFF
--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -14,6 +14,7 @@ import com.intellij.execution.process.KillableProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutputTypes;
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbService;
@@ -156,6 +157,8 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
             LOG.debug("Unable to launch JSON-RPC server, because CLI command is unavailable.");
             return;
         }
+
+        commandLine = commandLine.withEnvironment("APPMAP_CODE_EDITOR", createCodeEditorInfo());
 
         synchronized (this) {
             if (isServerRunning()) {
@@ -369,6 +372,11 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
                 .filter(Objects::nonNull)
                 .map(path -> path.normalize().toString())
                 .collect(Collectors.toList());
+    }
+
+    protected static @NotNull String createCodeEditorInfo() {
+        var info = ApplicationInfo.getInstance();
+        return info.getFullApplicationName() + " by " + info.getCompanyName();
     }
 
     @Data

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -3,8 +3,10 @@ package appland.rpcService;
 import appland.AppMapBaseTest;
 import appland.cli.AppLandCommandLineService;
 import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -98,6 +100,18 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
         } finally {
             appMapSettings.setApiKey(null);
         }
+    }
+
+    @Test
+    public void codeEditorInfo() {
+        // only run with IntelliJ Community
+        Assume.assumeTrue("IC".equals(ApplicationInfo.getInstance().getBuild().getProductCode()));
+        var editorInfo = DefaultAppLandJsonRpcService.createCodeEditorInfo();
+
+        // For example:
+        // IntelliJ IDEA 2023.2 by JetBrains s.r.o.
+        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+ by JetBrains s\\.r\\.o\\.");
+        assertTrue("Code editor info must match: " + editorInfo, matches);
     }
 
     private void waitForJsonRpcServer() {


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/708

Passes environment variable "APPMAP_CODE_EDITOR" to the Navie JSON-RPC process.

For simplicity and compatibility, we're currently using the SDK's built-in application info strings.
For IntelliJ Community, the value is "IntelliJ IDEA 2023.2 by JetBrains s.r.o.".

This should work well for products like WebStorm or Google's Android Studio.

