### PR TITLE
Improve test setup and reenable two tests

### DIFF
--- a/plugin-core/src/main/java/appland/cli/AppLandProjectManagerListener.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandProjectManagerListener.java
@@ -1,5 +1,6 @@
 package appland.cli;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManagerListener;
 import org.jetbrains.annotations.NotNull;
@@ -11,6 +12,12 @@ import org.jetbrains.annotations.NotNull;
 public class AppLandProjectManagerListener implements ProjectManagerListener {
     @Override
     public void projectClosed(@NotNull Project project) {
+        // We're not launching the CLI processes by default in test mode,
+        // because it's async and may interfere with other tests.
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            return;
+        }
+
         AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
     }
 }

--- a/plugin-core/src/main/java/appland/cli/AppMapCommandLineConfigListener.java
+++ b/plugin-core/src/main/java/appland/cli/AppMapCommandLineConfigListener.java
@@ -1,0 +1,14 @@
+package appland.cli;
+
+import appland.config.AppMapConfigFileListener;
+
+/**
+ * Listener to refresh the open projects, which is enabled in both production and test modes.
+ * Service {@link DefaultCommandLineService} is not loaded by default in tests.
+ */
+public class AppMapCommandLineConfigListener implements AppMapConfigFileListener {
+    @Override
+    public void refreshAppMapConfigs() {
+        AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -70,8 +70,8 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
     protected final ConcurrentHashMap<VirtualFile, CliProcesses> processes = new ConcurrentHashMap<>();
 
     public DefaultCommandLineService() {
-        var connection = ApplicationManager.getApplication().getMessageBus().connect(this);
-        connection.subscribe(AppMapConfigFileListener.TOPIC, (AppMapConfigFileListener) this::refreshForOpenProjectsInBackground);
+        // AppLandCommandLineListener is registering the listener for appmap.yml changes,
+        // it's active even in test mode.
     }
 
     @Override

--- a/plugin-core/src/main/java/appland/rpcService/AppMapJsonRpcServerStartupActivity.java
+++ b/plugin-core/src/main/java/appland/rpcService/AppMapJsonRpcServerStartupActivity.java
@@ -1,5 +1,6 @@
 package appland.rpcService;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
@@ -8,7 +9,9 @@ import org.jetbrains.annotations.NotNull;
 public class AppMapJsonRpcServerStartupActivity implements StartupActivity, DumbAware {
     @Override
     public void runActivity(@NotNull Project project) {
-        if (!project.isDefault()) {
+        // We're not launching the CLI processes by default in test mode,
+        // because it's async and may interfere with other tests.
+        if (!project.isDefault() && !ApplicationManager.getApplication().isUnitTestMode()) {
             AppLandJsonRpcService.getInstance(project).startServer();
         }
     }

--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -435,7 +435,7 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
             }
 
             var currentRestartDelay = nextRestartDelayMillis;
-            var restartNeeded = currentRestartDelay >= 0L
+            var restartNeeded = currentRestartDelay > 0L
                     && currentRestartDelay <= MAX_RESTART_DELAY_MILLIS
                     && !isDisposed;
 

--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -233,7 +233,11 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
         try {
             stopServerSync(this.jsonRpcServer);
         } finally {
-            startServer();
+            try {
+                startServer();
+            } finally {
+                project.getMessageBus().syncPublisher(AppLandJsonRpcListener.TOPIC).serverRestarted();
+            }
         }
     }
 

--- a/plugin-core/src/main/java/appland/utils/AppMapProcessUtil.java
+++ b/plugin-core/src/main/java/appland/utils/AppMapProcessUtil.java
@@ -1,0 +1,53 @@
+package appland.utils;
+
+import com.intellij.execution.process.KillableProcessHandler;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public final class AppMapProcessUtil {
+    private static final Logger LOG = Logger.getInstance(AppMapProcessUtil.class);
+
+    private AppMapProcessUtil() {
+    }
+
+    public static void terminateProcess(@NotNull KillableProcessHandler process, int timeout, @NotNull TimeUnit timeUnit) {
+        LOG.debug("Terminating process: " + process.getCommandLine() + " timeout " + timeUnit.toMillis(timeout) + "ms");
+
+        // AppMap processes don't seem to like a graceful shutdown
+        process.setShouldKillProcessSoftly(false);
+
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            // synchronously kills the process in test mode
+            process.killProcess();
+        } else {
+            process.destroyProcess();
+            if (!process.waitFor(500)) {
+                LOG.warn("Process did not terminate within 500ms: " + process.getCommandLine());
+            }
+
+            if (!process.isProcessTerminated()) {
+                process.killProcess();
+            }
+        }
+
+        waitForProcess(process, timeout, timeUnit);
+    }
+
+    public static void waitForProcess(@NotNull KillableProcessHandler process, int timeout, @NotNull TimeUnit timeUnit) {
+        if (timeout <= 0 || process.isProcessTerminated()) {
+            return;
+        }
+
+        var deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
+        while (System.currentTimeMillis() < deadline) {
+            if (process.isProcessTerminated()) {
+                break;
+            }
+
+            process.waitFor(100);
+        }
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -28,6 +28,9 @@
         <listener topic="appland.settings.AppMapSettingsListener"
                   class="appland.settings.AppMapNavieSettingsReloadProjectListener"
                   activeInTestMode="false"/>
+        <listener topic="appland.config.AppMapConfigFileListener"
+                  class="appland.cli.AppMapCommandLineConfigListener"
+                  activeInTestMode="true"/>
     </applicationListeners>
 
     <projectListeners>

--- a/plugin-core/src/test/java/appland/AppLandTestExecutionPolicy.java
+++ b/plugin-core/src/test/java/appland/AppLandTestExecutionPolicy.java
@@ -19,6 +19,7 @@ public class AppLandTestExecutionPolicy extends IdeaTestExecutionPolicy {
     }
 
     public static @NotNull String findAppMapHomePath() {
-        return System.getProperty("appland.testDataPath");
+        var path = System.getProperty("appland.testDataPath");
+        return path.endsWith("/") ? path : path + "/";
     }
 }

--- a/plugin-core/src/test/java/appland/AppMapBaseTest.java
+++ b/plugin-core/src/test/java/appland/AppMapBaseTest.java
@@ -4,6 +4,8 @@ import appland.cli.AppLandCommandLineService;
 import appland.cli.TestCommandLineService;
 import appland.config.AppMapConfigFile;
 import appland.files.AppMapFiles;
+import appland.problemsView.TestFindingsManager;
+import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapApplicationSettings;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.utils.IndexTestUtils;
@@ -50,6 +52,11 @@ public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4Tes
         } else {
             edt(() -> TempFileSystem.getInstance().cleanupForNextTest());
         }
+
+        TestFindingsManager.reset(getProject());
+
+        // init services to register its listeners
+        AppLandJsonRpcService.getInstance(getProject());
     }
 
     @Override

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -18,7 +18,7 @@ import static appland.cli.DefaultAppLandDownloadService.currentPlatform;
 
 public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
     @Rule
