### PR TITLE
Update to latest 2024.2 eap

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm") version "1.9.24"
-    id("org.jetbrains.intellij.platform") version "2.0.0-beta8"
+    id("org.jetbrains.intellij.platform") version "2.0.0-beta9"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=231.0
 untilBuild=242.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.19533.56
+ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.20224.38
 
 lombokVersion=1.18.32
 
@@ -13,7 +13,7 @@ ideVersion=2023.1
 #ideVersion=2023.2
 #ideVersion=2023.3.2
 #ideVersion=2024.1
-#ideVersion=242.19533.56
+#ideVersion=242.20224.38
 
 kotlin.stdlib.default.dependency=false
 

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -110,7 +110,7 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
 
         // For example:
         // IntelliJ IDEA 2023.2 by JetBrains s.r.o.
-        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+( EAP)? by JetBrains s\\.r\\.o\\.");
+        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+( EAP| Beta)? by JetBrains s\\.r\\.o\\.");
         assertTrue("Code editor info must match: " + editorInfo, matches);
     }
 


### PR DESCRIPTION
Unfortunately, JetBrains made another part of the API we were using `@Internal`. I'll try to get more information about this...