### PR TITLE
Show warning for users of 2024.1 with proxy servers

### DIFF
--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -33,6 +33,10 @@ public class AppMapApplicationSettings {
      * This flag is synced with {@link  #firstStart} to avoid the notification with existing users.
      */
     private volatile boolean showFirstAppMapNotification = false;
+    /**
+     * {@code true} if the warning about broken proxy settings should be displayed the next time an AppMap webview is opened.
+     */
+    private volatile boolean showBrokenProxyWarning = true;
 
     /**
      * Map of environment variables to be set when starting AppMap services

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -1,5 +1,6 @@
 package appland.toolwindow;
 
+import appland.notifications.AppMapNotifications;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.toolwindow.appmap.AppMapWindowPanel;
@@ -63,6 +64,10 @@ public class AppMapToolWindowFactory implements ToolWindowFactory, DumbAware {
                         }, ModalityState.defaultModalityState());
                     }
                 });
+
+        if (AppMapNotifications.isWebviewProxyWarningRequired()) {
+            AppMapNotifications.showWebviewProxyBrokenWarning(project);
+        }
     }
 
     private void updateToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -1,6 +1,7 @@
 package appland.webviews;
 
 import appland.AppMapBundle;
+import appland.notifications.AppMapNotifications;
 import appland.utils.GsonUtils;
 import appland.webviews.webserver.AppMapWebview;
 import appland.webviews.webserver.WebviewAuthTokenRequestHandler;
@@ -195,6 +196,10 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
 
         if (Registry.is("appmap.webview.open.dev.tools", false)) {
             ApplicationManager.getApplication().invokeLater(this::openDevTools);
+        }
+
+        if (AppMapNotifications.isWebviewProxyWarningRequired()) {
+            AppMapNotifications.showWebviewProxyBrokenWarning(project);
         }
     }
 

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -143,6 +143,11 @@ notification.appMapSignIn.content=Logged into AppMap
 
 notification.navieUnavailable.content=AppMap Explain is not ready yet. Please try again in a few seconds.
 
+notification.brokenProxySupport.title=AppMap
+notification.brokenProxySupport.content=<html>The version of your IDE has a bug which breaks proxy support in webflows.<br>AppMap uses webviews for most of its features including signup and Navie.<br>Please downgrade to 2023.3 or upgrade to the next updates of 2024.1 to use AppMaps features with proxy support when JetBrains resolves this issue.</html>
+notification.brokenProxySupport.showLinkAction=Open AppMap status
+notification.brokenProxySupport.confirmAction=Close
+
 notification.exportAppMapJson.content=An error occurred while exporting AppMap JSON data: {0}.
 
 notification.reloadProject.content=Please reload your project because the AppMap settings changed.


### PR DESCRIPTION
This PR displays a message about broken proxy support for users
- using 2024.1.x
- with an enabled HTTP proxy server
- which did not click "Don't show again" when the same message was displayed earlier

"Don't show again" deactivates the message for all projects.