-    public MockServerRule mockServerRule = new MockServerRule(this);
+    public MockServerRule mockServerRule = new MockServerRule(this, false);
     @Rule
     public MockServerSettingsRule mockServerSettingsRule = new MockServerSettingsRule();
     @Rule

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -5,9 +5,11 @@ import appland.files.AppMapFiles;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.testRules.ResetIdeHttpProxyRule;
+import appland.utils.AppMapProcessUtil;
 import appland.utils.ModuleTestUtils;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.PtyCommandLine;
+import com.intellij.execution.process.CapturingProcessAdapter;
 import com.intellij.execution.process.KillableProcessHandler;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
@@ -27,7 +29,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.*;
 import org.junit.rules.TestRule;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +48,11 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     @Override
     protected TempDirTestFixture createTempDirTestFixture() {
         return new TempDirTestFixtureImpl();
+    }
+
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
     }
 
     @Before
@@ -71,20 +77,15 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     @Test
     @Ignore("flaky test")
     public void directoryTree() throws Exception {
-        // fixme this test is failing oddly on Windows CI, remove when we made a proper fix
-        Assume.assumeTrue(SystemInfo.isUnix);
-
         var service = AppLandCommandLineService.getInstance();
 
-        var parentDir = myFixture.createFile("test.txt", "").getParent();
-        assertNotNull(parentDir);
-
-        withContentRoot(parentDir, () -> {
+        var parentDir = createVirtualFileDirectory("test.txt");
+        ModuleTestUtils.withContentRoot(getModule(), parentDir, () -> {
             assertFalse("Service must not execute for a directory without appmap.yaml", service.isRunning(parentDir, false));
 
             // creating an appmap.yml file must trigger the launch of the matching AppMap processes
-            var nestedDir = myFixture.addFileToProject("parent/child/file.txt", "").getParent().getVirtualFile();
-            assertNotNull(nestedDir);
+            var nestedDir = createVirtualFileDirectory("parent/child/file.txt");
+
             createAppMapYaml(nestedDir, "tmp/appmap");
             waitForProcessStatus(true, nestedDir, true);
             assertActiveRoots(nestedDir);
@@ -111,12 +112,8 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
     @Test
     public void directoryTreeWatchedSubdir() throws Exception {
-        // This test fails on Windows, because it's unable to delete the appmap directory.
-        // Maybe the scanner and indexer aren't being stopped properly?
-        Assume.assumeTrue(SystemInfo.isUnix);
-
-        var tempDir = myFixture.createFile("test.txt", "").getParent();
-        withContentRoot(tempDir, () -> {
+        var tempDir = createVirtualFileDirectory("file.txt");
+        ModuleTestUtils.withContentRoot(getModule(), tempDir, () -> {
             var service = AppLandCommandLineService.getInstance();
             createAppMapYaml(tempDir, "tmp/appmaps");
             waitForProcessStatus(true, tempDir, true);
@@ -133,54 +130,63 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     }
 
     @Test
-    public void environmentPassing() throws ExecutionException, InterruptedException, IOException {
-        final var settings = AppMapApplicationSettingsService.getInstance();
+    public void environmentPassing() throws ExecutionException {
+        var settings = AppMapApplicationSettingsService.getInstance();
         settings.setCliEnvironment(Map.of("FOO", "BAR", "BAZ", "QUX"));
+
         // use "cmd /c set" on windows, "env" on unix
-        Path workingDir = Path.of(".");
-        final var process = (SystemInfo.isWindows
+        var workingDir = Path.of(myFixture.getTempDirPath());
+        var processHandler = (SystemInfo.isWindows
                 ? DefaultCommandLineService.startProcess(workingDir, "cmd", "/c", "set")
                 : DefaultCommandLineService.startProcess(workingDir, "env")
-        ).getProcess();
+        );
 
-        process.waitFor(5, TimeUnit.SECONDS);
 
-        // read the output of the process
-        final var output = new String(process.getInputStream().readAllBytes());
+        try {
+            var capturingAdapter = new CapturingProcessAdapter();
+            processHandler.addProcessListener(capturingAdapter, getTestRootDisposable());
+            processHandler.startNotify();
+            processHandler.waitFor(5_000);
 
-        // check that the environment variables are passed to the process
-        assertTrue(output.contains("FOO=BAR"));
-        assertTrue(output.contains("BAZ=QUX"));
+            var output = capturingAdapter.getOutput().getStdout();
+
+            // check that the environment variables are passed to the process
+            assertTrue(output.contains("FOO=BAR"));
+            assertTrue(output.contains("BAZ=QUX"));
+        } finally {
+            AppMapProcessUtil.terminateProcess(processHandler, 5, TimeUnit.SECONDS);
+        }
     }
 
     @Test
-    @Ignore("flaky test")
     public void siblingDirectories() throws Exception {
-        var dirA = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
-        var dirB = myFixture.addFileToProject("parentB/file.txt", "").getParent().getVirtualFile();
+        var dirA = createVirtualFileDirectory("parentA/file.txt");
+        var dirB = createVirtualFileDirectory("parentB/file.txt");
 
         var service = AppLandCommandLineService.getInstance();
 
         // no appmap.yml files -> no processes
-        addContentRootAndLaunchService(dirA);
-        addContentRootAndLaunchService(dirB);
-        assertEmptyRoots();
+        var condition = ProjectRefreshUtil.newProjectRefreshCondition(getTestRootDisposable());
+        ModuleTestUtils.withContentRoots(getModule(), List.of(dirA, dirB), () -> {
+            assertTrue(condition.await(30, TimeUnit.SECONDS));
+            assertEmptyRoots();
 
-        // appmap.yml for dirA
-        createAppMapYaml(dirA);
-        addContentRootAndLaunchService(dirA);
-        assertTrue(service.isRunning(dirA, true));
-        assertFalse(service.isRunning(dirB, true));
+            // appmap.yml for dirA
+            createAppMapYaml(dirA);
+            waitForProcessStatus(true, dirA, true);
+            assertTrue(service.isRunning(dirA, true));
+            assertFalse(service.isRunning(dirB, true));
 
-        // appmap.yml for dirB and dirA
-        createAppMapYaml(dirB);
-        addContentRootAndLaunchService(dirB);
-        assertTrue(service.isRunning(dirA, true));
-        assertTrue(service.isRunning(dirB, true));
+            // appmap.yml for dirB and dirA
+            createAppMapYaml(dirB);
+            waitForProcessStatus(true, dirB, true);
+            assertTrue(service.isRunning(dirA, true));
+            assertTrue(service.isRunning(dirB, true));
 
-        assertActiveRoots(dirA, dirB);
+            assertActiveRoots(dirA, dirB);
+        });
 
-        service.stopAll(10_000, TimeUnit.MILLISECONDS);
+        service.stopAll(60, TimeUnit.SECONDS);
 
         var debugInfo = service.toString();
         assertFalse("No services expected for parentA: " + debugInfo, service.isRunning(dirA, true));
@@ -191,12 +197,12 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     public void contentRootUpdates() throws Exception {
         Assume.assumeFalse("On windows, it fails with java.io.IOException: Cannot delete ...", SystemInfo.isWindows);
 
-        var topLevelDir = myFixture.addFileToProject("file.txt", "").getParent().getVirtualFile();
-        var newRootA = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
-        var nestedRootA = myFixture.addFileToProject("parentA/subDir/file.txt", "").getParent().getVirtualFile();
-        var newRootB = myFixture.addFileToProject("parentB/file.txt", "").getParent().getVirtualFile();
+        var topLevelDir = createVirtualFileDirectory("file.txt");
+        var newRootA = createVirtualFileDirectory("parentA/file.txt");
+        var nestedRootA = createVirtualFileDirectory("parentA/subDir/file.txt");
+        var newRootB = createVirtualFileDirectory("parentB/file.txt");
 
-        withContentRoot(topLevelDir, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), topLevelDir, () -> {
             createAppMapYaml(newRootA);
             waitForProcessStatus(true, newRootA, true);
 
@@ -221,8 +227,6 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
     @Test
     public void directoryRefreshAfterAppMapIndexing() throws Throwable {
-        Assume.assumeFalse("AppMap processes don't terminate reliably on Windows", SystemInfo.isWindows);
-
         var appMapConfig = myFixture.copyFileToProject("projects/without_existing_index/appmap.yml", "test-project/appmap.yml");
         withContentRoot(appMapConfig.getParent(), () -> {
             // copying AppMaps into a watched directory must trigger a file refresh based on the output of the AppMap process
@@ -261,8 +265,8 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
                 .connect(getTestRootDisposable())
                 .subscribe(AppMapSettingsListener.TOPIC, new RestartServicesAfterApiChangeListener());
 
-        var tempDir = myFixture.createFile("test.txt", "").getParent();
-        withContentRoot(tempDir, () -> {
+        var tempDir = createVirtualFileDirectory("test.txt");
+        ModuleTestUtils.withContentRoot(getModule(), tempDir, () -> {
             createAppMapYaml(tempDir, "tmp/appmap");
             waitForProcessStatus(true, tempDir, true);
             assertActiveRoots(tempDir);
@@ -302,10 +306,10 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
 
     @Test
     public void appmapYamlTrigger() throws Exception {
-        var newRootA = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
+        var newRootA = createVirtualFileDirectory("parentA/file.txt");
 
         final var rootRefreshCondition = ProjectRefreshUtil.newProjectRefreshCondition(getTestRootDisposable());
-        withContentRoot(newRootA, () -> {
+        ModuleTestUtils.withContentRoot(getModule(), newRootA, () -> {
             assertTrue(rootRefreshCondition.await(30, TimeUnit.SECONDS));
 
             // no watched roots because there's no appmap.yml
@@ -406,8 +410,8 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     }
 
     private void setupAndAssertProcessRestart(@NotNull Function<VirtualFile, KillableProcessHandler> processForRoot) throws Exception {
-        var root = myFixture.addFileToProject("parentA/file.txt", "").getParent().getVirtualFile();
-        withContentRoot(root, () -> {
+        var root = createVirtualFileDirectory("parentA/file.txt");
+        ModuleTestUtils.withContentRoot(getModule(), root, () -> {
             createAppMapYaml(root);
             waitForProcessStatus(true, root, true);
             assertActiveRoots(root);
@@ -514,6 +518,13 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
         assertEquals("Unexpected process status for directory " + directory + ": " + service, expectedIsRunning, service.isRunning(directory, strict));
     }
 
+    private @NotNull VirtualFile createVirtualFileDirectory(String relativePath) {
+        var psiFile = myFixture.addFileToProject(relativePath, "");
+        var virtualFile = ReadAction.compute(() -> psiFile.getParent().getVirtualFile());
+        assertNotNull(virtualFile);
+        return virtualFile;
+    }
+
     private static void waitForProcessRestart(@NotNull VirtualFile root,
                                               @NotNull Function<VirtualFile, KillableProcessHandler> processForRoot,
                                               @NotNull ThrowableConsumer<KillableProcessHandler, Exception> restartTrigger) throws Exception {
@@ -534,9 +545,8 @@ public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     }
 
     private static void terminateProcess(@NotNull KillableProcessHandler process) {
-        process.destroyProcess();
-        process.killProcess();
-        assertTrue("Process must terminate", process.waitFor(5_000));
+        AppMapProcessUtil.terminateProcess(process, 60, TimeUnit.SECONDS);
+        assertTrue("Process must terminate: " + process, process.isProcessTerminated());
     }
 
     private static final Function<VirtualFile, KillableProcessHandler> getIndexerFunction = root -> {

--- a/plugin-core/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceProxyTest.java
@@ -23,7 +23,7 @@ public class AppMapJavaAgentDownloadServiceProxyTest extends AppMapBaseTest {
     @Rule
     public TestRule agentDownloadRule = new OverrideJavaAgentLocationRule(() -> this.myFixture);
     @Rule
-    public MockServerRule mockServerRule = new MockServerRule(this);
+    public MockServerRule mockServerRule = new MockServerRule(this, false);
     @Rule
     public MockServerSettingsRule mockServerSettingsRule = new MockServerSettingsRule();
     @Rule

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -4,6 +4,7 @@ import appland.AppMapBaseTest;
 import appland.cli.AppLandCommandLineService;
 import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
@@ -59,7 +60,7 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
     public void serverRestartAfterTermination() throws Exception {
         waitForJsonRpcServer();
 
-        var latch = createWaitForRestartCondition();
+        var latch = createWaitForRestartCondition(false);
 
         // kill and wait for restart
         TestAppLandJsonRpcService.killJsonRpcProcess(getProject());
@@ -91,7 +92,7 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
         var appMapSettings = AppMapApplicationSettingsService.getInstance();
         appMapSettings.setApiKey("dummy");
         try {
-            var latch = createWaitForRestartCondition();
+            var latch = createWaitForRestartCondition(false);
 
             // change API key and wait for restart
             appMapSettings.setApiKeyNotifying("new-api-key");
@@ -116,13 +117,12 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
 
     private void waitForJsonRpcServer() {
         var service = AppLandJsonRpcService.getInstance(getProject());
-
-        var latch = createWaitForRestartCondition();
-
         if (service.isServerRunning()) {
             return;
         }
 
+        var latch = createWaitForRestartCondition(true);
+        ApplicationManager.getApplication().executeOnPooledThread(service::startServer);
         try {
             assertTrue("The AppMap JSON-RPC server must launch", latch.await(30, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
@@ -130,11 +130,18 @@ public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
         }
     }
 
-    private @NotNull CountDownLatch createWaitForRestartCondition() {
+    private @NotNull CountDownLatch createWaitForRestartCondition(boolean allowStart) {
         var latch = new CountDownLatch(1);
         getProject().getMessageBus()
                 .connect(getTestRootDisposable())
                 .subscribe(AppLandJsonRpcListener.TOPIC, new AppLandJsonRpcListenerAdapter() {
+                    @Override
+                    public void serverStarted() {
+                        if (allowStart) {
+                            latch.countDown();
+                        }
+                    }
+
                     @Override
                     public void serverRestarted() {
                         latch.countDown();

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -22,6 +22,11 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertArrayEquals;
 
 public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
     @Test
     public void launchedWithProject() {
         waitForJsonRpcServer();


### PR DESCRIPTION
This is merging some changes of outdated PR https://github.com/getappmap/appmap-intellij-plugin/pull/674

This should make tests more reliable and easier to debug. Async process execution is disabled for tests now and this should avoid some of the unstable tests we've observed in the past.

The AppMap report is showing nicely that there this PR un-ignored two of the previously flaky tests :) 

A user-visible fix is https://github.com/getappmap/appmap-intellij-plugin/pull/762/commits/96cc6c2cfbfc7c86fb07504eba50d207e98dd310, which fixes the restart of the JSON-RPC server after too many terminations of the process.