### PR TITLE
Support 2024.2 eap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,16 @@ jobs:
         timeout-minutes: 45
         steps:
             - name: Fetch Sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Gradle Wrapper Validation
-              uses: gradle/wrapper-validation-action@v1
+              uses: gradle/actions/wrapper-validation@v3
 
             - name: Setup Java
-              uses: actions/setup-java@v3
+              uses: actions/setup-java@v4
               with:
                   distribution: temurin
-                  java-version: 17
+                  java-version: 21
 
             # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
             - name: Show GitHub Actions rate limit
@@ -39,26 +39,19 @@ jobs:
               run: |
                   curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -i https://api.github.com/users/octocat | grep x-ratelimit
 
-            - name: Run Linters and Test (Linux and macOS)
-              if: runner.os != 'Windows'
+            - name: Run Linters and Tests
               shell: bash
               run: ./gradlew check
 
-            # Termination of AppMap CLI processes is failing with IC-2021.3 for unknown reasons (process.destroy() etc.)
-            - name: Run Linters and Test with 2023.2 (Windows)
-              if: runner.os == 'Windows'
-              shell: bash
-              run: ./gradlew check -PideVersion=IC-2023.2.1
-
             - name: Verify plugin
               shell: bash
-              run: ./gradlew verifyPlugin
+              run: ./gradlew verifyPluginProjectConfiguration
 
             - name: Run Plugin Verifier
               shell: bash
               # JetBrains plugin verifier should always report the same results, regardless of the OS
               if: runner.os == 'Linux'
-              run: ./gradlew runPluginVerifier
+              run: ./gradlew verifyPlugin
 
             - name: Upload Test Reports
               uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/setup-java@v4
               with:
                   distribution: temurin
-                  java-version: 17
+                  java-version: 21
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .gradle
 .yarn
+.intellijPlatform
 build
 node_modules
 bin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,19 @@
 pluginVersion=0.67.0
 
 sinceBuild=231.0
-untilBuild=241.*
+untilBuild=242.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-2024.1
+ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.19533.56
 
 lombokVersion=1.18.32
 
 # alternative versions to simplify development and testing
-ideVersion=IC-2023.1
-#ideVersion=IC-2023.2
-#ideVersion=IC-2023.3.2
-#ideVersion=IC-2024.1
+ideVersion=2023.1
+#ideVersion=2023.2
+#ideVersion=2023.3.2
+#ideVersion=2024.1
+#ideVersion=242.19533.56
 
 kotlin.stdlib.default.dependency=false
 

--- a/plugin-core/src/main/java/appland/cli/AppLandProjectOpenActivity.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandProjectOpenActivity.java
@@ -1,5 +1,6 @@
 package appland.cli;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
@@ -8,6 +9,11 @@ import org.jetbrains.annotations.NotNull;
 public class AppLandProjectOpenActivity implements StartupActivity, DumbAware {
     @Override
     public void runActivity(@NotNull Project project) {
-        AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
+        // In 2024.2, StartupActivity (but not ProjectActivity) is not synchronous anymore for tests.
+        // We're enforcing this for all versions to make tests more reliable
+        // and to avoid surprises when we migrate to ProjectActivity.
+        if (!ApplicationManager.getApplication().isUnitTestMode()) {
+            AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
+        }
     }
 }

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -24,7 +24,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
+import com.intellij.openapi.vfs.ex.temp.TempFileSystemMarker;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.io.BaseOutputReader;
 import com.intellij.util.net.HttpConfigurable;
@@ -352,7 +352,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         }
 
         // don't launch for in-memory directories in unit test mode
-        if (ApplicationManager.getApplication().isUnitTestMode() && directory.getFileSystem() instanceof TempFileSystem) {
+        if (ApplicationManager.getApplication().isUnitTestMode() && directory.getFileSystem() instanceof TempFileSystemMarker) {
             return null;
         }
 
@@ -390,7 +390,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         }
 
         // don't launch for in-memory directories in unit test mode
