### PR TITLE
Work around internal API of 2024.2 `OpenInRightSplitSplit`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=231.0
 untilBuild=242.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-2024.1
+ideVersionVerifier=IC-2023.1,IC-2024.1,IC-242.20224.91
 
 lombokVersion=1.18.32
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginVersion=0.67.0
 
 sinceBuild=231.0
-untilBuild=241.*
+untilBuild=242.*
 
 # run plugin verifier for the earliest and latest supported versions
 ideVersionVerifier=IC-2023.1,IC-2024.1

--- a/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
+++ b/plugin-core/src/main/java/appland/actions/GenerateOpenApiAction.java
@@ -6,7 +6,6 @@ import appland.settings.AppMapProjectSettingsService;
 import appland.telemetry.TelemetryService;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.process.CapturingProcessHandler;
-import com.intellij.ide.actions.OpenInRightSplitAction;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -44,7 +43,7 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        createOpenApiFileInteractive(Objects.requireNonNull(e.getProject()), false);
+        createOpenApiFileInteractive(Objects.requireNonNull(e.getProject()));
     }
 
     /**
@@ -55,11 +54,10 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
      * <p>
      * After the file was created, the result is shown in a new editor.
      *
-     * @param project           The current project
-     * @param showInSplitEditor If the result file should be opened in a split editor
+     * @param project The current project
      */
     @RequiresEdt
-    public static void createOpenApiFileInteractive(@NotNull Project project, boolean showInSplitEditor) {
+    public static void createOpenApiFileInteractive(@NotNull Project project) {
         var commandLineService = AppLandCommandLineService.getInstance();
         var roots = commandLineService.getActiveRoots();
 
@@ -68,7 +66,7 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
                     AppMapBundle.get("action.appmap.generateOpenAPI.noRootMessage.text"),
                     AppMapBundle.get("action.appmap.generateOpenAPI.noRootMessage.title"));
         } else if (roots.size() == 1) {
-            createOpenApiFile(project, roots.get(0), showInSplitEditor);
+            createOpenApiFile(project, roots.get(0));
         } else {
             //noinspection RedundantCast,unchecked
             JBPopupFactory.getInstance()
@@ -78,14 +76,14 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
                     .setMovable(false)
                     .setResizable(false)
                     .setRequestFocus(true)
-                    .setItemChosenCallback(root -> createOpenApiFile(project, root, showInSplitEditor))
+                    .setItemChosenCallback(root -> createOpenApiFile(project, root))
                     .createPopup()
                     .showInFocusCenter();
         }
     }
 
     @RequiresEdt
