### PR TITLE
Run tests against the latest supported major version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
               run: ./gradlew verifyPlugin
 
             - name: Upload Test Reports
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: always()
               with:
                   name: test-reports-${{ matrix.os }}
@@ -63,7 +63,7 @@ jobs:
                       **/build/reports/
 
             - name: Save AppMaps
-              uses: actions/cache/save@v3
+              uses: actions/cache/save@v4
               if: runner.os == 'Linux'
               with:
                   path: ./tmp/appmap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                 os: [ ubuntu, windows, macos ]
                 include:
                     # Run tests with latest platform version, but only on Linux
-                    - ide_version: "2024.1.4"
+                    - ide_version: "2024.2"
                       os: ubuntu
 
         name: Test ${{ matrix.ide_version }} on ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,15 @@ jobs:
     test:
         strategy:
             matrix:
-                os: [ ubuntu-latest, windows-latest, macos-latest ]
+                ide_version: [ "2023.1" ]
+                os: [ ubuntu, windows, macos ]
+                include:
+                    # Run tests with latest platform version, but only on Linux
+                    - ide_version: "2024.1.4"
+                      os: ubuntu
 
-        name: Test ${{ matrix.os }}
-        runs-on: ${{ matrix.os }}
+        name: Test ${{ matrix.ide_version }} on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}-latest
         timeout-minutes: 45
         steps:
             - name: Fetch Sources
@@ -40,32 +45,22 @@ jobs:
               run: |
                   curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -i https://api.github.com/users/octocat | grep x-ratelimit
 
-            - name: Run Linters and Tests
+            - name: Run Linters and Test
               shell: bash
-              run: ./gradlew check
-
-            - name: Verify plugin
-              shell: bash
-              run: ./gradlew verifyPluginProjectConfiguration
-
-            - name: Run Plugin Verifier
-              shell: bash
-              # JetBrains plugin verifier should always report the same results, regardless of the OS
-              if: runner.os == 'Linux'
-              run: ./gradlew verifyPlugin
+              run: ./gradlew -PideVersion=${{ matrix.ide_version }} check
 
             - name: Upload Test Reports
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: test-reports-${{ matrix.os }}
+                  name: test-reports-${{ matrix.os }}-${{ matrix.ide_version }}
                   path: |
                       build/reports/
                       **/build/reports/
 
             - name: Save AppMaps
               uses: actions/cache/save@v4
-              if: runner.os == 'Linux'
+              if: runner.os == 'Linux' && matrix.ide_version == 'IC-2023.1'
               with:
                   path: ./tmp/appmap
                   key: appmaps-${{ github.sha }}-${{ github.run_attempt }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    JAVA_VERSION: 21
 on:
     pull_request:
     push:
@@ -29,7 +30,7 @@ jobs:
               uses: actions/setup-java@v4
               with:
                   distribution: temurin
-                  java-version: 21
+                  java-version: ${{ env.JAVA_VERSION }}
 
             # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
             - name: Show GitHub Actions rate limit
@@ -68,6 +69,29 @@ jobs:
               with:
                   path: ./tmp/appmap
                   key: appmaps-${{ github.sha }}-${{ github.run_attempt }}
+
+    verify:
+        name: Verify Plugin
+        runs-on: ubuntu-latest
+        needs: [test]
+        timeout-minutes: 45
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v4
+
+            - name: Setup Java
+              uses: actions/setup-java@v4
+              with:
+                  distribution: temurin
+                  java-version: ${{ env.JAVA_VERSION }}
+
+            - name: Verify Plugin Structure
+              shell: bash
+              run: ./gradlew verifyPlugin
+
+            - name: Run Plugin Verifier
+              shell: bash
+              run: ./gradlew verifyPlugin
 
     appmap-analysis:
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm") version "1.9.24"
-    id("org.jetbrains.intellij.platform") version "2.0.0-rc1"
+    id("org.jetbrains.intellij.platform") version "2.0.0"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"
@@ -258,7 +258,7 @@ project(":") {
             })
         }
 