-        if (ApplicationManager.getApplication().isUnitTestMode() && directory.getFileSystem() instanceof TempFileSystem) {
+        if (ApplicationManager.getApplication().isUnitTestMode() && directory.getFileSystem() instanceof TempFileSystemMarker) {
             return null;
         }
 

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 
 import static com.intellij.openapi.util.text.StringUtil.isNotEmpty;
 
+@SuppressWarnings("removal")
 public class DefaultCommandLineService implements AppLandCommandLineService {
     private static final Logger LOG = Logger.getInstance(DefaultCommandLineService.class);
     // initial delay for the first restart attempt

--- a/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
+++ b/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
  * We also have to update indexed files after the "Install Guide" wizard steps,
  * which add new roots after the project was opened.
  */
-@SuppressWarnings("UnstableApiUsage")
+@SuppressWarnings({"UnstableApiUsage", "removal"})
 public class AppMapIndexableFilesContributor implements IndexableFilesContributor {
     @Override
     public @NotNull List<IndexableFilesIterator> getIndexableFiles(@NotNull Project project) {

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -9,6 +9,7 @@ import appland.installGuide.projectData.ProjectMetadata;
 import appland.oauth.AppMapLoginAction;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
+import appland.utils.DataContexts;
 import appland.webviews.OpenExternalLinksHandler;
 import appland.webviews.WebviewEditor;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
@@ -310,12 +311,9 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
                 }
             };
 
-            var dataContext = new DataContext() {
-                @Override
-                public @Nullable Object getData(@NotNull String dataId) {
-                    return CommonDataKeys.PROJECT.is(dataId) ? project : null;
-                }
-            };
+            var dataContext = DataContexts.createCustomContext(dataId -> {
+                return CommonDataKeys.PROJECT.is(dataId) ? project : null;
+            });
 
             try {
                 var executor = DefaultRunExecutor.getRunExecutorInstance();

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/DeleteAllMapsAction.java
@@ -1,12 +1,12 @@
 package appland.toolwindow.appmap;
 
 import appland.AppMapBundle;
+import appland.utils.DataContexts;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.DeleteProvider;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.fileChooser.actions.VirtualFileDeleteProvider;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Action to delete all AppMaps displayed in the AppMap panel.
@@ -37,14 +37,11 @@ final class DeleteAllMapsAction extends AnAction {
 
     private static @NotNull DataContext createDataContext(@NotNull AnActionEvent e) {
         var parentContext = e.getDataContext();
-        return new DataContext() {
-            @Override
-            public @Nullable Object getData(@NotNull String dataId) {
-                if (CommonDataKeys.VIRTUAL_FILE_ARRAY.is(dataId)) {
-                    return parentContext.getData(AppMapWindowPanel.KEY_ALL_APPMAPS);
-                }
-                return parentContext.getData(dataId);
+        return DataContexts.createCustomContext(parentContext, dataId -> {
+            if (CommonDataKeys.VIRTUAL_FILE_ARRAY.is(dataId)) {
+                return parentContext.getData(AppMapWindowPanel.KEY_ALL_APPMAPS);
             }
-        };
+            return parentContext.getData(dataId);
+        });
     }
 }

--- a/plugin-core/src/main/java/appland/utils/DataContexts.java
+++ b/plugin-core/src/main/java/appland/utils/DataContexts.java
@@ -1,0 +1,26 @@
+package appland.utils;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DataContextWrapper;
+import com.intellij.openapi.actionSystem.DataProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides factory methods to create customized {@link DataContext} implementations, which are compatible with all our supported IDEs.
+ * <p>
+ * 2024.2 is rejecting custom implementations and is only accepting DataContext implementations provides by the SDK itself.
+ */
+@SuppressWarnings("removal")
+public final class DataContexts {
+    private DataContexts() {
+    }
+
+    public static @NotNull DataContext createCustomContext(@NotNull DataProvider provider) {
+        return createCustomContext(null, provider);
+    }
+
+    public static @NotNull DataContext createCustomContext(@Nullable DataContext parentContext, @NotNull DataProvider provider) {
+        return DataContextWrapper.create(parentContext == null ? DataContext.EMPTY_CONTEXT : parentContext, provider);
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -5,6 +5,7 @@ import appland.Icons;
 import appland.notifications.AppMapNotifications;
 import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapProjectSettingsService;
+import appland.utils.DataContexts;
 import appland.webviews.WebviewEditorProvider;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -60,12 +61,12 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
      */
     @RequiresEdt
     public static void openEditorForAppMap(@NotNull Project project, @NotNull VirtualFile appMap) {
-        openEditor(project, dataId -> {
+        openEditor(project, DataContexts.createCustomContext(dataId -> {
             if (DATA_KEY_APPMAP.is(dataId)) {
                 return appMap;
             }
             return null;
-        });
+        }));
     }
 
     /**

--- a/plugin-core/src/test/java/appland/index/AppMapIndexableFilesContributorTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapIndexableFilesContributorTest.java
@@ -15,12 +15,12 @@ import java.io.IOException;
 
 public class AppMapIndexableFilesContributorTest extends AppMapBaseTest {
     @Before
-    public void verifyVersions(){
+    public void verifyVersions() {
         Assume.assumeTrue(ApplicationInfo.getInstance().getBuild().getBaselineVersion() <= 231);
     }
 
     @Test
-    public void index() throws IOException {
+    public void index() throws Exception {
         var excludedFolder = myFixture.getTempDirFixture().findOrCreateDir("excluded");
         WriteAction.runAndWait(() -> {
             excludedFolder.createChildDirectory(this, "appmap");

--- a/plugin-core/src/test/java/appland/index/AppMapIndexedRootsSetContributorTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapIndexedRootsSetContributorTest.java
@@ -3,42 +3,39 @@ package appland.index;
 import appland.AppMapBaseTest;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.WriteAction;
-import com.intellij.psi.PsiFile;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
+import java.nio.file.Path;
 
 public class AppMapIndexedRootsSetContributorTest extends AppMapBaseTest {
     @Before
-    public void verifyVersions(){
+    public void verifyVersions() {
         Assume.assumeTrue(ApplicationInfo.getInstance().getBuild().getBaselineVersion() > 231);
     }
 
     @Test
-    public void index() throws IOException {
+    public void index() throws Exception {
         var excludedFolder = myFixture.getTempDirFixture().findOrCreateDir("excluded");
         WriteAction.runAndWait(() -> {
             excludedFolder.createChildDirectory(this, "appmap");
-            excludedFolder.createChildDirectory(this, "appmap-not-indexed");
         });
 
-        withExcludedFolder(excludedFolder, () -> {
-            myFixture.copyFileToProject("appmap-files/Create_Owner.appmap.json", "excluded/appmap/Create_Owner.appmap.json");
-            myFixture.copyDirectoryToProject("appmap-files/Create_Owner", "excluded/appmap/Create_Owner");
+        withContentRoot(excludedFolder, () -> {
+            // AppMaps created in already excluded folders must still keep indexing enabled for them.
+            // But we can only expect indexing if there's an appmap.yml file.
+            withExcludedFolder(excludedFolder, () -> {
+                createAppMapConfig(excludedFolder, Path.of("appmap"));
 
-            myFixture.copyFileToProject("appmap-files/Create_Owner.appmap.json", "excluded/appmap-not-indexed/Create_Owner.appmap.json");
-            myFixture.copyDirectoryToProject("appmap-files/Create_Owner", "excluded/appmap-not-indexed/Create_Owner");
+                myFixture.copyFileToProject("appmap-files/Create_Owner.appmap.json", "excluded/appmap/Create_Owner.appmap.json");
+                myFixture.copyDirectoryToProject("appmap-files/Create_Owner", "excluded/appmap/Create_Owner");
 
-            // 2020.2 EAP seems to always index excluded folders
-            var foundMaps = AppMapMetadataService.getInstance(getProject()).findAppMaps("Create Owner");
-            assertNotEmpty(foundMaps);
+                waitUntilIndexesAreReady();
+
+                var foundMaps = AppMapMetadataService.getInstance(getProject()).findAppMaps("Create Owner");
+                assertNotEmpty(foundMaps);
+            });
         });
-    }
-
-    private @NotNull PsiFile createFile(@NotNull String fileName) {
-        return myFixture.configureByText(fileName, "");
     }
 }

--- a/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapSearchScopesTest.java
@@ -1,7 +1,6 @@
 package appland.index;
 
 import appland.AppMapBaseTest;
-import appland.utils.ModuleTestUtils;
 import com.intellij.openapi.application.WriteAction;
 import org.junit.Test;
 
@@ -20,7 +19,7 @@ public class AppMapSearchScopesTest extends AppMapBaseTest {
         try {
             assertFalse("scope must not contain folders, which are outside content roots", scope.contains(topLevelDir));
 
-            ModuleTestUtils.withContentRoot(getModule(), topLevelDir, () -> {
+            withContentRoot(topLevelDir, () -> {
                 assertTrue("scope must contain content roots", scope.contains(topLevelDir));
 
                 withExcludedFolder(topLevelDir, () -> {
@@ -33,7 +32,7 @@ public class AppMapSearchScopesTest extends AppMapBaseTest {
     }
 
     @Test
-    public void appMapConfigScope() throws IOException {
+    public void appMapConfigScope() throws Exception {
         var scope = AppMapSearchScopes.appMapConfigSearchScope(getProject());
 
         var topLevelConfig = myFixture.configureByText("appmap.yml", "content").getVirtualFile();

--- a/plugin-core/src/test/java/appland/index/ClassMapTypeIndexTest.java
+++ b/plugin-core/src/test/java/appland/index/ClassMapTypeIndexTest.java
@@ -2,6 +2,8 @@ package appland.index;
 
 import appland.AppMapBaseTest;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
@@ -9,6 +11,11 @@ import java.util.List;
 import java.util.Map;
 
 public class ClassMapTypeIndexTest extends AppMapBaseTest {
+    @Override
+    protected TempDirTestFixture createTempDirTestFixture() {
+        return new TempDirTestFixtureImpl();
+    }
+
     @Test
     public void emptyResult() {
         assertEmpty(ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Package));
@@ -17,58 +24,67 @@ public class ClassMapTypeIndexTest extends AppMapBaseTest {
     }
 
     @Test
-    public void singleFile() {
+    public void singleFile() throws Exception {
         // use fixture dir, because the index only analyzes files with name classMap.json
-        myFixture.copyDirectoryToProject("classMaps/projectSingleFile", "root");
+        var root = myFixture.copyDirectoryToProject("classMaps/projectSingleFile", "root");
 
-        // root items
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
-
-        // leafs
-        assertSize(22 + 2, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Package));
-        assertSize(80, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Class));
-        assertSize(23, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Query));
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Route));
-
-        // each of the leaf item results must have two files attached, because the project contains a duplicate classMap
-        assertItemsFileCount("One associated AppMap file expected",
-                1,
-                List.of(ClassMapItemType.Package, ClassMapItemType.Class, ClassMapItemType.Query, ClassMapItemType.Route));
-    }
-
-    @Test
-    public void unexpectedClassMapType() {
-        // use fixture dir, because the index only analyzes files with name classMap.json
-        myFixture.copyDirectoryToProject("classMaps/unexpectedClassMapType", "root");
-
-        // items must still be found even if one of the items has an unknown class map type
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
-    }
-
-    @Test
-    public void duplicateItems() {
-        // use fixture dir, because the index only analyzes files with name classMap.json
-        myFixture.copyDirectoryToProject("classMaps/projectDuplicateIds", "root");
-
-        // root items
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
-        assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
-
-        // each of the leaf item results must have two files attached, because the project contains a duplicate classMap
-        assertItemsFileCount("Two associated AppMap files expected",
-                2,
-                List.of(ClassMapItemType.Package, ClassMapItemType.Class, ClassMapItemType.Query, ClassMapItemType.Route));
-    }
-
-    @Test
-    public void insideExcluded() {
-        var root = myFixture.copyDirectoryToProject("classMaps/projectDuplicateIds", "root");
-        withExcludedFolder(root, () -> {
-            // root items, classMap files in excluded folders must be processed by the query
+        withContentRoot(root, () -> {
+            // root items
             assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
             assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
+
+            // leafs
+            assertSize(22 + 2, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Package));
+            assertSize(80, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Class));
+            assertSize(23, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Query));
+            assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Route));
+
+            // each of the leaf item results must have two files attached, because the project contains a duplicate classMap
+            assertItemsFileCount("One associated AppMap file expected",
+                    1,
+                    List.of(ClassMapItemType.Package, ClassMapItemType.Class, ClassMapItemType.Query, ClassMapItemType.Route));
+        });
+    }
+
+    @Test
+    public void unexpectedClassMapType() throws Exception {
+        // use fixture dir, because the index only analyzes files with name classMap.json
+        var root = myFixture.copyDirectoryToProject("classMaps/unexpectedClassMapType", "root");
+
+        withContentRoot(root, () -> {
+            // items must still be found even if one of the items has an unknown class map type
+            assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
+            assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
+        });
+    }
+
+    @Test
+    public void duplicateItems() throws Exception {
+        // use fixture dir, because the index only analyzes files with name classMap.json
+        var root = myFixture.copyDirectoryToProject("classMaps/projectDuplicateIds", "root");
+
+        withContentRoot(root, () -> {
+            // root items
+            assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
+            assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
+
+            // each of the leaf item results must have two files attached, because the project contains a duplicate classMap
+            assertItemsFileCount("Two associated AppMap files expected",
+                    2,
+                    List.of(ClassMapItemType.Package, ClassMapItemType.Class, ClassMapItemType.Query, ClassMapItemType.Route));
+        });
+    }
+
+    @Test
+    public void insideExcluded() throws Exception {
+        var root = myFixture.copyDirectoryToProject("classMaps/projectDuplicateIds", "root");
+
+        withContentRoot(root, () -> {
+            withExcludedFolder(root, () -> {
+                // root items, classMap files in excluded folders must be processed by the query
+                assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.Database));
+                assertSize(1, ClassMapTypeIndex.findItems(getProject(), ClassMapItemType.HTTP));
+            });
         });
     }
 

--- a/plugin-core/src/test/java/appland/problemsView/FindingsManagerTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/FindingsManagerTest.java
@@ -73,6 +73,7 @@ public class FindingsManagerTest extends AppMapBaseTest {
         var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
         var root = myFixture.copyDirectoryToProject("projects/with_modification_date", "root");
         assertTrue(condition.await(30, TimeUnit.SECONDS));
+        waitUntilIndexesAreReady();
 
         var findingsFile = root.findFileByRelativePath("tmp/appmap/with_modification_date/appmap-findings.json");
         assertNotNull(findingsFile);
@@ -98,6 +99,7 @@ public class FindingsManagerTest extends AppMapBaseTest {
         var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
         myFixture.copyDirectoryToProject("projects/with_http_requests", "root");
         assertTrue(condition.await(30, TimeUnit.SECONDS));
+        waitUntilIndexesAreReady();
 
         var manager = FindingsManager.getInstance(getProject());
         var findings = manager.findFindingsByHash("b751d44a3b3cf40dd0fa5ba47b2f910f3d73229907b7b5d3b47de87b0c747541");

--- a/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
@@ -3,7 +3,6 @@ package appland.problemsView.listener;
 import appland.AppMapBaseTest;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.TestFindingsManager;
-import appland.utils.ModuleTestUtils;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class ScannerFilesAsyncListenerContentRootTest extends AppMapBaseTest {
         // create src/root to add it as content root to the current module
         // the file listener is using a project scope, which needs a properly set up content root
         var rootDir = myFixture.getTempDirFixture().findOrCreateDir("root");
-        ModuleTestUtils.withContentRoot(getModule(), rootDir, () -> {
+        withContentRoot(rootDir, () -> {
             var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
             // adding an appmap-findings.json file must trigger a refresh via the file watcher
             myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -110,7 +110,7 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
 
         // For example:
         // IntelliJ IDEA 2023.2 by JetBrains s.r.o.
-        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+ by JetBrains s\\.r\\.o\\.");
+        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+( EAP)? by JetBrains s\\.r\\.o\\.");
         assertTrue("Code editor info must match: " + editorInfo, matches);
     }
 

--- a/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
@@ -42,7 +42,7 @@ public class AppMapModelTest extends AppMapBaseTest {
                 "request_recording1.appmap.json",
                 "request_recording2.appmap.json");
 
-        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
+        withContentRoot(rootOne, () -> {
             var model = new AppMapModel(getProject());
             var expected = "-AppMaps\n" +
                     " -root_one\n" +
@@ -57,7 +57,7 @@ public class AppMapModelTest extends AppMapBaseTest {
                 "request_recording2.appmap.json",
                 "request_recording1.appmap.json");
 
-        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
+        withContentRoot(rootOne, () -> {
             var model = new AppMapModel(getProject());
             var expected = "-AppMaps\n" +
                     " -root_one\n" +
@@ -73,7 +73,7 @@ public class AppMapModelTest extends AppMapBaseTest {
         // copy into parent dir, because the default location is "src/", which already is a content root
         var rootOne = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_one"));
 
-        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
+        withContentRoot(rootOne, () -> {
             var model = new AppMapModel(getProject());
             var expected = "-AppMaps\n" +
                     " -root_one\n" +
@@ -92,24 +92,22 @@ public class AppMapModelTest extends AppMapBaseTest {
         var rootOne = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_one"));
         var rootTwo = WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject("projects/runtime_analysis_tree", "../root_two"));
 
-        ModuleTestUtils.withContentRoot(getModule(), rootOne, () -> {
-            ModuleTestUtils.withContentRoot(getModule(), rootTwo, () -> {
-                var model = new AppMapModel(getProject());
-                var expected = "-AppMaps\n" +
-                        " -root_one\n" +
-                        "  -Tests (ruby + minitest)\n" +
-                        "   Failed test 1\n" +
-                        "   Failed test 2\n" +
-                        "   Successful Test 1\n" +
-                        "   Successful Test 2\n" +
-                        " -root_two\n" +
-                        "  -Tests (ruby + minitest)\n" +
-                        "   Failed test 1\n" +
-                        "   Failed test 2\n" +
-                        "   Successful Test 1\n" +
-                        "   Successful Test 2\n";
-                assertTreeHierarchy(model, expected, getTestRootDisposable());
-            });
+        withContentRoots(List.of(rootOne, rootTwo), () -> {
+            var model = new AppMapModel(getProject());
+            var expected = "-AppMaps\n" +
+                    " -root_one\n" +
+                    "  -Tests (ruby + minitest)\n" +
+                    "   Failed test 1\n" +
+                    "   Failed test 2\n" +
+                    "   Successful Test 1\n" +
+                    "   Successful Test 2\n" +
+                    " -root_two\n" +
+                    "  -Tests (ruby + minitest)\n" +
+                    "   Failed test 1\n" +
+                    "   Failed test 2\n" +
+                    "   Successful Test 1\n" +
+                    "   Successful Test 2\n";
+            assertTreeHierarchy(model, expected, getTestRootDisposable());
         });
     }
 

--- a/plugin-core/src/test/java/appland/utils/IndexTestUtils.java
+++ b/plugin-core/src/test/java/appland/utils/IndexTestUtils.java
@@ -1,0 +1,42 @@
+package appland.utils;
+
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+public class IndexTestUtils {
+    public static void waitUntilIndexesAreReady(@NotNull Project project) {
+        // IndexingTestUtil.waitUntilIndexesAreReady(project);
+        // 2024.2 made indexing in tests async and added IndexingTestUtil.waitUntilIndexesAreReady(project)
+        // to allow tests to wait for indexing to finish.
+        // But because this class and method is unavailable in < 2024.1, we need to use reflection to call this method.
+
+        if (ApplicationInfo.getInstance().getBuild().getBaselineVersion() >= 241) {
+            // according to JetBrains Slack, waitUntilIndexesAreReady must not be called inside a WriteAction or ReadAction
+            var application = ApplicationManager.getApplication();
+
+            if (application.isWriteAccessAllowed()) {
+                throw new IllegalStateException("waitUntilIndexesAreReady must not be called in a WriteAction");
+            }
+
+            if (!application.isDispatchThread()) {
+                application.assertReadAccessNotAllowed();
+            }
+
+            reflectiveWaitUntilIndexesAreReady(project);
+        }
+    }
+
+    private static void reflectiveWaitUntilIndexesAreReady(@NotNull Project project) {
+        try {
+            var indexingTestUtil = IndexTestUtils.class.getClassLoader().loadClass("com.intellij.testFramework.IndexingTestUtil");
+            var waitUntilIndexesAreReady = indexingTestUtil.getDeclaredMethod("waitUntilIndexesAreReady", Project.class);
+            waitUntilIndexesAreReady.invoke(null, project);
+        } catch (Exception e) {
+            Logger.getInstance(IndexTestUtils.class).error("Error calling waitUntilIndexesAreReady via reflection");
+        }
+    }
+}

--- a/plugin-core/src/test/java/appland/utils/ModuleTestUtils.java
+++ b/plugin-core/src/test/java/appland/utils/ModuleTestUtils.java
@@ -53,6 +53,8 @@ public class ModuleTestUtils {
                 contentEntriesRef.set(contentEntries);
             });
 
+            IndexTestUtils.waitUntilIndexesAreReady(module.getProject());
+
             runnable.run();
         } finally {
             // remove again to avoid breaking follow-up tests

--- a/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
+++ b/plugin-java/src/test/java/appland/execution/BaseAppMapJavaTest.java
@@ -44,6 +44,7 @@ public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
         return false;
     }
 
+    @SuppressWarnings("removal")
     @Override
     protected Sdk getTestProjectJdk() {
         // we need Java 11 for our AppMap tests, but CI has Java 17 to build and compile the plugin
@@ -60,7 +61,6 @@ public abstract class BaseAppMapJavaTest extends JavaPsiTestCase {
             return sdk;
         }
 
-        //noinspection UnstableApiUsage,deprecation
         return JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,6 @@
 pluginManagement {
     repositories {
-        maven {
-            setUrl("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/717

Adds compatibility with 2024.2 eap.
This time, supporting the new EAP is a bit painful. It requires a new Gradle build setup (using a beta version of a new Gradle plugin) and JetBrains clarified the internal API in the new major version.

- Because 2024.2 requires a new build setup, this PR is migrating to the new Gradle build setup.
- CI is now using Java 21, because 2024.2 migrated from Java 17 to 21
- Indexing is now async in tests with 2024.2. We're changing our tests to wait until indexing finished because we rely on indexes.
- In the build setup, we're working around a few problems of the new intellij-platform-gradle plugin, we'll remove them as soon as the plugin is fixed