### PR TITLE
Improve performance when Navie editor is opened

### DIFF
--- a/plugin-core/src/main/java/appland/files/AppMapAsyncFileListener.java
+++ b/plugin-core/src/main/java/appland/files/AppMapAsyncFileListener.java
@@ -57,7 +57,7 @@ public class AppMapAsyncFileListener implements AsyncFileListener {
 
         @Override
         public void afterVfsChange() {
-            AppMapFileChangeListener.sendNotification(changeTypes);
+            AppMapFileChangeListener.sendNotification(changeTypes, false);
         }
     }
 }

--- a/plugin-core/src/main/java/appland/files/AppMapFileChangeListener.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFileChangeListener.java
@@ -15,15 +15,18 @@ public interface AppMapFileChangeListener {
     /**
      * Posts an application-wide notification about changed AppMaps.
      */
-    static void sendNotification(Set<AppMapFileEventType> changeTypes) {
+    static void sendNotification(@NotNull Set<AppMapFileEventType> changeTypes, boolean isGenericRefresh) {
         ApplicationManager.getApplication().getMessageBus()
                 .syncPublisher(AppMapFileChangeListener.TOPIC)
-                .refreshAppMaps(changeTypes);
+                .refreshAppMaps(changeTypes, isGenericRefresh);
     }
 
     /**
      * Sent after any refresh of the local file system
      * and after changes to .appmap.json files (e.g. created, updated, deleted, renamed).
+     *
+     * @param isGenericRefresh {@code true} if the refresh was triggered by a generic refresh of the filesystem
+     *                         when it's not know that an .appmap.json file was changed.
      */
-    void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes);
+    void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes, boolean isGenericRefresh);
 }

--- a/plugin-core/src/main/java/appland/files/AppMapFileChangeListener.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFileChangeListener.java
@@ -9,6 +9,7 @@ import java.util.Set;
 /**
  * Listener to be notified after changes to .appmap.json files.
  */
