### PR TITLE
Fix incorrect AppMap upload of CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
 
             - name: Save AppMaps
               uses: actions/cache/save@v4
-              if: runner.os == 'Linux' && matrix.ide_version == 'IC-2023.1'
+              if: runner.os == 'Linux' && matrix.ide_version == '2023.1'
               with:
                   path: ./tmp/appmap
                   key: appmaps-${{ github.sha }}-${{ github.run_attempt }}


### PR DESCRIPTION
This PR fixes the broken CI.
Due to a regression, the AppMaps were not uploaded on CI which caused the AppMap analysis action to fail.