### PR TITLE
Add support for 2025.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                 os: [ ubuntu, windows, macos ]
                 include:
                     # Run tests with latest platform version, but only on Linux
-                    - ide_version: "2024.2"
+                    - ide_version: "2024.3"
                       os: ubuntu
 
         name: Test ${{ matrix.ide_version }} on ${{ matrix.os }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,13 +23,13 @@ buildscript {
 
 plugins {
     idea
-    id("org.jetbrains.kotlin.jvm") version "1.9.24"
+    id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.intellij.platform") version "2.1.0"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"
 
-    kotlin("plugin.lombok") version "1.9.24"
+    kotlin("plugin.lombok")
 }
 
 val pluginVersionString = prop("pluginVersion")
@@ -249,7 +249,10 @@ project(":") {
             pluginModule(implementation(project(":plugin-copilot")))
 
             // adding this for runIde support
-            plugin("com.github.copilot", prop("copilotPluginVersion"))
+            val copilotPluginVersion = prop("copilotPluginVersion")
+            if (copilotPluginVersion.isNotEmpty()) {
+                plugin("com.github.copilot", copilotPluginVersion)
+            }
 
             pluginVerifier()
             zipSigner()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 pluginVersion=0.67.0
 
 sinceBuild=231.0
-untilBuild=243.*
+untilBuild=251.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2023.1,IC-243.21155.17
+ideVersionVerifier=IC-2023.1,IC-2024.3,IC-251.17181.16
 
 lombokVersion=1.18.32
 
@@ -15,9 +15,11 @@ ideVersion=2023.1
 #ideVersion=2024.1
 #ideVersion=2024.2
 #ideVersion=2024.3.1
+#ideVersion=251.17181.16
 
 copilotPluginVersion=1.5.30-231
 #copilotPluginVersion=1.5.30-242
+#copilotPluginVersion=
 
 kotlin.stdlib.default.dependency=false
 

--- a/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
+++ b/plugin-core/src/main/java/appland/actions/StopAppMapRecordingAction.java
@@ -1,5 +1,11 @@
 package appland.actions;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
 import appland.AppMapBundle;
 import appland.Icons;
 import appland.files.AppMapFiles;
@@ -31,12 +37,6 @@ import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
-
 public class StopAppMapRecordingAction extends AnAction implements DumbAware {
     private static final Logger LOG = Logger.getInstance(StopAppMapRecordingAction.class);
 
@@ -67,8 +67,12 @@ public class StopAppMapRecordingAction extends AnAction implements DumbAware {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         var project = e.getProject();
-        assert project != null;
+        if (project != null) {
+            execute(project);
+        }
+    }
 
+    public static void execute(@NotNull Project project) {
         new Task.Modal(project, AppMapBundle.get("action.stopAppMapRemoteRecording.locationProgress.title"), true) {
             private final AtomicReference<Path> location = new AtomicReference<>();
 

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -1,5 +1,10 @@
 package appland.notifications;
 
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import static appland.AppMapBundle.lazy;
+
 import appland.AppMapBundle;
 import appland.AppMapPlugin;
 import appland.actions.StopAppMapRecordingAction;
@@ -27,11 +32,6 @@ import com.intellij.util.net.HttpConfigurable;
 import com.intellij.util.ui.EdtInvocationManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Arrays;
-import java.util.function.Consumer;
-
-import static appland.AppMapBundle.lazy;
 
 public final class AppMapNotifications {
     public static final String REMOTE_RECORDING_ID = "appmap.remoteRecording";
@@ -90,7 +90,7 @@ public final class AppMapNotifications {
                         lazy("notification.stopButton"),
                         (e, n) -> {
                             n.expire();
-                            new StopAppMapRecordingAction().actionPerformed(e);
+                            StopAppMapRecordingAction.execute(project);
                         }));
             }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,16 @@ pluginManagement {
         maven("https://oss.sonatype.org/content/repositories/snapshots/")
         gradlePluginPortal()
     }
+
+    val platformVersion = extra["ideVersion"] as String
+    plugins {
+        val kotlinVersion = when {
+            platformVersion.startsWith("251.") || platformVersion.startsWith("2025.1") -> "2.1.0"
+            else -> "1.9.24"
+        }
+        kotlin("jvm") version kotlinVersion
+        kotlin("plugin.lombok") version kotlinVersion
+    }
 }
 
 rootProject.name = "intellij-appmap"


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/837

This PR adds compatibility with the upcoming 2025.1.
To build with 2025.1 for local development, we  need to use Kotlin 2.1 instead of 1.9.x.
This PR drops an override-only violation when invoking one of our own actions.

As there's no Copilot plugin yet for 2025.1, there's a change to work without the plugin. The Copilot integration is still enabled, though.