+@FunctionalInterface
 public interface AppMapFileChangeListener {
     Topic<AppMapFileChangeListener> TOPIC = Topic.create("AppMap file change", AppMapFileChangeListener.class);
 

--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -1,6 +1,7 @@
 package appland.files;
 
 import appland.cli.AppLandCommandLineService;
+import appland.index.AppMapConfigFileIndex;
 import appland.index.AppMapSearchScopes;
 import appland.utils.GsonUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +14,7 @@ import com.intellij.execution.process.ProcessOutput;
 import com.intellij.execution.util.ExecUtil;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.io.FileUtil;
@@ -21,10 +23,10 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import com.intellij.util.indexing.FileBasedIndex;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,7 +79,8 @@ public final class AppMapFiles {
      */
     @RequiresReadLock
     public static @NotNull Collection<VirtualFile> findAppMapConfigFiles(@NotNull GlobalSearchScope scope) {
-        return FilenameIndex.getVirtualFilesByName(APPMAP_YML, false, scope);
+        var indexId = AppMapConfigFileIndex.INDEX_ID;
+        return FileBasedIndex.getInstance().getContainingFiles(indexId, AppMapFiles.APPMAP_YML, scope);
     }
 
     /**

--- a/plugin-core/src/main/java/appland/files/AppMapFiles.java
+++ b/plugin-core/src/main/java/appland/files/AppMapFiles.java
@@ -79,8 +79,19 @@ public final class AppMapFiles {
      */
     @RequiresReadLock
     public static @NotNull Collection<VirtualFile> findAppMapConfigFiles(@NotNull GlobalSearchScope scope) {
-        var indexId = AppMapConfigFileIndex.INDEX_ID;
-        return FileBasedIndex.getInstance().getContainingFiles(indexId, AppMapFiles.APPMAP_YML, scope);
+        var project = scope.getProject();
+        if (project != null && DumbService.isDumb(scope.getProject())) {
+            return Collections.emptyList();
+        }
+
+        return FileBasedIndex.getInstance().getContainingFiles(AppMapConfigFileIndex.INDEX_ID, APPMAP_YML, scope);
+    }
+
+    @RequiresReadLock
+    public static boolean isAppMapConfigAvailable(@NotNull Project project) {
+        // FileBasedIndex.getAllKeys and FileBasedIndex.processAllKeys didn't work,
+        // because they processed outdated index data.
+        return !findAppMapConfigFiles(project).isEmpty();
     }
 
     /**

--- a/plugin-core/src/main/java/appland/files/VirtualFileManagerLister.java
+++ b/plugin-core/src/main/java/appland/files/VirtualFileManagerLister.java
@@ -7,6 +7,6 @@ import java.util.Set;
 public class VirtualFileManagerLister implements VirtualFileManagerListener {
     @Override
     public void afterRefreshFinish(boolean asynchronous) {
-        AppMapFileChangeListener.sendNotification(Set.of(AppMapFileEventType.Refresh));
+        AppMapFileChangeListener.sendNotification(Set.of(AppMapFileEventType.Refresh), true);
     }
 }

--- a/plugin-core/src/main/java/appland/index/AppMapConfigFileIndex.java
+++ b/plugin-core/src/main/java/appland/index/AppMapConfigFileIndex.java
@@ -1,0 +1,53 @@
+package appland.index;
+
+import appland.files.AppMapFiles;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.indexing.*;
+import com.intellij.util.io.EnumeratorStringDescriptor;
+import com.intellij.util.io.KeyDescriptor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+
+/**
+ * Indexes appmap.yml configuration files to locate them quickly.
+ */
+public class AppMapConfigFileIndex extends ScalarIndexExtension<String> {
+    public static final ID<String, Void> INDEX_ID = ID.create("appmap.configFile");
+
+    @Override
+    public @NotNull ID<String, Void> getName() {
+        return INDEX_ID;
+    }
+
+    @Override
+    public int getVersion() {
+        return IndexUtil.BASE_VERSION;
+    }
+
+    @Override
+    public @NotNull KeyDescriptor<String> getKeyDescriptor() {
+        return EnumeratorStringDescriptor.INSTANCE;
+    }
+
+    @Override
+    public boolean dependsOnFileContent() {
+        return false;
+    }
+
+    @Override
+    @NotNull
+    public FileBasedIndex.InputFilter getInputFilter() {
+        return VirtualFile::isInLocalFileSystem;
+    }
+
+    @Override
+    public @NotNull DataIndexer<String, Void, FileContent> getIndexer() {
+        return fileContent -> {
+            var fileName = fileContent.getFileName();
+            return AppMapFiles.isAppMapConfigFileName(fileName)
+                    ? Collections.singletonMap(fileName, null)
+                    : Collections.emptyMap();
+        };
+    }
+}

--- a/plugin-core/src/main/java/appland/index/IndexUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexUtil.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 
 final class IndexUtil {
     // base version for our indexes, increase when the data structures or the parsing logic change
-    static final int BASE_VERSION = 65;
+    static final int BASE_VERSION = 66;
 
     // filenames covered by our own indexes
     static final Set<String> indexedFilenames = Collections.unmodifiableSet(findIndexedFilenames());

--- a/plugin-core/src/main/java/appland/index/IndexedFileListenerUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexedFileListenerUtil.java
@@ -39,7 +39,7 @@ public final class IndexedFileListenerUtil {
         });
 
         if (appMapFileListener) {
-            busConnection.subscribe(AppMapFileChangeListener.TOPIC, changes -> application.invokeLater(action));
+            busConnection.subscribe(AppMapFileChangeListener.TOPIC, (changes, isGenericRefresh) -> application.invokeLater(action));
         }
 
         if (findingsFileListener) {

--- a/plugin-core/src/main/java/appland/index/IndexedFileListenerUtil.java
+++ b/plugin-core/src/main/java/appland/index/IndexedFileListenerUtil.java
@@ -15,8 +15,11 @@ public final class IndexedFileListenerUtil {
     private IndexedFileListenerUtil() {
     }
 
-    public static void registerListeners(@NotNull Project project, @NotNull Disposable parent,
-                                         boolean appMapFileListener, boolean findingsFileListener,
+    public static void registerListeners(@NotNull Project project,
+                                         @NotNull Disposable parent,
+                                         boolean appMapFileListener,
+                                         boolean findingsFileListener,
+                                         boolean allowGenericFilesystemRefresh,
                                          @NotNull Runnable action) {
 
         var application = ApplicationManager.getApplication();
@@ -39,7 +42,11 @@ public final class IndexedFileListenerUtil {
         });
 
         if (appMapFileListener) {
-            busConnection.subscribe(AppMapFileChangeListener.TOPIC, (changes, isGenericRefresh) -> application.invokeLater(action));
+            busConnection.subscribe(AppMapFileChangeListener.TOPIC, (AppMapFileChangeListener) (changes, isGenericRefresh) -> {
+                if (allowGenericFilesystemRefresh || !isGenericRefresh) {
+                    application.invokeLater(action);
+                }
+            });
         }
 
         if (findingsFileListener) {

--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -104,7 +104,7 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
     }
 
     private void setupListeners() {
-        IndexedFileListenerUtil.registerListeners(project, this, true, true, projectRefreshAlarm::cancelAndRequest);
+        IndexedFileListenerUtil.registerListeners(project, this, true, true, true, projectRefreshAlarm::cancelAndRequest);
 
         ApplicationManager.getApplication().getMessageBus()
                 .connect(this)

--- a/plugin-core/src/main/java/appland/notifications/FirstAppMapListener.java
+++ b/plugin-core/src/main/java/appland/notifications/FirstAppMapListener.java
@@ -27,7 +27,7 @@ public class FirstAppMapListener implements AppMapFileChangeListener {
     }
 
     @Override
-    public void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes) {
+    public void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes, boolean isGenericRefresh) {
         if (!changeTypes.contains(AppMapFileEventType.Create)) {
             return;
         }

--- a/plugin-core/src/main/java/appland/problemsView/FindingsViewTab.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsViewTab.java
@@ -35,7 +35,7 @@ public final class FindingsViewTab extends ProblemsViewPanel {
         var rootNode = new FindingsRootNode(this);
         getTreeModel().setRoot(rootNode);
 
-        IndexedFileListenerUtil.registerListeners(project, this, false, true, () -> {
+        IndexedFileListenerUtil.registerListeners(project, this, false, true, false, () -> {
             rootNode.structureChanged(null);
         });
     }

--- a/plugin-core/src/main/java/appland/telemetry/AppMapRecordListener.java
+++ b/plugin-core/src/main/java/appland/telemetry/AppMapRecordListener.java
@@ -11,7 +11,7 @@ public class AppMapRecordListener implements AppMapFileChangeListener {
     @NotNull private final AtomicBoolean appMapRecordedThisSession = new AtomicBoolean(false);
 
     @Override
-    public void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes) {
+    public void refreshAppMaps(@NotNull Set<AppMapFileEventType> changeTypes, boolean isGenericRefresh) {
         if (!changeTypes.contains(AppMapFileEventType.Create) && !changeTypes.contains(AppMapFileEventType.Modify)) {
             return;
         }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
@@ -91,7 +91,7 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
         this.tree = createTree(project, this, appMapModel);
         this.treeRefreshAlarm = new SingleAlarm(() -> refreshAndExpand(appMapModel), TREE_REFRESH_DELAY_MILLIS, this, Alarm.ThreadToUse.POOLED_THREAD);
 
-        IndexedFileListenerUtil.registerListeners(project, this, true, false, () -> rebuild(false));
+        IndexedFileListenerUtil.registerListeners(project, this, true, false, true, () -> rebuild(false));
 
         // create the content panel
         var appMapPanel = createAppMapPanel(project, tree, appMapModel);

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
@@ -3,12 +3,12 @@ package appland.webviews.navie;
 import appland.AppMapBundle;
 import appland.actions.SetNavieOpenAiKeyAction;
 import appland.config.AppMapConfigFileListener;
-import appland.files.AppMapFileChangeListener;
 import appland.files.AppMapFiles;
 import appland.files.FileLookup;
 import appland.files.OpenAppMapFileNavigatable;
 import appland.index.AppMapMetadata;
 import appland.index.AppMapMetadataService;
+import appland.index.IndexedFileListenerUtil;
 import appland.installGuide.InstallGuideEditorProvider;
 import appland.installGuide.InstallGuideViewPage;
 import appland.rpcService.AppLandJsonRpcService;
@@ -135,12 +135,10 @@ public class NavieEditor extends WebviewEditor<Void> {
                 applyWebViewFilters();
             }
         });
-        busConnection.subscribe(AppMapFileChangeListener.TOPIC, (AppMapFileChangeListener) (changeTypes, isGenericRefresh) -> {
-            if (!isGenericRefresh) {
-                updateNaviePropertiesAlarm.cancelAndRequest();
-            }
-        });
         busConnection.subscribe(AppMapConfigFileListener.TOPIC, (AppMapConfigFileListener) updateNaviePropertiesAlarm::cancelAndRequest);
+
+        // listen for changes of AppMap files
+        IndexedFileListenerUtil.registerListeners(project, this, true, false, false, updateNaviePropertiesAlarm::cancelAndRequest);
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
@@ -377,7 +377,7 @@ public class NavieEditor extends WebviewEditor<Void> {
      */
     @RequiresReadLock
     private static @NotNull UpdatableNavieData createUpdatableNavieData(@NotNull Project project) {
-        var isAppMapYamlPresent = !AppMapFiles.findAppMapConfigFiles(project).isEmpty();
+        var isAppMapYamlPresent = AppMapFiles.isAppMapConfigAvailable(project);
         var mostRecentAppMaps = findMostRecentAppMaps(project);
         return new UpdatableNavieData(isAppMapYamlPresent, mostRecentAppMaps);
     }

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
@@ -135,8 +135,10 @@ public class NavieEditor extends WebviewEditor<Void> {
                 applyWebViewFilters();
             }
         });
-        busConnection.subscribe(AppMapFileChangeListener.TOPIC, (AppMapFileChangeListener) changeTypes -> {
-            updateNaviePropertiesAlarm.cancelAndRequest();
+        busConnection.subscribe(AppMapFileChangeListener.TOPIC, (AppMapFileChangeListener) (changeTypes, isGenericRefresh) -> {
+            if (!isGenericRefresh) {
+                updateNaviePropertiesAlarm.cancelAndRequest();
+            }
         });
         busConnection.subscribe(AppMapConfigFileListener.TOPIC, (AppMapConfigFileListener) updateNaviePropertiesAlarm::cancelAndRequest);
     }

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -69,6 +69,7 @@
         <fileBasedIndex implementation="appland.index.AppMapServerRequestCountIndex"/>
         <fileBasedIndex implementation="appland.index.AppMapSqlQueriesCountIndex"/>
         <fileBasedIndex implementation="appland.index.ClassMapTypeIndex"/>
+        <fileBasedIndex implementation="appland.index.AppMapConfigFileIndex"/>
 
         <roots.watchedRootsProvider implementation="appland.index.AppMapWatchedRootsProvider"/>
         <!-- For 2023.1 and earlier -->

--- a/plugin-core/src/test/java/appland/files/AppMapAsyncFileListenerTest.java
+++ b/plugin-core/src/test/java/appland/files/AppMapAsyncFileListenerTest.java
@@ -22,7 +22,7 @@ public class AppMapAsyncFileListenerTest extends AppMapBaseTest {
 
         ApplicationManager.getApplication().getMessageBus()
                 .connect(getTestRootDisposable())
-                .subscribe(AppMapFileChangeListener.TOPIC, changes -> {
+                .subscribe(AppMapFileChangeListener.TOPIC, (changes, isGenericRefresh) -> {
                     latch.countDown();
                 });
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/754

- https://github.com/getappmap/appmap-intellij-plugin/pull/759/commits/dd46266f6a10f45c5dd8e6c4c9410dae2dc658cb
For Navie and other code the presence of appmap.yml files in the project is detected. We used the SDK's FilenameIndex, which should be suitable for tasks like this. But it proved to expensive to call because it attempted to update a lot of index data of files we don't care about.  This commit adds an index only for the filename indexing of appmap.yml files to make the lookup much faster and cheaper.
- https://github.com/getappmap/appmap-intellij-plugin/pull/759/commits/553decd799abb1b466d26e22fcdf8fc9a8b6c3e9 changes the handling of generic filesystem refresh events. Previously, every refresh and even a refresh of non-AppMap files, triggered an update of the Navie editor. Because there can be a lot of file changes in the background, the Navie editor was updated a lot. Every update triggered a somewhat expensive lookup of AppMaps and appmap.yml files. The generic refresh does not update the Navie editor anymore, but updates of .appmap.json, appmap.yml and a status change of indexing does update it.