### PR TITLE
Avoid exception about slow operation when loading OpenAI key

### DIFF
--- a/plugin-core/src/main/java/appland/settings/AppMapSecureApplicationSettingsService.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSecureApplicationSettingsService.java
@@ -1,10 +1,14 @@
 package appland.settings;
 
+import appland.AppMapBundle;
 import com.intellij.credentialStore.CredentialAttributes;
 import com.intellij.credentialStore.CredentialAttributesKt;
 import com.intellij.ide.passwordSafe.PasswordSafe;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,9 +20,40 @@ public final class AppMapSecureApplicationSettingsService implements AppMapSecur
         return ApplicationManager.getApplication().getService(AppMapSecureApplicationSettingsService.class);
     }
 
+    private volatile boolean isCached = false;
+    private volatile @Nullable String cachedOpenAIKey;
+
+    /**
+     * @return The stored value of the OpenAI key. Because this method is called often
+     * and is a slow operation in 2024.2+, we're caching the value to avoid too many slow calls.
+     */
     @Override
     public @Nullable String getOpenAIKey() {
-        return PasswordSafe.getInstance().getPassword(createOpenAIKey());
+        if (!isCached) {
+            // load the key in a background task to avoid the warning about the slow operation
+            var title = AppMapBundle.get("applicationSettings.openAI.loadingKey");
+            var task = new Task.WithResult<String, Exception>(null, title, false) {
+                @Override
+                protected String compute(@NotNull ProgressIndicator indicator) {
+                    return PasswordSafe.getInstance().getPassword(createOpenAIKey());
+                }
+            };
+
+            // getPassword is a slow operation in 2024.2+
+            task.queue();
+
+            try {
+                cachedOpenAIKey = task.getResult();
+                // we're only caching successfully retrieved key values
+                isCached = true;
+            } catch (Exception e) {
+                isCached = false;
+                Logger.getInstance(this.getClass()).warn("Failed to fetch OpenAI key", e);
+                return null;
+            }
+        }
+
+        return cachedOpenAIKey;
     }
 
     @Override
@@ -26,6 +61,9 @@ public final class AppMapSecureApplicationSettingsService implements AppMapSecur
         var oldValue = getOpenAIKey();
         try {
             PasswordSafe.getInstance().setPassword(createOpenAIKey(), key);
+
+            cachedOpenAIKey = key;
+            isCached = true;
         } finally {
             if (!Objects.equals(oldValue, key)) {
                 ApplicationManager.getApplication().getMessageBus()

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -165,6 +165,8 @@ upload.progress.title=Uploading AppMap...
 upload.docUnavailable.title=Upload Failed
 upload.docUnavailable.message=Unable to retrieve the text of the AppMap to upload.
 
+applicationSettings.openAI.loadingKey=Loading OpenAI key...
+
 projectSettings.displayName=AppMap
 projectSettings.serverName=URL of AppMap Cloud for AppMaps uploading:
 projectSettings.confirmUpload=Confirm upload of AppMaps

--- a/plugin-core/src/test/java/appland/settings/AppMapSecureApplicationSettingsServiceTest.java
+++ b/plugin-core/src/test/java/appland/settings/AppMapSecureApplicationSettingsServiceTest.java
@@ -1,0 +1,19 @@
+package appland.settings;
+
+import appland.AppMapBaseTest;
+import org.junit.Test;
+
+public class AppMapSecureApplicationSettingsServiceTest extends AppMapBaseTest {
+    @Test
+    public void openAiKey() {
+        var settings = AppMapSecureApplicationSettingsService.getInstance();
+
+        // if executed on the EDT, it must not throw an exception about slow operations
+        var oldValue = settings.getOpenAIKey();
+        try {
+            settings.setOpenAIKey("my-new-key");
+        } finally {
+            settings.setOpenAIKey(oldValue);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/773

In 2024.2+ the method to load a key from secure password storage is a slow operation and causes an exception.
This PR applies the changes to load the key in a background task to avoid the exception.
The key is cached in memory after it's been retrieved from secure storage to avoid the expensive call at runtime.