### PR TITLE
Support to choose the copilot model for Navie

### DIFF
--- a/plugin-copilot/src/main/java/appland/copilotChat/ChooseCopilotModelAction.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/ChooseCopilotModelAction.java
@@ -1,0 +1,157 @@
+package appland.copilotChat;
+
+import appland.AppMapBundle;
+import appland.copilotChat.copilot.CopilotModelDefinition;
+import appland.copilotChat.copilot.GitHubCopilotService;
+import appland.settings.AppMapApplicationSettingsService;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.ui.ColoredListCellRenderer;
+import com.intellij.ui.SimpleTextAttributes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ChooseCopilotModelAction extends AnAction implements DumbAware {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        var isEnabled = e.getProject() != null
+                && !CopilotAppMapEnvProvider.isDisabled()
+                && GitHubCopilotService.getInstance().isCopilotAuthenticated();
+        e.getPresentation().setEnabled(isEnabled);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        var project = e.getProject();
+        if (project == null) {
+            return;
+        }
+
+        try {
+            var task = new Task.WithResult<List<CopilotModelDefinition>, IOException>(project, AppMapBundle.get("action.copilot.chooseModel.loadingModels"), true) {
+                @Override
+                protected List<CopilotModelDefinition> compute(@NotNull ProgressIndicator progressIndicator) throws IOException {
+                    var chatSession = GitHubCopilotService.getInstance().createChatSession();
+                    return chatSession != null ? chatSession.loadChatModels() : null;
+                }
+            };
+
+            var models = ProgressManager.getInstance().run(task);
+            var filteredModels = withoutDuplicateModels(models);
+            if (filteredModels == null || filteredModels.isEmpty()) {
+                Messages.showErrorDialog(
+                        project,
+                        AppMapBundle.get("action.copilot.chooseModel.noModels.text"),
+                        AppMapBundle.get("action.copilot.chooseModel.noModels.title")
+                );
+                return;
+            }
+
+            // null value at the beginning to allow resetting the selected Copilot model
+            filteredModels.add(0, null);
+
+            var currentModel = findCurrentModel(filteredModels);
+            var popup = JBPopupFactory.getInstance()
+                    .createPopupChooserBuilder(filteredModels)
+                    .setTitle(AppMapBundle.get("action.copilot.chooseModel.popup.title"))
+                    .setAdText(AppMapBundle.get("action.copilot.chooseModel.popup.adText"))
+                    .setRenderer(new CopilotModelRenderer(currentModel))
+                    .setSelectedValue(currentModel, true)
+                    .setItemsChosenCallback(selectedModels -> {
+                        assert (selectedModels.size() == 1);
+                        var selectedModel = selectedModels.iterator().next();
+                        var selectedId = selectedModel == null ? null : selectedModel.id();
+                        AppMapApplicationSettingsService.getInstance().setCopilotModelId(selectedId);
+                    });
+            popup.createPopup().showCenteredInCurrentWindow(project);
+        } catch (IOException ex) {
+            Messages.showErrorDialog(
+                    project,
+                    AppMapBundle.get("action.copilot.chooseModel.errorLoadingModels.text"),
+                    AppMapBundle.get("action.copilot.chooseModel.errorLoadingModels.title")
+            );
+        }
+    }
+
+    /**
+     * Remove duplicates, there are models with the same name and version, but with different IDs.
+     * We're keeping the model with the shortest ID, e.g. gpt-4o instead gpt-4o-preview.
+     * <p>
+     * This method returns a mutable list if at least one model is available.
+     */
+    private static @NotNull List<CopilotModelDefinition> withoutDuplicateModels(@Nullable List<CopilotModelDefinition> models) {
+        if (models == null || models.isEmpty()) {
+            return List.of();
+        }
+
+        var comparator = Comparator.comparing((CopilotModelDefinition model) -> model.name() + model.version())
+                .thenComparing(CopilotModelDefinition::id);
+        final String[] lastClassifier = {null};
+        return models.stream()
+                .sorted(comparator)
+                .filter(model -> {
+                    var classifier = model.name() + model.version();
+                    try {
+                        return lastClassifier[0] == null || !lastClassifier[0].equals(classifier);
+                    } finally {
+                        lastClassifier[0] = classifier;
+                    }
+                })
+                .sorted(Comparator.comparing(CopilotModelDefinition::name))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private static @Nullable CopilotModelDefinition findCurrentModel(Collection<CopilotModelDefinition> models) {
+        // highlight the currently selected model in the list
+        // awkward code, because "Stream.findFirst()" doesn't like null values inside the Optional.
+        var currentModelId = AppMapApplicationSettingsService.getInstance().getCopilotModelId();
+        var filteredModels = models.stream()
+                .filter(model -> Objects.equals(currentModelId, model == null ? null : model.id()))
+                .toList();
+        return filteredModels.size() == 1 ? filteredModels.get(0) : null;
+    }
+
+    private static class CopilotModelRenderer extends ColoredListCellRenderer<CopilotModelDefinition> {
+        private final @Nullable CopilotModelDefinition currentModel;
+
+        public CopilotModelRenderer(@Nullable CopilotModelDefinition currentModelId) {
+            this.currentModel = currentModelId;
+        }
+
+        @Override
+        protected void customizeCellRenderer(@NotNull JList<? extends CopilotModelDefinition> list,
+                                             CopilotModelDefinition value,
+                                             int index,
+                                             boolean selected,
+                                             boolean hasFocus) {
+            var defaultAttributes = Objects.equals(value, currentModel)
+                    ? SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES
+                    : SimpleTextAttributes.REGULAR_ATTRIBUTES;
+
+            if (value == null) {
+                append(AppMapBundle.get("action.copilot.chooseModel.popup.defaultModel"), defaultAttributes);
+                return;
+            }
+
+            append(value.name(), defaultAttributes);
+            append(" (" + value.version() + ")", SimpleTextAttributes.GRAY_ATTRIBUTES);
+        }
+    }
+}

