### PR TITLE
Make the AppMap viewer the default view for .appmap.json files

### DIFF
--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -40,14 +40,14 @@
         <postStartupActivity implementation="appland.rpcService.AppMapJsonRpcServerStartupActivity"/>
         <postStartupActivity implementation="appland.cli.AppLandProjectOpenActivity"/>
 
-        <fileEditorProvider implementation="appland.webviews.appMap.AppMapFileEditorProvider"/>
+        <fileEditorProvider implementation="appland.webviews.appMap.AppMapFileEditorProvider" order="first"/>
         <editorNotificationProvider implementation="appland.webviews.appMap.AppMapNotificationProvider"/>
 
-        <fileEditorProvider implementation="appland.installGuide.InstallGuideEditorProvider"/>
+        <fileEditorProvider implementation="appland.installGuide.InstallGuideEditorProvider" order="first"/>
 
-        <fileEditorProvider implementation="appland.webviews.findings.FindingsOverviewEditorProvider"/>
-        <fileEditorProvider implementation="appland.webviews.findingDetails.FindingDetailsEditorProvider"/>
-        <fileEditorProvider implementation="appland.webviews.navie.NavieEditorProvider"/>
+        <fileEditorProvider implementation="appland.webviews.findings.FindingsOverviewEditorProvider" order="first"/>
+        <fileEditorProvider implementation="appland.webviews.findingDetails.FindingDetailsEditorProvider" order="first"/>
+        <fileEditorProvider implementation="appland.webviews.navie.NavieEditorProvider" order="first"/>
 
         <fileIconProvider implementation="appland.webviews.WebviewEditorIconProvider"/>
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/781

The AppMap should provide the default view for its own JSON files (.appmap.json).
In this case, the DataGraph plugin was overriding the default view.


![image](https://github.com/user-attachments/assets/2b397540-ea76-478d-83ce-5f97696830b4)

