### PR TITLE
Support new UI in install instructions

### DIFF
--- a/appland-install-guide/webview.js
+++ b/appland-install-guide/webview.js
@@ -19,6 +19,7 @@ export function mountWebview() {
           props: {
             projects: this.projects,
             editor: 'jetbrains',
+            uiStyle: initialData.uiStyle || 'classic',
             analysisEnabled: this.analysisEnabled,
             userAuthenticated: this.userAuthenticated,
             featureFlags: new Set(['disable-record-pending']),

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -35,6 +35,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.NewUI;
 import com.intellij.util.Alarm;
 import com.intellij.util.SingleAlarm;
 import org.jetbrains.annotations.Nls;
@@ -141,6 +142,7 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
     @Override
     protected void setupInitMessage(@Nullable List<ProjectMetadata> initData, @NotNull JsonObject payload) {
         addBaseProperties(payload);
+        payload.addProperty("uiStyle", NewUI.isEnabled() ? "new-ui" : "classic");
         payload.add("projects", gson.toJsonTree(initData));
         payload.add("disabledPages", new JsonArray());
     }


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/734

This passes a new property to the install instructions webview: `uiStyle`
Possible values are `new-ui` for the new UI and `classic` for the old-style user-interface.