### PR TITLE
Add setting to control launch of AppMap scanner

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -383,6 +383,10 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return null;
         }
 
+        if (!AppMapApplicationSettingsService.getInstance().isEnableScanner()) {
+            return null;
+        }
+
         // don't launch for in-memory directories in unit test mode
         if (ApplicationManager.getApplication().isUnitTestMode() && directory.getFileSystem() instanceof TempFileSystem) {
             return null;

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -22,6 +22,7 @@ import java.util.*;
 public class AppMapApplicationSettings {
     private volatile boolean firstStart = true;
     private volatile boolean enableTelemetry = true;
+    private volatile boolean enableScanner = false;
     private volatile @Nullable String apiKey = null;
     /**
      * {@code true} if page "Install AppMap Agent" of the installation guide webview was at least shown once.
@@ -49,6 +50,7 @@ public class AppMapApplicationSettings {
     public AppMapApplicationSettings(@NotNull AppMapApplicationSettings settings) {
         this.firstStart = settings.firstStart;
         this.enableTelemetry = settings.enableTelemetry;
+        this.enableScanner = settings.enableScanner;
         this.apiKey = settings.apiKey;
         this.installInstructionsViewed = settings.installInstructionsViewed;
         this.showFirstAppMapNotification = settings.showFirstAppMapNotification;

--- a/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
+++ b/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
@@ -13,6 +13,7 @@ import javax.swing.JPanel
 
 class AppMapProjectSettingsPanel {
     private lateinit var enableTelemetry: JCheckBox
+    private lateinit var enableScanner: JCheckBox
     private lateinit var cliEnvironment: EnvironmentVariablesComponent
     private lateinit var openAIKey: JBTextField
 
@@ -21,6 +22,7 @@ class AppMapProjectSettingsPanel {
         secureApplicationSettings: AppMapSecureApplicationSettings
     ) {
         enableTelemetry.isSelected = applicationSettings.isEnableTelemetry
+        enableScanner.isSelected = applicationSettings.isEnableScanner
         cliEnvironment.envs = applicationSettings.cliEnvironment
         cliEnvironment.isPassParentEnvs = applicationSettings.isCliPassParentEnv
 
@@ -33,6 +35,7 @@ class AppMapProjectSettingsPanel {
         notify: Boolean,
     ) {
         applicationSettings.isEnableTelemetry = enableTelemetry.isSelected
+        applicationSettings.isEnableScanner = enableScanner.isSelected
         applicationSettings.isCliPassParentEnv = cliEnvironment.isPassParentEnvs
         if (notify) {
             applicationSettings.setCliEnvironmentNotifying(cliEnvironment.envs)
@@ -52,6 +55,9 @@ class AppMapProjectSettingsPanel {
                 enableTelemetry = checkBox(AppMapBundle.get("projectSettings.enableTelemetry.title")).component
             }
             group(AppMapBundle.get("projectSettings.appMapServices")) {
+                row {
+                    enableScanner = checkBox(AppMapBundle.get("projectSettings.enableScanner.title")).component
+                }
                 row(AppMapBundle.get("projectSettings.openAIKey.title")) {
                     openAIKey = textField().align(AlignX.FILL).component
                 }.layout(RowLayout.INDEPENDENT)

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -165,6 +165,7 @@ projectSettings.serverName=URL of AppMap Cloud for AppMaps uploading:
 projectSettings.confirmUpload=Confirm upload of AppMaps
 projectSettings.enableFindings.title=Enable findings (experimental, requires restart)
 projectSettings.enableTelemetry.title=Enable telemetry
+projectSettings.enableScanner.title=Enable AppMap scanner
 projectSettings.appMapServices=AppMap Services
 projectSettings.openAIKey.title=OpenAI key:
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/722

This PR adds a setting to control if the AppMap scanner process is launched. It's `off` by default.
A change of the settings for an open project is only applied after reopening the project.

This PR adds a test to verify the new seting and sets the setting to `true` to let existing tests complete successfully.