### PR TITLE
NPE with 2024.1 if a proxy server without exceptions is set

### DIFF
--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -616,7 +616,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return Map.of(
                     "http_proxy", proxyURL,
                     "https_proxy", proxyURL,
-                    "no_proxy", settings.PROXY_EXCEPTIONS);
+                    "no_proxy", StringUtil.defaultIfEmpty(settings.PROXY_EXCEPTIONS, ""));
         } catch (MalformedURLException | URISyntaxException e) {
             LOG.debug("Unable to create proxy settings for AppMap command line", e);
             return Map.of();

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -364,6 +364,20 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         ), DefaultCommandLineService.createProxyEnvironment());
     }
 
+    @Test
+    public void proxySettingsEnvironmentMinimalSettings() {
+        HttpConfigurable.getInstance().USE_HTTP_PROXY = true;
+        HttpConfigurable.getInstance().PROXY_HOST = "my.proxy.host";
+        HttpConfigurable.getInstance().PROXY_PORT = 8080;
+        HttpConfigurable.getInstance().PROXY_EXCEPTIONS = null;
+
+        assertEquals(Map.of(
+                "http_proxy", "http://my.proxy.host:8080",
+                "https_proxy", "http://my.proxy.host:8080",
+                "no_proxy", ""
+        ), DefaultCommandLineService.createProxyEnvironment());
+    }
+
     private void setupAndAssertProcessRestart(@NotNull Function<VirtualFile, KillableProcessHandler> processForRoot) throws Exception {
         var root = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
         ModuleTestUtils.withContentRoot(getModule(), root, () -> {


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/725

This fixes a `NullPointerException` when a HTTP proxy server is enabled but not host exceptions are defined.
It adds a test to verify that the proxy environment is properly created for a `null` value of proxy exclusions.