### PR TITLE
fix: "New chat" button opens a new chat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*/dist/** binary

--- a/appland-navie/package.json
+++ b/appland-navie/package.json
@@ -18,7 +18,7 @@
     "webpack-cli": "^4.6"
   },
   "dependencies": {
-    "@appland/components": "^4.30.0",
+    "@appland/components": "^4.30.1",
     "highlight.js": "^11.9.0",
     "url": "^0.11",
     "vue": "^2.7",

--- a/appland-navie/webview.js
+++ b/appland-navie/webview.js
@@ -25,6 +25,9 @@ export function mountWebview() {
             appmapYmlPresent: this.appmapYmlPresent,
             targetAppmapData: initialData.targetAppmapData,
             targetAppmapFsPath: initialData.targetAppmapFsPath,
+            openNewChat() {
+              vscode.postMessage({ command: "open-new-chat" });
+            },
           },
         });
       },

--- a/appland-navie/yarn.lock
+++ b/appland-navie/yarn.lock
@@ -22,10 +22,10 @@
     rxjs "^7.8.1"
     socket.io-client "^4.7.2"
 
-"@appland/components@^4.30.0":
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/@appland/components/-/components-4.30.0.tgz#2891627a32b34f109bb7729d49350c5ce180d8d3"
-  integrity sha512-FoVxCia9i3jdWaaqBbpXpg7vtx2KWmDsO2fSjlPogXWyCniiX3j5xNlbi5C0M9x6fpCGwwm99ZvWI8qnaVeRNQ==
+"@appland/components@^4.30.1":
+  version "4.30.1"
+  resolved "https://registry.yarnpkg.com/@appland/components/-/components-4.30.1.tgz#ca2d3c118b4a53b752b57e26728de743333ac1d7"
+  integrity sha512-Eivp6LuXS6up0kucSn/3YERJiBQrGZd7kpdq4iWkzSsubtbsdwS543okxw6aH6e4BGAhl39r/QRzgWhvJibTTw==
   dependencies:
     "@appland/client" "^1.12.0"
     "@appland/diagrams" "^1.7.0"

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
@@ -25,6 +25,7 @@ import appland.webviews.appMap.AppMapFileEditorState;
 import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.ReadAction;
@@ -77,6 +78,7 @@ public class NavieEditor extends WebviewEditor<Void> {
                 "open-appmap",
                 "open-install-instructions",
                 "open-location",
+                "open-new-chat",
                 "open-record-instructions",
                 "select-llm-option",
                 "show-appmap-tree"));
@@ -171,6 +173,11 @@ public class NavieEditor extends WebviewEditor<Void> {
                 }
                 break;
             }
+            case "open-new-chat":
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    NavieEditorProvider.openEditor(project, DataContext.EMPTY_CONTEXT);
+                }, ModalityState.defaultModalityState());
+                break;
             case "open-record-instructions":
                 ApplicationManager.getApplication().invokeLater(() -> {
                     InstallGuideEditorProvider.open(project, InstallGuideViewPage.RecordAppMaps);


### PR DESCRIPTION
Instead of destructively clearing the current chat, "new chat" button opens a new tab instead.

Requires support in @appland/components provided by https://github.com/getappmap/appmap-js/pull/1925
(Counterpart of https://github.com/getappmap/vscode-appland/pull/995 )

Please note I haven't committed recompiled dist files. They should be recompiled after the components change is merged.
Also note I haven't actually tested this (I have some issues trying to run the plugin).