### PR TITLE
Temporarily drop compatibility with 2024.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm") version "1.9.24"
-    id("org.jetbrains.intellij.platform") version "2.0.0-beta8"
+    id("org.jetbrains.intellij.platform") version "2.0.0-rc1"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 pluginVersion=0.67.0
 
 sinceBuild=231.0
-untilBuild=242.*
+untilBuild=241.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.20224.91
+ideVersionVerifier=IC-2023.1,IC-2024.1
 
 lombokVersion=1.18.32
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=231.0
 untilBuild=242.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.19533.56
+ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.20224.91
 
 lombokVersion=1.18.32
 
@@ -13,7 +13,7 @@ ideVersion=2023.1
 #ideVersion=2023.2
 #ideVersion=2023.3.2
 #ideVersion=2024.1
-#ideVersion=242.19533.56
+#ideVersion=242.20224.91
 
 kotlin.stdlib.default.dependency=false
 


### PR DESCRIPTION
The SDK made API internal without a replacement. Until this is hopefully solved with one of the next eap releases, we're dropping compatibility with 2024.2 to pass the release review process.