### PR TITLE
Focus open install guide webview editor when it's invoked from AppMap toolwindow

### DIFF
--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditorProvider.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditorProvider.java
@@ -31,7 +31,7 @@ public class InstallGuideEditorProvider extends WebviewEditorProvider {
             assert provider != null;
 
             // an open Install Guide webview must navigate to the new page
-            var openEditor = provider.findOpenEditor(project, Predicates.alwaysTrue());
+            var openEditor = provider.focusOpenEditor(project, Predicates.alwaysTrue());
             if (openEditor != null) {
                 ((InstallGuideEditor) openEditor).navigateTo(page, true, false);
                 return;

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditorProvider.java
@@ -87,7 +87,7 @@ public abstract class WebviewEditorProvider implements FileEditorProvider, DumbA
      * @param reuseOpenEditor If {@code true}, then an already available webview editor is focused instead of creating a new one.
      */
     public void open(@NotNull Project project, @NotNull String title, boolean reuseOpenEditor) {
-        if (reuseOpenEditor && focusOpenEditor(project, Predicates.alwaysTrue())) {
+        if (reuseOpenEditor && focusOpenEditor(project, Predicates.alwaysTrue()) != null) {
             return;
         }
 
@@ -109,14 +109,14 @@ public abstract class WebviewEditorProvider implements FileEditorProvider, DumbA
         return file;
     }
 
-    public boolean focusOpenEditor(@NotNull Project project, @NotNull Predicate<WebviewEditor<?>> editorPredicate) {
+    public WebviewEditor<?> focusOpenEditor(@NotNull Project project, @NotNull Predicate<WebviewEditor<?>> editorPredicate) {
         var openEditor = findOpenEditor(project, editorPredicate);
         if (openEditor != null) {
             FileEditorManagerEx.getInstanceEx(project).openFile(openEditor.file, true, true);
-            return true;
+            return openEditor;
         }
 
-        return false;
+        return null;
     }
 
     public @Nullable WebviewEditor<?> findOpenEditor(@NotNull Project project,

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditorProvider.java
@@ -40,7 +40,7 @@ public class FindingDetailsEditorProvider extends WebviewEditorProvider {
         assert provider != null;
 
         // we only want to reuse for the same list of findings
-        if (provider.focusOpenEditor(project, webviewEditor -> isEditorWithFindings(webviewEditor, findings))) {
+        if (provider.focusOpenEditor(project, webviewEditor -> isEditorWithFindings(webviewEditor, findings)) != null) {
             return;
         }
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/752

When the install guide instructions are clicked, an already opened editor is now always selected and focused.