### PR TITLE
Restore compatibility with 2023.1

### DIFF
--- a/description.md
+++ b/description.md
@@ -11,7 +11,7 @@ By using AppMap data, Navie is the first AI code architect with the context to u
 
 ## Requirements and Use
 
-**2023.2** and newer JetBrains IDEs are required to use this plugin.  
+**2023.1** and newer JetBrains IDEs are required to use this plugin.  
 Supported web applications and API frameworks: Ruby on Rails, Django, Flask, Express, Nest.js, Next.js, and Spring, Kotlin, and Scala
 Supported programming languages: Java, Python, Ruby, TypeScript/JavaScript (for Node.js).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,16 @@
 pluginVersion=0.67.0
 
-sinceBuild=232.0
+sinceBuild=231.0
 untilBuild=241.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.2,IC-2024.1
+ideVersionVerifier=IC-2023.1,IC-2024.1
 
 lombokVersion=1.18.32
 
 # alternative versions to simplify development and testing
-ideVersion=IC-2023.2
+ideVersion=IC-2023.1
+#ideVersion=IC-2023.2
 #ideVersion=IC-2023.3.2
 #ideVersion=IC-2024.1
 

--- a/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
+++ b/plugin-core/src/main/java/appland/index/AppMapIndexableFilesContributor.java
@@ -1,0 +1,42 @@
+package appland.index;
+
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.indexing.roots.IndexableFilesContributor;
+import com.intellij.util.indexing.roots.IndexableFilesIterator;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Only used in 2023.1 and earlier.
+ * <p>
+ * Adds excluded "appmap" folders and excluded AppMap files for indexing.
+ * <p>
+ * We can't use an {@link com.intellij.util.indexing.AdditionalIndexedRootsScope}, because it's only called at startup.
+ * We also have to update indexed files after the "Install Guide" wizard steps,
+ * which add new roots after the project was opened.
+ */
+@SuppressWarnings("UnstableApiUsage")
+public class AppMapIndexableFilesContributor implements IndexableFilesContributor {
+    @Override
+    public @NotNull List<IndexableFilesIterator> getIndexableFiles(@NotNull Project project) {
+        var iterators = new ArrayList<IndexableFilesIterator>();
+        for (var module : ModuleManager.getInstance(project).getModules()) {
+            for (var excludedRoot : ModuleRootManager.getInstance(module).getExcludeRoots()) {
+                iterators.add(new AppMapFilesIterator(excludedRoot));
+            }
+        }
+        return iterators;
+    }
+
+    @Override
+    public @NotNull Predicate<VirtualFile> getOwnFilePredicate(@NotNull Project project) {
+        // we have to include directories, because that controls if the sub-entries are processed
+        return file -> file.isDirectory() || IndexUtil.isIndexedFile(file);
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -6,16 +6,23 @@ import appland.notifications.AppMapNotifications;
 import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.webviews.WebviewEditorProvider;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DataKey;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
@@ -94,6 +101,12 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
 
             AppMapProjectSettingsService.getState(project).setExplainWithNavieOpened(true);
             FileEditorManager.getInstance(project).openFile(file, true);
+
+            var hideMessagePropertyKey = "appmap.navie.hideIsBrokenMessage";
+            var properties = PropertiesComponent.getInstance();
+            if (isNavieWebviewSupportBroken() && !properties.getBoolean(hideMessagePropertyKey, false)) {
+                showNavieWebviewBrokenMessage(project, properties, hideMessagePropertyKey);
+            }
         });
     }
 
