### PR TITLE
Don't show AppMap problems view and the Runtime Analysis if scanner is off

### DIFF
--- a/plugin-core/src/main/java/appland/problemsView/FindingsPanelProvider.java
+++ b/plugin-core/src/main/java/appland/problemsView/FindingsPanelProvider.java
@@ -1,5 +1,6 @@
 package appland.problemsView;
 
+import appland.settings.AppMapApplicationSettingsService;
 import com.intellij.analysis.problemsView.toolWindow.ProblemsViewPanelProvider;
 import com.intellij.analysis.problemsView.toolWindow.ProblemsViewState;
 import com.intellij.analysis.problemsView.toolWindow.ProblemsViewTab;
@@ -20,6 +21,8 @@ public class FindingsPanelProvider implements ProblemsViewPanelProvider {
     @Nullable
     @Override
     public ProblemsViewTab create() {
-        return new FindingsViewTab(project, ProblemsViewState.getInstance(project));
+        return AppMapApplicationSettingsService.getInstance().isEnableScanner()
+                ? new FindingsViewTab(project, ProblemsViewState.getInstance(project))
+                : null;
     }
 }

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -103,6 +103,15 @@ public class AppMapApplicationSettings {
         }
     }
 
+    public void setEnableScannerNotifying(boolean enableScanner) {
+        var changed = this.enableScanner != enableScanner;
+        this.enableScanner = enableScanner;
+
+        if (changed) {
+            settingsPublisher().scannedEnabledChanged();
+        }
+    }
+
     public boolean isAuthenticated() {
         return apiKey != null;
     }

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -30,6 +30,9 @@ public interface AppMapSettingsListener {
     default void openAIKeyChange() {
     }
 
+    default void scannedEnabledChanged() {
+    }
+
     default void cliEnvironmentChanged(@NotNull Set<String> modifiedKeys) {
     }
 }

--- a/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
+++ b/plugin-core/src/main/java/appland/toolwindow/appmap/AppMapWindowPanel.java
@@ -8,6 +8,7 @@ import appland.actions.StopAppMapRecordingAction;
 import appland.index.IndexedFileListenerUtil;
 import appland.installGuide.InstallGuideEditorProvider;
 import appland.installGuide.InstallGuideViewPage;
+import appland.settings.AppMapApplicationSettingsService;
 import appland.toolwindow.AppMapContentPanel;
 import appland.toolwindow.AppMapToolWindowContent;
 import appland.toolwindow.CollapsiblePanel;
@@ -437,7 +438,9 @@ public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProv
 
     private static @NotNull JComponent createSouthPanel(@NotNull Project project, @NotNull Disposable parent) {
         var contentPanel = new VerticalBox();
-        contentPanel.add(createRuntimeAnalysisPanel(project, parent));
+        if (AppMapApplicationSettingsService.getInstance().isEnableScanner()) {
+            contentPanel.add(createRuntimeAnalysisPanel(project, parent));
+        }
         contentPanel.add(createCodeObjectsPanel(project, parent));
         contentPanel.add(createDocumentationLinksPanel(project));
         return contentPanel;

--- a/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
+++ b/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
@@ -35,7 +35,11 @@ class AppMapProjectSettingsPanel {
         notify: Boolean,
     ) {
         applicationSettings.isEnableTelemetry = enableTelemetry.isSelected
-        applicationSettings.isEnableScanner = enableScanner.isSelected
+        if (notify) {
+            applicationSettings.setEnableScannerNotifying(enableScanner.isSelected)
+        } else {
+            applicationSettings.isEnableScanner = enableScanner.isSelected
+        }
         applicationSettings.isCliPassParentEnv = cliEnvironment.isPassParentEnvs
         if (notify) {
             applicationSettings.setCliEnvironmentNotifying(cliEnvironment.envs)

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -10,7 +10,7 @@
                   class="appland.cli.RestartServicesAfterApiChangeListener"
                   activeInTestMode="false"/>
         <listener topic="appland.settings.AppMapSettingsListener"
-                  class="appland.settings.AppMapNavieSettingsReloadProjectListener"
+                  class="appland.settings.AppMapSettingsReloadProjectListener"
                   activeInTestMode="false"/>
         <listener topic="appland.config.AppMapConfigFileListener"
                   class="appland.cli.AppMapCommandLineConfigListener"


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/751

This hidese the problems view panel and the Runtime Analysis panel in the AppMap toolwindow if the scanner is turned off.
When the setting is changed, a notification about a required project reload is shown.