### PR TITLE
fix: Forward inbound request headers to Copilot

### DIFF
--- a/plugin-copilot/src/main/java/appland/copilotChat/CopilotAppMapEnvProvider.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/CopilotAppMapEnvProvider.java
@@ -7,9 +7,12 @@ import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSecureApplicationSettingsService;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.extensions.PluginDescriptor;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Extends the environment setup of AppMap CLI commands with the values to use this plugin's GitHub Copilot integration.
@@ -60,13 +63,22 @@ public class CopilotAppMapEnvProvider implements AppLandCliEnvProvider {
                 || environment.containsKey(AppLandJsonRpcService.AZURE_OPENAI_API_KEY);
     }
 
+    /**
+     * @return The GitHub Copilot plugin descriptor, or {@code null} if it's not installed.
+     */
+    public static @Nullable PluginDescriptor getCopilotPlugin() {
+        return PluginManager.getLoadedPlugins()
+                .stream()
+                .filter(plugin -> plugin.isEnabled() && plugin.getPluginId().equals(GitHubCopilotService.CopilotPluginId))
+                .findFirst()
+                .orElse(null);
+    }
+
     private static boolean isGitHubCopilotDisabled() {
         if (AppMapApplicationSettingsService.getInstance().isCopilotIntegrationDisabled()) {
             return true;
         }
 
-        return PluginManager.getLoadedPlugins()
-                .stream()
-                .noneMatch(plugin -> plugin.isEnabled() && plugin.getPluginId().equals(GitHubCopilotService.CopilotPluginId));
+        return getCopilotPlugin() == null;
     }
 }

--- a/plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java
@@ -241,7 +241,10 @@ public class NavieCopilotChatRequestHandler extends HttpRequestHandler {
     }
 
     private @NotNull Map<String, String> collectProxiedRequestHeaders(@NotNull FullHttpRequest fullHttpRequest) {
-        return fullHttpRequest.headers().entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return fullHttpRequest.headers().entries().stream()
+            .filter(entry -> entry.getKey().toLowerCase().startsWith("x-appmap-")
+                || entry.getKey().toLowerCase().equals("user-agent"))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private @NotNull List<CopilotChatRequest.Message> asCopilotChatMessages(List<OpenAIChatCompletionsRequest.Message> messages) {

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java
@@ -53,6 +53,7 @@ public final class CopilotChatSession {
     public void ask(@NotNull CopilotChatResponseListener responseListener,
                     @NotNull CopilotModelDefinition model,
                     @NotNull List<CopilotChatRequest.Message> messages,
+                    @NotNull Map<String, String> proxiedRequestHeaders,
                     @Nullable Double temperature,
                     @Nullable Double topP,
                     @Nullable Integer n) throws IOException {
@@ -67,6 +68,7 @@ public final class CopilotChatSession {
                     .throwStatusCodeException(true)
                     .isReadResponseOnError(true)
                     .tuner(connection -> {
+                        applyHeaders(connection, proxiedRequestHeaders);
                         applyHeaders(connection, baseHeaders);
                         connection.setRequestProperty(GitHubCopilot.HEADER_OPENAI_INTENT, "conversation-panel");
                         connection.setRequestProperty(GitHubCopilot.HEADER_OPENAI_ORGANIZATION, "github-copilot");

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java
@@ -73,12 +73,13 @@ public final class GitHubCopilotService {
         var apiEndpoint = copilotToken.getToken().endpoints().getOrDefault(CopilotToken.CopilotEndpoint.API, "https://api.githubcopilot.com");
         var baseHeaders = new HashMap<>(
             Map.of(
-                "editor-version", getCopilotEditorVersion(),
+                "x-appmap-plugin-version", AppMapPlugin.getDescriptor().getVersion(),
                 "x-github-api-version", GitHubCopilot.GITHUB_API_VERSION,
-                "x-appmap-machineid", machineId,
-                "x-appmap-copilot-language-server-version", GitHubCopilot.LANGUAGE_SERVER_VERSION,
-                "x-appmap-copilot-plugin-version", CopilotAppMapEnvProvider.getCopilotPlugin().getVersion(),
-                "x-appmap-plugin-version", AppMapPlugin.getDescriptor().getVersion()
+                "copilot-language-server-version", GitHubCopilot.LANGUAGE_SERVER_VERSION,
+                "editor-plugin-version", GitHubCopilot.GITHUB_COPILOT_PLUGIN_VERSION,
+                "editor-version", getCopilotEditorVersion(),
+                "vscode-machineid", machineId,
+                "vscode-sessionid", UUID.randomUUID().toString()
             )
         );
 

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java
@@ -1,5 +1,7 @@
 package appland.copilotChat.copilot;
 
+import appland.AppMapPlugin;
+import appland.copilotChat.CopilotAppMapEnvProvider;
 import appland.utils.GsonUtils;
 import appland.utils.SystemProperties;
 import com.esotericsoftware.kryo.kryo5.util.Null;
@@ -23,6 +25,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -68,14 +71,22 @@ public final class GitHubCopilotService {
         }
 
         var apiEndpoint = copilotToken.getToken().endpoints().getOrDefault(CopilotToken.CopilotEndpoint.API, "https://api.githubcopilot.com");
-        var baseHeaders = Map.of(
-                "copilot-language-server-version", GitHubCopilot.LANGUAGE_SERVER_VERSION,
-                "editor-plugin-version", GitHubCopilot.GITHUB_COPILOT_PLUGIN_VERSION,
+        var baseHeaders = new HashMap<>(
+            Map.of(
                 "editor-version", getCopilotEditorVersion(),
                 "x-github-api-version", GitHubCopilot.GITHUB_API_VERSION,
-                "vscode-machineid", machineId,
-                "vscode-sessionid", UUID.randomUUID().toString()
+                "x-appmap-machineid", machineId,
+                "x-appmap-copilot-language-server-version", GitHubCopilot.LANGUAGE_SERVER_VERSION,
+                "x-appmap-copilot-plugin-version", CopilotAppMapEnvProvider.getCopilotPlugin().getVersion(),
+                "x-appmap-plugin-version", AppMapPlugin.getDescriptor().getVersion()
+            )
         );
+
+        var copilotPlugin = CopilotAppMapEnvProvider.getCopilotPlugin();
+        if (copilotPlugin != null) {
+            baseHeaders.put("x-appmap-copilot-plugin-version", copilotPlugin.getVersion());
+        }
+
         return new CopilotChatSession(apiEndpoint, copilotToken, baseHeaders);
     }
 

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java
@@ -72,7 +72,6 @@ public final class GitHubCopilotService {
                 "copilot-language-server-version", GitHubCopilot.LANGUAGE_SERVER_VERSION,
                 "editor-plugin-version", GitHubCopilot.GITHUB_COPILOT_PLUGIN_VERSION,
                 "editor-version", getCopilotEditorVersion(),
-                "user-agent", GitHubCopilot.USER_AGENT,
                 "x-github-api-version", GitHubCopilot.GITHUB_API_VERSION,
                 "vscode-machineid", machineId,
                 "vscode-sessionid", UUID.randomUUID().toString()


### PR DESCRIPTION
This change improves the handling of HTTP headers when making requests to GitHub Copilot by:

1. Forwarding all inbound request headers from the client to Copilot
2. Removing the hardcoded user-agent header since it should be set by the requesting entity

The implementation collects all headers from the incoming request and applies them to the outbound Copilot request, while maintaining existing required headers for Copilot authentication and session management.