@@ -141,5 +154,32 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
     @FunctionalInterface
     private interface ShowNavieConsumer {
         void openNavie(@Nullable Integer indexerPort, @Nullable NavieCodeSelection codeSelection);
+    }
+
+    private static boolean isNavieWebviewSupportBroken() {
+        var buildBaseline = ApplicationInfo.getInstance().getBuild().getBaselineVersion();
+
+        // Linux <= 2023.1 is broken,
+        // https://youtrack.jetbrains.com/issue/JBR-5348/JCEF-OSR-Keyboard-doesnt-work-on-Linux
+        return SystemInfo.isLinux && buildBaseline <= 231;
+    }
+
+    @SuppressWarnings("removal")
+    private static void showNavieWebviewBrokenMessage(@NotNull Project project, PropertiesComponent properties, String hideMessagePropertyKey) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Messages.showDialog(project,
+                    AppMapBundle.get("webview.navie.webviewBroken.message"),
+                    AppMapBundle.get("webview.navie.webviewBroken.title"),
+                    new String[]{Messages.getOkButton()},
+                    0,
+                    Messages.getWarningIcon(),
+                    // already deprecated in 2022.1, but there's no alternative API in Messages.
+                    new DialogWrapper.DoNotAskOption.Adapter() {
+                        @Override
+                        public void rememberChoice(boolean isSelected, int exitCode) {
+                            properties.setValue(hideMessagePropertyKey, isSelected, false);
+                        }
+                    });
+        }, ModalityState.any());
     }
 }

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -71,6 +71,10 @@
         <fileBasedIndex implementation="appland.index.ClassMapTypeIndex"/>
 
         <roots.watchedRootsProvider implementation="appland.index.AppMapWatchedRootsProvider"/>
+        <!-- For 2023.1 and earlier -->
+        <!--suppress PluginXmlValidity -->
+        <indexableFilesContributor implementation="appland.index.AppMapIndexableFilesContributor"/>
+        <!-- For 2023.2 and later -->
         <indexedRootsProvider implementation="appland.index.AppMapIndexedRootsSetContributor"/>
 
         <toolWindow id="applandToolWindow" anchor="right" secondary="false"

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -216,6 +216,8 @@ webview.findingDetails.appMapNotFound.message=The AppMap file could not be found
 webview.navie.title=AppMap AI: Explain
 webview.navie.chooseAppMapModule.title=Choose AppMap module
 webview.navie.updatingMostRecentAppMaps=Locating most recent AppMaps...
+webview.navie.webviewBroken.title=AppMap Navie
+webview.navie.webviewBroken.message=Please update your IDE to version 2023.2 or later.\nNavie will not work with versions prior to 2023.2 because there is an IDE issue that prevents typing into input fields.
 
 codeObjects.codeTopLevel.label=Code
 codeObjects.navigation.locatingFiles=Locating AppMaps....

