### PR TITLE
feat: notify when sign-in to AppMap is attempted with broken text input support

### DIFF
--- a/appland-signin/webview.js
+++ b/appland-signin/webview.js
@@ -18,6 +18,18 @@ export function mountWebview() {
       },
       data() {
         return initData;
+      },
+      mounted() {
+        let emailInput = document.querySelector("#email-input");
+        if (emailInput) {
+          let focusEventSent = false;
+          emailInput.addEventListener("focus", () => {
+            if (!focusEventSent) {
+              focusEventSent = true;
+              setTimeout(() => vscode.postMessage({"command": "email-input-focused"}), 250);
+            }
+          });
+        }
       }
     });
 

--- a/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/plugin-core/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -100,7 +100,7 @@ public class AppMapToolWindowFactory implements ToolWindowFactory, DumbAware {
 
         return AppMapApplicationSettingsService.getInstance().isAuthenticated()
                 ? (T) new AppMapWindowPanel(project, toolWindow.getDisposable())
-                : (T) new SignInViewPanel(toolWindow.getDisposable());
+                : (T) new SignInViewPanel(project, toolWindow.getDisposable());
     }
 }
 

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -6,23 +6,16 @@ import appland.notifications.AppMapNotifications;
 import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapProjectSettingsService;
 import appland.webviews.WebviewEditorProvider;
-import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DataKey;
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
@@ -102,10 +95,8 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
             AppMapProjectSettingsService.getState(project).setExplainWithNavieOpened(true);
             FileEditorManager.getInstance(project).openFile(file, true);
 
-            var hideMessagePropertyKey = "appmap.navie.hideIsBrokenMessage";
-            var properties = PropertiesComponent.getInstance();
-            if (isNavieWebviewSupportBroken() && !properties.getBoolean(hideMessagePropertyKey, false)) {
-                showNavieWebviewBrokenMessage(project, properties, hideMessagePropertyKey);
+            if (AppMapNotifications.isWebviewTextInputBroken()) {
+                AppMapNotifications.showWebviewTextInputBrokenMessage(project, true);
             }
         });
     }
@@ -154,32 +145,5 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
     @FunctionalInterface
     private interface ShowNavieConsumer {
         void openNavie(@Nullable Integer indexerPort, @Nullable NavieCodeSelection codeSelection);
-    }
-
-    private static boolean isNavieWebviewSupportBroken() {
-        var buildBaseline = ApplicationInfo.getInstance().getBuild().getBaselineVersion();
-
-        // Linux <= 2023.1 is broken,
-        // https://youtrack.jetbrains.com/issue/JBR-5348/JCEF-OSR-Keyboard-doesnt-work-on-Linux
-        return SystemInfo.isLinux && buildBaseline <= 231;
-    }
-
-    @SuppressWarnings("removal")
-    private static void showNavieWebviewBrokenMessage(@NotNull Project project, PropertiesComponent properties, String hideMessagePropertyKey) {
-        ApplicationManager.getApplication().invokeLater(() -> {
-            Messages.showDialog(project,
-                    AppMapBundle.get("webview.navie.webviewBroken.message"),
-                    AppMapBundle.get("webview.navie.webviewBroken.title"),
-                    new String[]{Messages.getOkButton()},
-                    0,
-                    Messages.getWarningIcon(),
-                    // already deprecated in 2022.1, but there's no alternative API in Messages.
-                    new DialogWrapper.DoNotAskOption.Adapter() {
-                        @Override
-                        public void rememberChoice(boolean isSelected, int exitCode) {
-                            properties.setValue(hideMessagePropertyKey, isSelected, false);
-                        }
-                    });
-        }, ModalityState.any());
     }
 }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -225,6 +225,9 @@ webview.navie.updatingMostRecentAppMaps=Locating most recent AppMaps...
 webview.navie.webviewBroken.title=AppMap Navie
 webview.navie.webviewBroken.message=Please update your IDE to version 2023.2 or later.\nNavie will not work with versions prior to 2023.2 because there is an IDE issue that prevents typing into input fields.
 
+webview.signin.webviewBroken.title=AppMap Sign-In
+webview.signin.webviewBroken.message=Please update your IDE to version 2023.2 or later.\nSign-In will not work with versions prior to 2023.2 because there is an IDE issue that prevents typing into input fields.
+
 codeObjects.codeTopLevel.label=Code
 codeObjects.navigation.locatingFiles=Locating AppMaps....
 codeObjects.chooseAppMap=Choose AppMap File


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/731

- The existing notification about broken text input, which was shown when Navie is opened, is made more generic to support the sign-in webview, too
- The IDE's default "Don't ask again" option for this notification is changed to "don't show again". This also applies to the same notification shown for Navie
- The notification is shown until the user selected "don't show again"
- This PR also opens the webview for the sign-in webview when registry option "appmap.webview.open.dev.tools" is set, just like for the editor webviews.

![image](https://github.com/getappmap/appmap-intellij-plugin/assets/11473063/de55607b-1231-4eea-a54d-ed01d01f493b)
