### PR TITLE
Mark AppMap as incompatible with Rider

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ ideVersion=2023.1
 #ideVersion=2024.2
 #ideVersion=2024.3.1
 
-#copilotPluginVersion=1.5.30-231
-copilotPluginVersion=1.5.30-242
+copilotPluginVersion=1.5.30-231
+#copilotPluginVersion=1.5.30-242
 
 kotlin.stdlib.default.dependency=false
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,9 @@
     <!--suppress CheckTagEmptyBody, PluginXmlValidity -->
     <description></description>
 
+    <!-- The AppMap plugin is currently not compatible with Rider -->
+    <incompatible-with>com.intellij.modules.rider</incompatible-with>
+
     <xi:include href="/META-INF/appmap-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/appmap-copilot.xml" xpointer="xpointer(/idea-plugin/*)"/>
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/834

I'm not sure if the Marketplace is properly evaluating the compatibility. We'll have to check the detected compatibility after a new release with this change has been uploaded.

How it's shown in Rider after manual installation:
![image](https://github.com/user-attachments/assets/8d8b49a8-47b1-418d-bf85-2545e010f127)