--- a/plugin-core/src/test/java/appland/index/AppMapIndexableFilesContributorTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapIndexableFilesContributorTest.java
@@ -1,16 +1,24 @@
 package appland.index;
 
 import appland.AppMapBaseTest;
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.indexing.FileBasedIndexExtension;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 
 public class AppMapIndexableFilesContributorTest extends AppMapBaseTest {
+    @Before
+    public void verifyVersions(){
+        Assume.assumeTrue(ApplicationInfo.getInstance().getBuild().getBaselineVersion() <= 231);
+    }
+
     @Test
     public void index() throws IOException {
         var excludedFolder = myFixture.getTempDirFixture().findOrCreateDir("excluded");

--- a/plugin-core/src/test/java/appland/index/AppMapIndexableFilesContributorTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapIndexableFilesContributorTest.java
@@ -1,0 +1,80 @@
+package appland.index;
+
+import appland.AppMapBaseTest;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.indexing.FileBasedIndexExtension;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AppMapIndexableFilesContributorTest extends AppMapBaseTest {
+    @Test
+    public void index() throws IOException {
+        var excludedFolder = myFixture.getTempDirFixture().findOrCreateDir("excluded");
+        WriteAction.runAndWait(() -> {
+            excludedFolder.createChildDirectory(this, "appmap");
+            excludedFolder.createChildDirectory(this, "appmap-not-indexed");
+        });
+
+        withExcludedFolder(excludedFolder, () -> {
+            myFixture.copyFileToProject("appmap-files/Create_Owner.appmap.json", "excluded/appmap/Create_Owner.appmap.json");
+            myFixture.copyDirectoryToProject("appmap-files/Create_Owner", "excluded/appmap/Create_Owner");
+
+            myFixture.copyFileToProject("appmap-files/Create_Owner.appmap.json", "excluded/appmap-not-indexed/Create_Owner.appmap.json");
+            myFixture.copyDirectoryToProject("appmap-files/Create_Owner", "excluded/appmap-not-indexed/Create_Owner");
+
+            // 2020.2 EAP seems to always index excluded folders
+            var foundMaps = AppMapMetadataService.getInstance(getProject()).findAppMaps("Create Owner");
+            assertNotEmpty(foundMaps);
+        });
+    }
+
+    @Test
+    public void files() throws IOException {
+        assertAccepted(createFile("classMap.json"));
+        assertAccepted(createFile("appmap-findings.json"));
+        for (var extension : FileBasedIndexExtension.EXTENSION_POINT_NAME.getExtensionList()) {
+            if (extension instanceof AbstractAppMapMetadataFileIndex<?>) {
+                assertAccepted(createFile(((AbstractAppMapMetadataFileIndex<?>) extension).getIndexedFileName()));
+            }
+        }
+
+        assertRejected(createFile("sample.appmap.json"));
+        assertRejected(createFile("sample.json"));
+        assertRejected(createFile("sample.txt"));
+
+        // any directory must be accepted, because it may contain an "appmap" directory
+        assertAccepted(myFixture.getTempDirFixture().findOrCreateDir("some-directory"));
+        assertAccepted(myFixture.getTempDirFixture().findOrCreateDir("target"));
+        assertAccepted(myFixture.getTempDirFixture().findOrCreateDir("appmap"));
+    }
+
+    private void assertAccepted(PsiFile file) {
+        assertAccepted(file.getVirtualFile());
+    }
+
+    private void assertRejected(PsiFile file) {
+        assertRejected(file.getVirtualFile());
+    }
+
+    private void assertAccepted(@NotNull VirtualFile virtualFile) {
+        var contributor = new AppMapIndexableFilesContributor();
+        var predicate = contributor.getOwnFilePredicate(getProject());
+        assertNotNull(virtualFile);
+        assertTrue("File must be accepted: " + virtualFile.getName(), predicate.test(virtualFile));
+    }
+
+    private void assertRejected(@NotNull VirtualFile virtualFile) {
+        var contributor = new AppMapIndexableFilesContributor();
+        var predicate = contributor.getOwnFilePredicate(getProject());
+        assertNotNull(virtualFile);
+        assertFalse("File must be rejected: " + virtualFile.getName(), predicate.test(virtualFile));
+    }
+
+    private @NotNull PsiFile createFile(@NotNull String fileName) {
+        return myFixture.configureByText(fileName, "");
+    }
+}

--- a/plugin-core/src/test/java/appland/index/AppMapIndexedRootsSetContributorTest.java
+++ b/plugin-core/src/test/java/appland/index/AppMapIndexedRootsSetContributorTest.java
@@ -1,14 +1,22 @@
 package appland.index;
 
 import appland.AppMapBaseTest;
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 
 public class AppMapIndexedRootsSetContributorTest extends AppMapBaseTest {
+    @Before
+    public void verifyVersions(){
+        Assume.assumeTrue(ApplicationInfo.getInstance().getBuild().getBaselineVersion() > 231);
+    }
+
     @Test
     public void index() throws IOException {
         var excludedFolder = myFixture.getTempDirFixture().findOrCreateDir("excluded");


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/728

Reverts changes which were made to drop support for older major versions.

This PR reverts selected changes of the following commits:
- b2279455f8b039ba0ddb1b53fb4580dde17ed7a5
- 4c756aad28bbdfec52c03349df71d228a9ad4785
- 74bbaa816e74b88e459952ae0a7d5d956c5c2600

This also restores the warning about broken text input shown when a Linux user opens Navie.