--- a/plugin-copilot/src/main/java/appland/copilotChat/CopilotAppMapEnvProvider.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/CopilotAppMapEnvProvider.java
@@ -6,7 +6,9 @@ import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSecureApplicationSettingsService;
 import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.util.text.StringUtil;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -25,11 +27,16 @@ public class CopilotAppMapEnvProvider implements AppLandCliEnvProvider {
             return Map.of();
         }
 
-        return Map.of(
-                "OPENAI_BASE_URL", NavieCopilotChatRequestHandler.getBaseUrl(),
-                "APPMAP_NAVIE_COMPLETION_BACKEND", "openai",
-                "OPENAI_API_KEY", GitHubCopilotService.RandomIdeSessionId
-        );
+        var userCopilotModel = AppMapApplicationSettingsService.getInstance().getCopilotModelId();
+
+        var env = new HashMap<String, String>();
+        env.put("OPENAI_BASE_URL", NavieCopilotChatRequestHandler.getBaseUrl());
+        env.put("APPMAP_NAVIE_COMPLETION_BACKEND", "openai");
+        env.put("OPENAI_API_KEY", GitHubCopilotService.RandomIdeSessionId);
+        if (StringUtil.isNotEmpty(userCopilotModel)) {
+            env.put("APPMAP_NAVIE_MODEL", userCopilotModel);
+        }
+       return Map.copyOf(env);
     }
 
     /**

--- a/plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java
@@ -262,7 +262,7 @@ public class NavieCopilotChatRequestHandler extends HttpRequestHandler {
         if (_cachedModels == null) {
             var chatSession = cachedCopilotChatSession();
             if (chatSession != null) {
-                _cachedModels = chatSession.loadModels();
+                _cachedModels = chatSession.loadChatModels();
             }
         }
         return _cachedModels;

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URLConnection;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,7 +33,7 @@ public final class CopilotChatSession {
         this.baseHeaders = baseHeaders;
     }
 
-    public List<CopilotModelDefinition> loadModels() throws IOException {
+    public List<CopilotModelDefinition> loadChatModels() throws IOException {
         record ModelsResponse(@SerializedName("data") CopilotModelDefinition[] models) {
         }
 
@@ -43,7 +44,10 @@ public final class CopilotChatSession {
                 .isReadResponseOnError(true)
                 .tuner(connection -> applyHeaders(connection, baseHeaders))
                 .readString();
-        return List.of(GsonUtils.GSON.fromJson(response, ModelsResponse.class).models);
+
+        return Arrays.stream(GsonUtils.GSON.fromJson(response, ModelsResponse.class).models)
+                .filter(model -> "chat".equals(model.capabilities().type()))
+                .toList();
     }
 
     public void ask(@NotNull CopilotChatResponseListener responseListener,

--- a/plugin-copilot/src/main/resources/META-INF/appmap-copilot.xml
+++ b/plugin-copilot/src/main/resources/META-INF/appmap-copilot.xml
@@ -5,6 +5,14 @@
                      implementation="appland.copilotChat.CopilotAppMapEnvProvider"/>
     </extensions>
 
+    <actions>
+        <action id="copilot.chooseModel"
+                class="appland.copilotChat.ChooseCopilotModelAction">
+            <override-text place="MainMenu"/>
+            <add-to-group group-id="appmapToolsMenu" relative-to-action="appmap.navie.openAIKey" anchor="after"/>
+        </action>
+    </actions>
+
     <extensions defaultExtensionNs="com.intellij">
         <httpRequestHandler implementation="appland.copilotChat.NavieCopilotChatRequestHandler"/>
 

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -56,6 +56,12 @@ public class AppMapApplicationSettings {
     private volatile boolean copilotIntegrationDisabled = false;
 
     /**
+     * The id of the Copilot model to use with Navie.
+     * A default will be used if it's null or if there's no model of the name available in Copilot.
+     */
+    private volatile @Nullable String copilotModelId = null;
+
+    /**
      * Tracks if the Copilot integration was detected to be available at least once.
      */
     private volatile boolean copilotIntegrationDetected = false;
