### PR TITLE
Fix unstable findings tests

### DIFF
--- a/plugin-core/src/main/java/appland/problemsView/listener/PendingScannerFindingsChangesService.java
+++ b/plugin-core/src/main/java/appland/problemsView/listener/PendingScannerFindingsChangesService.java
@@ -1,0 +1,173 @@
+package appland.problemsView.listener;
+
+import appland.index.AppMapFindingsUtil;
+import appland.problemsView.FindingsManager;
+import com.google.common.collect.Sets;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.Alarm;
+import com.intellij.util.SingleAlarm;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.SystemIndependent;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Service to handle the queue of collected finding file changes.
+ * Changes to findings must be debounced and only be applied when no other file changes are in progress.
+ */
+@Service(Service.Level.PROJECT)
+public final class PendingScannerFindingsChangesService implements Disposable {
+    public static @NotNull PendingScannerFindingsChangesService getInstance(@NotNull Project project) {
+        return project.getService(PendingScannerFindingsChangesService.class);
+    }
+
+    private final Project project;
+    private final SingleAlarm alarm = new SingleAlarm(this::processChanges, 5_000, Alarm.ThreadToUse.POOLED_THREAD, this);
+
+    private final Object lock = new Object();
+    private @NotNull PendingFindings pending = new PendingFindings();
+
+    public PendingScannerFindingsChangesService(@NotNull Project project) {
+        this.project = project;
+    }
+
+    /**
+     * Queues changes to findings files to be processed.
+     *
+     * @param directories Directories containing AppMap findings which changed. A directory causes a complete reload.
+     * @param toAdd       Added findings files
+     * @param toRefresh   Refreshed findings files
+     * @param toRemove    Removed findings files
+     */
+    public void queueChanges(@NotNull Set<@SystemIndependent String> directories,
+                             @NotNull Set<@SystemIndependent String> toAdd,
+                             @NotNull Set<@SystemIndependent String> toRefresh,
+                             @NotNull Set<@SystemIndependent String> toRemove) {
+        synchronized (lock) {
+            pending.directories(directories);
+            pending.add(toAdd);
+            pending.refresh(toRefresh);
+            pending.remove(toRemove);
+
+            alarm.cancelAndRequest();
+        }
+    }
+
+    private void processChanges() {
+        // Only process when indexes are available because FindingsManager uses them.
+        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
+            // Bet pending changes and replace with new changeset, anything added to the new changeset while this method
+            // is being executed will be processed wih the next alarm.
+            PendingFindings toProcess;
+            synchronized (lock) {
+                toProcess = this.pending;
+                this.pending = new PendingFindings();
+            }
+
+            if (!toProcess.isEmpty()) {
+                processChanges(toProcess);
+            }
+        });
+    }
+
+    private void processChanges(@NotNull PendingFindings pending) {
+        var fs = LocalFileSystem.getInstance();
+        var manager = FindingsManager.getInstance(project);
+
+        // If there's at least one modified directory with finding files,
+        // then we do a complete reload instead of attempting to find the best diff.
+        for (var path : pending.directories) {
+            var directory = fs.findFileByPath(path);
+            // either a deleted directory, which may have contained AppMaps
+            // or a new/modified directory, which contains AppMaps
+            if (directory == null || isDirectoryWithFindingFiles(directory)) {
+                manager.reloadAsync();
+                return;
+            }
+        }
+
+        for (var filePath : pending.toRemove) {
+            if (filePath != null) {
+                manager.removeFindingsFile(filePath);
+            }
+        }
+
+        for (var filePath : pending.toAdd) {
+            var file = fs.findFileByPath(filePath);
+            if (file != null) {
+                manager.addFindingsFile(file);
+            }
+        }
+
+        for (var filePath : pending.toRefresh) {
+            var file = fs.findFileByPath(filePath);
+            if (file != null) {
+                manager.reloadFindingsFile(file);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    @RequiresReadLock
+    private boolean isDirectoryWithFindingFiles(@NotNull VirtualFile directory) {
+        var hasFindings = new AtomicBoolean(false);
+        VfsUtilCore.iterateChildrenRecursively(directory,
+                fileOrDir -> fileOrDir.isDirectory() || AppMapFindingsUtil.isFindingFile(fileOrDir),
+                fileOrDir -> {
+                    if (fileOrDir.isDirectory()) {
+                        return true;
+                    }
+                    var isFindingsFile = AppMapFindingsUtil.isFindingFile(fileOrDir);
+                    hasFindings.set(isFindingsFile);
+                    return !isFindingsFile;
+                }
+        );
+        return hasFindings.get();
+    }
+
+    /**
+     * Class to wrap all pending changes in a single object.
+     * This is used to avoid that changes are updated while a set of pending changes is being processed.
+     */
+    @EqualsAndHashCode
+    private static class PendingFindings {
+        final Set<@SystemIndependent String> directories = Sets.newConcurrentHashSet();
+        final Set<@SystemIndependent String> toAdd = Sets.newConcurrentHashSet();
+        final Set<@SystemIndependent String> toRefresh = Sets.newConcurrentHashSet();
+        final Set<@SystemIndependent String> toRemove = Sets.newConcurrentHashSet();
+
+        boolean isEmpty() {
+            return directories.isEmpty() && toAdd.isEmpty() && toRefresh.isEmpty() && toRemove.isEmpty();
+        }
+
+        void directories(Collection<@SystemIndependent String> paths) {
+            directories.addAll(paths);
+        }
+
+        void add(Collection<@SystemIndependent String> paths) {
+            toAdd.addAll(paths);
+        }
+
+        void refresh(Collection<@SystemIndependent String> paths) {
+            toRefresh.addAll(paths);
+        }
+
+        void remove(Collection<@SystemIndependent String> paths) {
+            toRemove.addAll(paths);
+        }
+    }
+
+}

--- a/plugin-core/src/main/java/appland/problemsView/listener/ScannerFilesAsyncListener.java
+++ b/plugin-core/src/main/java/appland/problemsView/listener/ScannerFilesAsyncListener.java
@@ -1,30 +1,17 @@
 package appland.problemsView.listener;
 
 import appland.index.AppMapFindingsUtil;
-import appland.problemsView.FindingsManager;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressManager;
-import com.intellij.openapi.project.DumbService;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.AsyncFileListener;
 import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VfsUtilCore;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.events.*;
-import com.intellij.util.concurrency.AppExecutorUtil;
-import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.SystemIndependent;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 /**
  * Async file listener to update the problems view of the open projects when appmap-findings.json files
@@ -32,31 +19,12 @@ import java.util.function.Supplier;
  */
 @SuppressWarnings("UnstableApiUsage")
 public class ScannerFilesAsyncListener implements AsyncFileListener {
-    @TestOnly
-    private static volatile boolean TEST_ENABLED = true;
-
-    @TestOnly
-    public static <T> T disableForTests(@NotNull ThrowableComputable<T, Exception> runnable) throws Exception {
-        TEST_ENABLED = false;
-        try {
-            return runnable.compute();
-        } finally {
-            TEST_ENABLED = true;
-        }
-    }
-
-    private static final @NotNull ExecutorService executor = AppExecutorUtil.createBoundedApplicationPoolExecutor("AppMap file changes", 2);
-
     @Override
     public @Nullable ChangeApplier prepareChange(@NotNull List<? extends @NotNull VFileEvent> events) {
-        if (!TEST_ENABLED && ApplicationManager.getApplication().isUnitTestMode()) {
-            return null;
-        }
-
-        var toAdd = new HashSet<Supplier<VirtualFile>>();
-        var toRefresh = new HashSet<VirtualFile>();
-        var toRemove = new HashSet<String>();
-        var directories = new HashSet<String>();
+        var toAdd = new HashSet<@SystemIndependent String>();
+        var toRefresh = new HashSet<@SystemIndependent String>();
+        var toRemove = new HashSet<@SystemIndependent String>();
+        var directories = new HashSet<@SystemIndependent String>();
 
         for (var event : events) {
             ProgressManager.checkCanceled();
@@ -79,20 +47,20 @@ public class ScannerFilesAsyncListener implements AsyncFileListener {
 
                 var newPath = ((VFileMoveEvent) event).getNewPath();
                 if (AppMapFindingsUtil.isFindingFile(newPath)) {
-                    toAdd.add(event::getFile);
+                    toAdd.add(newPath);
                 }
             } else if (event instanceof VFileCopyEvent) {
                 var newFile = ((VFileCopyEvent) event).findCreatedFile();
                 if (newFile != null) {
-                    toAdd.add(() -> newFile);
+                    toAdd.add(event.getPath());
                 }
             } else if (event instanceof VFileCreateEvent) {
                 if (AppMapFindingsUtil.isFindingFile(event.getPath())) {
-                    toAdd.add(event::getFile);
+                    toAdd.add(event.getPath());
                 }
             } else if (event instanceof VFileContentChangeEvent) {
                 if (AppMapFindingsUtil.isFindingFile(event.getPath())) {
-                    toRefresh.add(event.getFile());
+                    toRefresh.add(event.getPath());
                 }
             } else if (event instanceof VFilePropertyChangeEvent) {
                 // file was renamed, still under the same parent directory
@@ -105,7 +73,7 @@ public class ScannerFilesAsyncListener implements AsyncFileListener {
                     }
 
                     if (AppMapFindingsUtil.isFindingFile(newPath)) {
-                        toAdd.add(event::getFile);
+                        toAdd.add(newPath);
                     }
                 }
             }
@@ -119,85 +87,19 @@ public class ScannerFilesAsyncListener implements AsyncFileListener {
             @Override
             public void afterVfsChange() {
                 for (var project : ProjectManager.getInstance().getOpenProjects()) {
-                    if (project.isDefault() || project.isDisposed()) {
-                        continue;
+                    if (!project.isDefault() && !project.isDisposed()) {
+                        PendingScannerFindingsChangesService
+                                .getInstance(project)
+                                .queueChanges(directories, toAdd, toRefresh, toRemove);
                     }
-
-                    executor.submit(() -> {
-                        // we need to run in smart mode because the findings manager uses the index to find relative files
-                        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
-                            processChangesAsync(project, toAdd, toRemove, toRefresh, directories);
-                        });
-                    });
                 }
             }
         };
     }
 
-    @RequiresReadLock
-    private void processChangesAsync(@NotNull Project project,
-                                     Set<Supplier<VirtualFile>> toAdd,
-                                     Set<String> toRemove,
-                                     Set<VirtualFile> toRefresh,
-                                     Set<String> directories) {
-        if (project.isDisposed()) {
-            return;
-        }
-
-        var manager = FindingsManager.getInstance(project);
-
-        // if there's at least one modified directory with finding files, then we do a complete reload
-        // instead of attempting to find the best diff
-        for (var path : directories) {
-            var directory = LocalFileSystem.getInstance().findFileByPath(path);
-            // either a deleted directory, which may have contained AppMaps
-            // or a new/modified directory, which contains AppMaps
-            if (directory == null || isDirectoryWithFindingFiles(directory)) {
-                manager.reloadAsync();
-                return;
-            }
-        }
-
-        for (var deletedFile : toRemove) {
-            if (deletedFile != null) {
-                manager.removeFindingsFile(deletedFile);
-            }
-        }
-
-        for (var supplier : toAdd) {
-            var file = supplier.get();
-            if (file != null) {
-                manager.addFindingsFile(file);
-            }
-        }
-
-        for (var file : toRefresh) {
-            if (file != null) {
-                manager.reloadFindingsFile(file);
-            }
-        }
-    }
-
-    @RequiresReadLock
-    private boolean isDirectoryWithFindingFiles(@NotNull VirtualFile directory) {
-        var hasFindings = new AtomicBoolean(false);
-        VfsUtilCore.iterateChildrenRecursively(directory,
-                fileOrDir -> fileOrDir.isDirectory() || AppMapFindingsUtil.isFindingFile(fileOrDir),
-                fileOrDir -> {
-                    if (fileOrDir.isDirectory()) {
-                        return true;
-                    }
-                    var isFindingsFile = AppMapFindingsUtil.isFindingFile(fileOrDir);
-                    hasFindings.set(isFindingsFile);
-                    return !isFindingsFile;
-                }
-        );
-        return hasFindings.get();
-    }
-
     private boolean isDirectoryEvent(VFileEvent event) {
-        return event instanceof VFileDeleteEvent && event.getFile() != null && event.getFile().isDirectory()
+        return event instanceof VFileDeleteEvent && event.getFile().isDirectory()
                 || event instanceof VFileCreateEvent && ((VFileCreateEvent) event).isDirectory()
-                || event instanceof VFileMoveEvent && event.getFile() != null && event.getFile().isDirectory();
+                || event instanceof VFileMoveEvent && event.getFile().isDirectory();
     }
 }

--- a/plugin-core/src/main/java/appland/startup/AppLandStartupActivity.java
+++ b/plugin-core/src/main/java/appland/startup/AppLandStartupActivity.java
@@ -1,6 +1,7 @@
 package appland.startup;
 
 import appland.problemsView.FindingsManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import org.jetbrains.annotations.NotNull;
@@ -8,6 +9,12 @@ import org.jetbrains.annotations.NotNull;
 public class AppLandStartupActivity implements StartupActivity {
     @Override
     public void runActivity(@NotNull Project project) {
+        // Don't reload in unit tests because the reload is async.
+        // AppMapBaseTest reset all findings before each test, anyway.
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            return;
+        }
+
         // load initial findings of the project
         FindingsManager.getInstance(project).reloadAsync();
     }

--- a/plugin-core/src/test/java/appland/AppMapLocalTempFilesTest.java
+++ b/plugin-core/src/test/java/appland/AppMapLocalTempFilesTest.java
@@ -1,0 +1,51 @@
+package appland;
+
+import appland.utils.IndexTestUtils;
+import com.intellij.openapi.roots.ContentEntry;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Test base class to execute tests which need files on the local disk and not in the in-memory TempFileSystem,
+ * which is used by default.
+ */
+public abstract class AppMapLocalTempFilesTest extends AppMapBaseTest {
+    private AtomicReference<ContentEntry> tempDirContentEntry;
+
+    @Override
+    protected final TempDirTestFixture createTempDirTestFixture() {
+        // create temp files on disk
+        return new TempDirTestFixtureImpl();
+    }
+
+    @Before
+    public void setupTempPathContentRoot() {
+        var tempDir = LocalFileSystem.getInstance().findFileByPath(myFixture.getTempDirPath());
+        assertNotNull("Temp directory must exist on disk", tempDir);
+
+        // hack to use ModuleRootModificationUtil and to keep a reference to the new entry
+        assertNull(tempDirContentEntry);
+        tempDirContentEntry = new AtomicReference<>();
+        ModuleRootModificationUtil.updateModel(getModule(), modifiableRootModel -> {
+            tempDirContentEntry.set(modifiableRootModel.addContentEntry(tempDir));
+        });
+
+        IndexTestUtils.waitUntilIndexesAreReady(getProject());
+    }
+
+    @After
+    public void removeTempPathContentRoot() {
+        var contentRoot = tempDirContentEntry.getAndSet(null);
+        assertNotNull("Content root of temp dir file must be available", contentRoot);
+
+        ModuleRootModificationUtil.updateModel(getModule(), modifiableRootModel -> {
+            modifiableRootModel.removeContentEntry(contentRoot);
+        });
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -2,7 +2,6 @@ package appland.cli;
 
 import appland.AppMapBaseTest;
 import appland.files.AppMapFiles;
-import appland.settings.AppMapApplicationSettings;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
 import appland.testRules.ResetIdeHttpProxyRule;

--- a/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerContentRootTest.java
@@ -1,10 +1,8 @@
 package appland.problemsView.listener;
 
-import appland.AppMapBaseTest;
+import appland.AppMapLocalTempFilesTest;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.TestFindingsManager;
-import com.intellij.testFramework.fixtures.TempDirTestFixture;
-import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -12,29 +10,19 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test of the async listener, which adds the folder with findings as content root to make sure it's found.
  */
-public class ScannerFilesAsyncListenerContentRootTest extends AppMapBaseTest {
+public class ScannerFilesAsyncListenerContentRootTest extends AppMapLocalTempFilesTest {
     @Override
     protected boolean runInDispatchThread() {
         return false;
     }
 
-    @Override
-    protected TempDirTestFixture createTempDirTestFixture() {
-        // creates files on the local filesystem to enable the file watcher
-        return new TempDirTestFixtureImpl();
-    }
-
     @Test
     public void findingsFileWatcher() throws Exception {
-        // create src/root to add it as content root to the current module
-        // the file listener is using a project scope, which needs a properly set up content root
-        var rootDir = myFixture.getTempDirFixture().findOrCreateDir("root");
-        withContentRoot(rootDir, () -> {
-            var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
-            // adding an appmap-findings.json file must trigger a refresh via the file watcher
-            myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");
-            assertTrue("Findings must be reloaded when a appmap-findings.json is added", condition.await(60, TimeUnit.SECONDS));
-        });
+        var condition = TestFindingsManager.createFindingsCondition(getProject(), getTestRootDisposable());
+
+        // adding an appmap-findings.json file must trigger a refresh via the file watcher
+        myFixture.copyDirectoryToProject("vscode/workspaces/project-system", "root");
+        assertTrue("Findings must be reloaded when a appmap-findings.json is added", condition.await(60, TimeUnit.SECONDS));
 
         assertEquals(1, FindingsManager.getInstance(getProject()).getProblemFileCount());
         assertEquals(1, FindingsManager.getInstance(getProject()).getProblemCount());

--- a/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerTest.java
+++ b/plugin-core/src/test/java/appland/problemsView/listener/ScannerFilesAsyncListenerTest.java
@@ -1,6 +1,6 @@
 package appland.problemsView.listener;
 
-import appland.AppMapBaseTest;
+import appland.AppMapLocalTempFilesTest;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import static appland.problemsView.TestFindingsManager.createFindingsCondition;
 
-public class ScannerFilesAsyncListenerTest extends AppMapBaseTest {
+public class ScannerFilesAsyncListenerTest extends AppMapLocalTempFilesTest {
     @Override
     protected boolean runInDispatchThread() {
         return false;

--- a/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
+++ b/plugin-core/src/test/java/appland/toolwindow/runtimeAnalysis/RuntimeAnalysisModelTest.java
@@ -1,6 +1,6 @@
 package appland.toolwindow.runtimeAnalysis;
 
-import appland.AppMapBaseTest;
+import appland.AppMapLocalTempFilesTest;
 import appland.problemsView.FindingsManager;
 import appland.problemsView.TestFindingsManager;
 import appland.settings.AppMapApplicationSettingsService;
@@ -15,12 +15,18 @@ import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static appland.utils.ModelTestUtil.assertTreeHierarchy;
 
-public class RuntimeAnalysisModelTest extends AppMapBaseTest {
+public class RuntimeAnalysisModelTest extends AppMapLocalTempFilesTest {
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
     @Test
     public void unauthenticated() {
         AppMapApplicationSettingsService.getInstance().setApiKey(null);
@@ -81,11 +87,11 @@ public class RuntimeAnalysisModelTest extends AppMapBaseTest {
     public void hierarchy() throws Exception {
         loadFindingsDirectory("projects/runtime_analysis_tree");
 
+        var tempDirName = Path.of(myFixture.getTempDirPath()).getFileName();
         var model = new RuntimeAnalysisModel(getProject(), getTestRootDisposable());
-
         var expected = "-Root\n" +
                 " Findings Table\n" +
-                " -src\n" +
+                " -" + tempDirName + "\n" +
                 "  -Failed tests\n" +
                 "   Failed test 1\n" +
                 "   Failed test 2\n" +


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/770

Tests of the plugin are passing, but the AppMap task is still failing for unknown reasons.

Especially with 2024.2 and GitHub Actions, the tests of the finding manager were unstable.
This was caused by too many async change requests of findings launched in the background.
The tests only wait for one of these changes and then continue to work with findings data. At this point, other queued async changes to findings could still be processed and change the findings data in unexpected ways.

This PR 
- batches changes to findings and debounces the processing. Findings are processed 5s after the last change to findings was recorded.
- avoids spawning a cancellable ReadAction to all findings from an existing ReadAction.
- When processing findings, each project has its own set of pending changes now to avoid mixing data of different project.
- Executes findings tests with temp files located on the local filesystem and non in memory. FindingsManager only works with files on the local filesystem. Finding files must also be located in a content root of the project to be processed.
- Adds a new base class for tests to simplify the setup with local temp files: `AppMapLocalTempFilesTest`

https://github.com/getappmap/appmap-intellij-plugin/pull/771/commits/0bc206908f9945989200ab88afdb20cab2a9970b hopefully fixes another unstable test which prevented CI of this PR to run successfully.