### PR TITLE
chore: run plugin verification with latest eap of 2024.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=231.0
 untilBuild=243.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-243.16718.32
+ideVersionVerifier=IC-2023.1,IC-243.21155.17
 
 lombokVersion=1.18.32
 
@@ -14,7 +14,7 @@ ideVersion=2023.1
 #ideVersion=2023.3.2
 #ideVersion=2024.1
 #ideVersion=2024.2
-#ideVersion=243.16718.32
+#ideVersion=243.21155.17
 
 kotlin.stdlib.default.dependency=false
 


### PR DESCRIPTION
This updates the verification during the build to use the latest eap of 2024.3