@@ -148,6 +154,15 @@ public class AppMapApplicationSettings {
 
         if (changed) {
             settingsPublisher().copilotIntegrationDisabledChanged();
+        }
+    }
+
+    public void setCopilotModelId(@Nullable String copilotModelId) {
+        var changed = !Objects.equals(copilotModelId, this.copilotModelId);
+        this.copilotModelId = copilotModelId;
+
+        if (changed) {
+            settingsPublisher().copilotModelChanged();
         }
     }
 

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -33,6 +33,9 @@ public interface AppMapSettingsListener {
     default void copilotIntegrationDisabledChanged() {
     }
 
+    default void copilotModelChanged() {
+    }
+
     default void scannedEnabledChanged() {
     }
 

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsReloadProjectListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsReloadProjectListener.java
@@ -36,6 +36,11 @@ public class AppMapSettingsReloadProjectListener implements AppMapSettingsListen
     }
 
     @Override
+    public void copilotModelChanged() {
+        showReloadNotificationAlarm.cancelAndRequest();
+    }
+
+    @Override
     public void scannedEnabledChanged() {
         showReloadNotificationInAllProjects();
     }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -64,6 +64,17 @@ action.appmap.navie.pinContextFile.text=AppMap: Add Files to Navie Context
 action.appmap.navie.chooseAndPinContextFile.text=AppMap: Add Files to Navie Context
 action.appmap.navie.chooseAndPinContextFile.MainMenu.text=Add Files to Navie Context
 
+action.copilot.chooseModel.text=AppMap: Choose Copilot Model
+action.copilot.chooseModel.MainMenu.text=Choose Copilot Model
+action.copilot.chooseModel.loadingModels=Loading available Copilot models...
+action.copilot.chooseModel.noModels.text=No models were found. Please try again later.
+action.copilot.chooseModel.noModels.title=AppMap
+action.copilot.chooseModel.errorLoadingModels.text=An error occurred loading Copilot models. Please try again later.
+action.copilot.chooseModel.errorLoadingModels.title=AppMap
+action.copilot.chooseModel.popup.defaultModel=Use default model
+action.copilot.chooseModel.popup.title=Choose Copilot Model for Navie
+action.copilot.chooseModel.popup.adText=Remember to reload the project after changing the model.
+
 group.appmapToolsMenu.text=AppMap
 group.appmapToolsMenu.title=AppMap Tools
 


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/824

This PR adds a new action to choose the Copilot model for Navie.

This changes the existing "loadModels" to only return models suitable for chat, i.e. only models with `type == "chat"`.

Menu item to invoke the action:
![image](https://github.com/user-attachments/assets/a667f40c-d488-40cc-910d-b4dffb260117)

Popup to choose the model. The model currently selected for Navie is pre-selected when the popup is shown.
![image](https://github.com/user-attachments/assets/cfad6ac5-37ea-46a6-9a82-0fcb86d40f38)