-    public static void createOpenApiFile(@NotNull Project project, @NotNull VirtualFile projectRoot, boolean showInSplitEditor) {
+    public static void createOpenApiFile(@NotNull Project project, @NotNull VirtualFile projectRoot) {
         var commandLine = AppLandCommandLineService.getInstance().createGenerateOpenApiCommand(projectRoot);
         if (commandLine == null) {
             LOG.debug("Unable to create command line, e.g. because CLI tool is missing.");
@@ -99,12 +97,7 @@ public class GenerateOpenApiAction extends AnAction implements DumbAware {
             @Override
             public void onSuccess() {
                 if (openApiFile != null) {
-                    var editorManager = FileEditorManager.getInstance(project);
-                    if (showInSplitEditor && editorManager.getSelectedEditor() != null) {
-                        OpenInRightSplitAction.Companion.openInRightSplit(project, openApiFile, null, true);
-                    } else {
-                        editorManager.openFile(openApiFile, true);
-                    }
+                    FileEditorManager.getInstance(project).openFile(openApiFile, true);
                 }
             }
 

--- a/plugin-core/src/main/java/appland/actions/OpenInRightSplit.java
+++ b/plugin-core/src/main/java/appland/actions/OpenInRightSplit.java
@@ -1,0 +1,85 @@
+package appland.actions;
+
+import appland.utils.DataContexts;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.ex.ActionUtil;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.EmptyRunnable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.pom.Navigatable;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.impl.FakePsiElement;
+import com.intellij.util.concurrency.annotations.RequiresEdt;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class OpenInRightSplit {
+    private static final String RIGHT_SPLIT_ACTION = "OpenInRightSplit";
+
+    private OpenInRightSplit() {
+    }
+
+    /**
+     * Opens the given file in a right split editor.
+     * <p>
+     * This method exists to work around the internal API of {@link com.intellij.ide.actions.OpenInRightSplitAction}
+     * in 2024.2.
+     * <p>
+     * See <a href="https://youtrack.jetbrains.com/issue/IJPL-158380">YouTrack</a> for the JetBrains YouTrack ticket.
+     *
+     * @param project     Current project
+     * @param file        File to open
+     * @param navigatable Optional navigatable to navigate to
+     */
+    @RequiresEdt
+    public static void openInRightSplit(@NotNull Project project,
+                                        @NotNull VirtualFile file,
+                                        @Nullable Navigatable navigatable) {
+        ApplicationManager.getApplication().assertIsDispatchThread();
+        AnAction action = ActionManager.getInstance().getAction(RIGHT_SPLIT_ACTION);
+
+        // Context suitable for the SDK's OpenInRightSplitAction
+        DataContext actionContext = DataContexts.createCustomContext((dataId) -> {
+            if (CommonDataKeys.PROJECT.is(dataId)) {
+                return project;
+            }
+
+            if (CommonDataKeys.VIRTUAL_FILE.is(dataId)) {
+                return file;
+            }
+
+            if (navigatable != null && CommonDataKeys.PSI_ELEMENT.is(dataId)) {
+                // The action is using PSI_ELEMENT to retrieve a Navigatable.
+                // The DataKey enforces the PsiElement type, so we have to use a wrapper to make it work.
+                if (navigatable instanceof PsiElement) {
+                    return navigatable;
+                }
+
+                // Wrap in a PsiElement to satisfy the DataKey.
+                // OpenInRightSplitAction uses the navigate method.
+                return new FakePsiElement() {
+                    @Override
+                    public PsiElement getParent() {
+                        // try to provide a valid parent, it's the navigation target
+                        return PsiManager.getInstance(project).findFile(file);
+                    }
+
+                    @Override
+                    public void navigate(boolean requestFocus) {
+                        navigatable.navigate(requestFocus);
+                    }
+                };
+            }
+
+            return null;
+        });
+
+        ActionUtil.invokeAction(action,
+                actionContext,
+                ActionPlaces.KEYBOARD_SHORTCUT,
+                null,
+                EmptyRunnable.getInstance());
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/SharedAppMapWebViewMessages.java
+++ b/plugin-core/src/main/java/appland/webviews/SharedAppMapWebViewMessages.java
@@ -1,6 +1,7 @@
 package appland.webviews;
 
 import appland.AppMapBundle;
+import appland.actions.OpenInRightSplit;
 import appland.files.FileLocation;
 import appland.files.FileLookup;
 import appland.notifications.AppMapNotifications;
@@ -10,7 +11,6 @@ import appland.telemetry.TelemetryService;
 import appland.utils.GsonUtils;
 import appland.webviews.appMap.ExportSvgUtil;
 import com.google.gson.JsonObject;
-import com.intellij.ide.actions.OpenInRightSplitAction;
 import com.intellij.ide.actions.RevealFileAction;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -186,7 +186,7 @@ public final class SharedAppMapWebViewMessages {
         ApplicationManager.getApplication().invokeLater(() -> {
             // IntelliJ's lines are 0-based, AppMap lines seem to be 1-based
             var descriptor = new OpenFileDescriptor(project, referencedFile, location.getZeroBasedLine(-1), -1);
-            OpenInRightSplitAction.Companion.openInRightSplit(project, referencedFile, descriptor, true);
+            OpenInRightSplit.openInRightSplit(project, referencedFile, descriptor);
         }, ModalityState.defaultModalityState());
     }
 

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -110,7 +110,7 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
 
         // For example:
         // IntelliJ IDEA 2023.2 by JetBrains s.r.o.
-        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+( EAP)? by JetBrains s\\.r\\.o\\.");
+        var matches = editorInfo.matches("IntelliJ IDEA [0-9.]+( EAP | Beta)? by JetBrains s\\.r\\.o\\.");
         assertTrue("Code editor info must match: " + editorInfo, matches);
     }
 


### PR DESCRIPTION
2024.2 made this API internal without a replacement, despite use in published plugins.
This has been reported to JetBrains YouTrack  at https://youtrack.jetbrains.com/issue/IJPL-158380

"Generate OpenAPI" does not open a split mode anymore, so this use of the split action was removed.

This PR also updates to the latest beta of 2024.2 to make sure that the plugin verifier is running with a version which already contains the API change.

This change can be tested by navigating to a source file from the AppMap webview.
I've tested this on 2023.1 and 2024.2 eap.