-        verifyPlugin {
+        pluginVerification {
             ides {
                 ides(prop("ideVersionVerifier").split(","))
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=231.0
 untilBuild=242.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.20224.91
+ideVersionVerifier=IC-2023.1,IC-2024.2
 
 lombokVersion=1.18.32
 
@@ -13,7 +13,7 @@ ideVersion=2023.1
 #ideVersion=2023.2
 #ideVersion=2023.3.2
 #ideVersion=2024.1
-#ideVersion=242.20224.91
+#ideVersion=2024.2
 
 kotlin.stdlib.default.dependency=false
 

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -2,6 +2,7 @@ package appland.cli;
 
 import appland.AppMapBaseTest;
 import appland.files.AppMapFiles;
+import appland.settings.AppMapApplicationSettings;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.testRules.ResetIdeHttpProxyRule;
@@ -224,7 +225,7 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         Assume.assumeFalse("AppMap processes don't terminate reliably on Windows", SystemInfo.isWindows);
 
         var appMapConfig = myFixture.copyFileToProject("projects/without_existing_index/appmap.yml", "test-project/appmap.yml");
-        withContentRoot(appMapConfig.getParent(), () -> {
+        ModuleTestUtils.withContentRoot(getModule(), appMapConfig.getParent(), () -> {
             // copying AppMaps into a watched directory must trigger a file refresh based on the output of the AppMap process
             var refreshCondition = TestCommandLineService.newVfsRefreshCondition(getProject(), getTestRootDisposable());
             myFixture.copyDirectoryToProject("projects/without_existing_index", "test-project");

--- a/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/appmap/AppMapModelTest.java
@@ -15,11 +15,6 @@ import static appland.utils.ModelTestUtil.assertTreeHierarchy;
 
 public class AppMapModelTest extends AppMapBaseTest {
     @Override
-    protected boolean runInDispatchThread() {
-        return false;
-    }
-
-    @Override
     protected TempDirTestFixture createTempDirTestFixture() {
         // create temp files on disk
         return new TempDirTestFixtureImpl();

--- a/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
@@ -21,11 +21,6 @@ import java.util.concurrent.TimeUnit;
 import static appland.utils.ModelTestUtil.assertTreeHierarchy;
 
 public class RuntimeAnalysisModelTest extends AppMapBaseTest {
-    @Override
-    protected boolean runInDispatchThread() {
-        return false;
-    }
-
     @Test
     public void unauthenticated() {
         AppMapApplicationSettingsService.getInstance().setApiKey(null);
@@ -132,6 +127,7 @@ public class RuntimeAnalysisModelTest extends AppMapBaseTest {
     private void loadFindingsDirectory(@NotNull String directoryPath) throws Exception {
         var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
         WriteAction.computeAndWait(() -> myFixture.copyDirectoryToProject(directoryPath, "root"));
+        waitUntilIndexesAreReady();
         assertTrue(condition.await(30, TimeUnit.SECONDS));
     }
 }

--- a/plugin-core/src/test/java/appland/utils/ModelTestUtil.java
+++ b/plugin-core/src/test/java/appland/utils/ModelTestUtil.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.TreeTestUtil;
 import com.intellij.ui.treeStructure.Tree;
+import com.intellij.util.ui.EDT;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.tree.TreeModel;
@@ -16,14 +17,24 @@ public final class ModelTestUtil {
     public static void assertTreeHierarchy(@NotNull TreeModel model,
                                            @NotNull String expected,
                                            @NotNull Disposable disposable) {
-        ApplicationManager.getApplication().invokeAndWait(() -> {
-            new TreeTestUtil(new Tree(new AsyncTreeModel(model, disposable)))
-                    .expandAll()
-                    .expandAll()
-                    .expandAll()
-                    .expandAll()
-                    .expandAll()
-                    .assertStructure(expected);
-        });
+        if (EDT.isCurrentThreadEdt()) {
+            assertTreeHierarchyOnEDT(model, expected, disposable);
+        } else {
+            ApplicationManager.getApplication().invokeAndWait(() -> {
+                assertTreeHierarchyOnEDT(model, expected, disposable);
+            });
+        }
+    }
+
+    private static void assertTreeHierarchyOnEDT(@NotNull TreeModel model,
+                                                 @NotNull String expected,
+                                                 @NotNull Disposable disposable) {
+        new TreeTestUtil(new Tree(new AsyncTreeModel(model, disposable)))
+                .expandAll()
+                .expandAll()
+                .expandAll()
+                .expandAll()
+                .expandAll()
+                .assertStructure(expected);
     }
 }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/557
CI: Only the AppMap analysis failed and I'm unable to fix it because a re-run doesn't do that.

This PR adds an additional matrix build configuration to test against the latest supported IDE major version.
To avoid unnecessarily long job runtime, we're only running tests against the latest version on Linux, for now.

The verification of the plugin structure and binary release was split off into another job to simplify the structure of the workflow.

Tests, which failed on 2024.1 but not on 2023.1, are also fixed in this PR.