### PR TITLE
Download content exclusion lists from GitHub

### DIFF
--- a/.run/intellij-plugin [runIde].run.xml
+++ b/.run/intellij-plugin [runIde].run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value="-PideVersion=2024.3.1 -PcopilotPluginVersion=1.5.30-242" />
       <option name="taskDescriptions">
         <list />
       </option>
@@ -18,6 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -321,6 +321,7 @@ project(":") {
 
         task<Copy>("copyPluginAssets") {
             dependsOn(":downloadAppMapAgent")
+            doNotTrackState("target directory can contain temporary sockets")
 
             inputs.file("${project.rootDir}/NOTICE.txt")
             inputs.file(agentOutputPath)

--- a/plugin-copilot/src/main/java/appland/copilotChat/CopilotStartupNotificationActivity.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/CopilotStartupNotificationActivity.java
@@ -27,7 +27,8 @@ public class CopilotStartupNotificationActivity implements StartupActivity, Dumb
         }
 
         // if the Copilot integration is enabled, but not authenticated, show a notification
-        if (!GitHubCopilotService.getInstance().isCopilotAuthenticated()) {
+        GitHubCopilotService copilotService = GitHubCopilotService.getInstance();
+        if (!copilotService.isCopilotAuthenticated()) {
             ApplicationManager.getApplication().invokeLater(AppMapNotifications::showCopilotAuthenticationRequired);
             return;
         }
@@ -39,6 +40,12 @@ public class CopilotStartupNotificationActivity implements StartupActivity, Dumb
                 AppMapApplicationSettingsService.getInstance().setCopilotIntegrationDetected(true);
                 ApplicationManager.getApplication().invokeLater(AppMapNotifications::showFirstCopilotIntegrationEnabled);
             }
+        }
+
+        try {
+            copilotService.ensureContentExclusionsDownloaded();
+        } catch (Exception e) {
+            // this is ok for now, it will be retried later
         }
     }
 }

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotContentExclusion.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotContentExclusion.java
@@ -1,0 +1,77 @@
+package appland.copilotChat.copilot;
+
+import appland.utils.GsonUtils;
+import com.google.gson.annotations.SerializedName;
+import com.intellij.util.Url;
+import com.intellij.util.Urls;
+import com.intellij.util.io.HttpRequests;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public record CopilotContentExclusion(@SerializedName("rules") @NotNull List<Rule> rules,
+                                      @SerializedName("last_updated_at") @NotNull String lastUpdatedAt,
+                                      @SerializedName("scope") @NotNull Scope scope) {
+    /**
+     * Fetches the global exclusion rules from the Copilot API.
+     *
+     * @param gitHubToken The GitHub token to use for authentication.
+     * @return The content exclusion rules.
+     * @throws IOException
+     */
+    static public @NotNull List<CopilotContentExclusion> fetchGlobal(@NotNull String gitHubToken) throws IOException {
+        return fetch(gitHubToken, Scope.ALL, null);
+    }
+
+    /**
+     * Fetches the content exclusion rules from the Copilot API.
+     *
+     * @param gitHubToken The GitHub token to use for authentication.
+     * @param scope       The scope of the content exclusion rules to fetch.
+     * @param repos       The specific repositories to fetch the content exclusion rules for
+     * @return The content exclusion rules.
+     * @throws IOException
+     */
+    static public @NotNull List<CopilotContentExclusion> fetch(@NotNull String gitHubToken, @NotNull Scope scope, @Nullable List<String> repos) throws IOException {
+        try {
+            var response = HttpRequests.request(contentExclusionUrl(scope, repos)).tuner(connection -> {
+                connection.setRequestProperty("Authorization", "Bearer " + gitHubToken);
+                connection.setRequestProperty("Accept", "application/json");
+            }).isReadResponseOnError(true).readString();
+            return List.of(GsonUtils.GSON.fromJson(response, CopilotContentExclusion[].class));
+        } catch (HttpRequests.HttpStatusException e) {
+            if (e.getStatusCode() == 404) {
+                return List.of();
+            }
+            throw e;
+        }
+    }
+
+
+    /**
+     * @param scope The scope of the content exclusion rules to fetch.
+     * @param repos The specific repositories to fetch the content exclusion rules for
+     */
+    static private @NotNull Url contentExclusionUrl(@NotNull Scope scope, @Nullable List<String> repos) {
+        var url = Urls.parse(GitHubCopilot.INTERNAL_API_URL + "/content_exclusion", false).addParameters(Map.of("scope", scope.name().toLowerCase()));
+        if (repos != null) {
+            return url.addParameters(Map.of("repos", String.join(",", repos)));
+        }
+
+        return url;
+    }
+
+    public enum Scope {
+        @SerializedName("repo") REPO, @SerializedName("all") ALL,
+    }
+
+    public record Rule(@SerializedName("source") @NotNull Source source,
+                       @SerializedName("paths") @NotNull List<String> paths) {
+    }
+
+    public record Source(@SerializedName("name") @NotNull String name, @SerializedName("type") @NotNull String type) {
+    }
+}

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilot.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilot.java
@@ -17,6 +17,8 @@ public final class GitHubCopilot {
     public static final String CHAT_FALLBACK_MODEL_NAME = "gpt-4o";
     public static final double CHAT_DEFAULT_TEMPERATURE = 0.1;
 
+    public static final String INTERNAL_API_URL = "https://api.github.com/copilot_internal";
+
     // HTTP header names used by GitHub Copilot
     public static final String HEADER_OPENAI_ORGANIZATION = "openai-organization";
     public static final String HEADER_OPENAI_VERSION = "openai-version";

--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/UpdatingCopilotToken.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/UpdatingCopilotToken.java
@@ -16,7 +16,7 @@ class UpdatingCopilotToken {
 
     private static @Nullable CopilotToken fetchRawCopilotToken(@NotNull String githubToken) {
         try {
-            var response = HttpRequests.request("https://api.github.com/copilot_internal/v2/token")
+            var response = HttpRequests.request(GitHubCopilot.INTERNAL_API_URL + "/v2/token")
                     .accept("application/json")
                     .isReadResponseOnError(true)
                     .gzip(true)

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -317,8 +317,28 @@ public final class AppMapNotifications {
         });
     }
 
+
     /**
-     * Displays a notification that the Copilot authentication is required in all open projects.
+     * Displays a notification that the Copilot content exclusions download failed.
+     */
+    public static void showCopilotExclusionDownloadFailed(Exception error) {
+        ApplicationManager.getApplication().assertIsDispatchThread();
+
+        ReadAction.run(() -> {
+            for (var project : ProjectManager.getInstance().getOpenProjects()) {
+                new AppMapFullContentNotification(
+                        GENERIC_NOTIFICATIONS_ID, null,
+                        AppMapBundle.get("notification.copilotExclusionDownloadFailed.title"),
+                        AppMapBundle.get("notification.copilotExclusionDownloadFailed.subtitle"),
+                        AppMapBundle.get("notification.copilotExclusionDownloadFailed.content", error.toString()),
+                        NotificationType.ERROR, null
+                ).notify(project);
+            }
+        });
+    }
+
+    /**
+     * Displays a notification that the Copilot integration is available in all open projects.
      */
     public static void showFirstCopilotIntegrationEnabled() {
         ApplicationManager.getApplication().assertIsDispatchThread();

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -292,3 +292,6 @@ notification.copilotIntegrationAvailable.content=The integration of GitHub Copil
 
 notification.copilotAuthRequired.title=AppMap Copilot Integration
 notification.copilotAuthRequired.content=Please authenticate GitHub Copilot to use it with AppMap Navie.
+notification.copilotExclusionDownloadFailed.title=AppMap Copilot Integration
+notification.copilotExclusionDownloadFailed.subtitle=Error
+notification.copilotExclusionDownloadFailed.content=Content exclusion policy download from GitHub failed:<br>{0}<br>Please try again later.


### PR DESCRIPTION
This pull request introduces several changes to enhance the Copilot plugin, including new functionality for handling content exclusions and updates to existing services and notifications.

### New Functionality:
* [`plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotContentExclusion.java`](diffhunk://#diff-f2e48992aa593951e22d2a1f51f9d70b2cc556d203efab514ae59f085dfafb08R1-R77): Added a new class to fetch and manage content exclusion rules from the Copilot API.
* [`plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilot.java`](diffhunk://#diff-b2fd844a2f86c4b4539119b7150dba414faea536ec4246a18a0df6bd1639b03eR20-R21): Introduced a new constant `INTERNAL_API_URL` for the Copilot internal API.

### Service Updates:
* [`plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java`](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR56-R124): Added methods to download and ensure content exclusions are up-to-date. Modified the `createChatSession` method to handle content exclusion downloads. [[1]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR56-R124) [[2]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bL117-R177)

### Notification Enhancements:
* [`plugin-core/src/main/java/appland/notifications/AppMapNotifications.java`](diffhunk://#diff-7473336df14fc297e0fe900fcb8dff631f06d4981fe9f97a3123e35d6020c087R320-R341): Added a new notification method `showCopilotExclusionDownloadFailed` to inform users when content exclusion downloads fail.
* [`plugin-core/src/main/resources/messages/appland.properties`](diffhunk://#diff-8423749c5b5ea32c141cf9d4cdaa0163471934f02cd341cf3eb7a9902e93e10eR295-R297): Added new notification messages for content exclusion download failures.

### Minor Updates:
* `.run/intellij-plugin [runIde].run.xml`: Updated script parameters to run with a newer IDE version by default. ([.run/intellij-plugin [runIde].run.xmlL7-R7](diffhunk://#diff-05f911c196589d75db7e6cd94e42c17e6fe72be9c8db1cb2c024dba717ab65c5L7-R7), [.run/intellij-plugin [runIde].run.xmlR21](diffhunk://#diff-05f911c196589d75db7e6cd94e42c17e6fe72be9c8db1cb2c024dba717ab65c5R21))
* [`plugin-copilot/src/main/java/appland/copilotChat/CopilotStartupNotificationActivity.java`](diffhunk://#diff-4691286119508929523e2ed132862962c9271f31595390b8473a84dcb1f0c4c3L30-R31): Refactored code to use a local variable for the Copilot service and added a call to ensure content exclusions are downloaded. [[1]](diffhunk://#diff-4691286119508929523e2ed132862962c9271f31595390b8473a84dcb1f0c4c3L30-R31) [[2]](diffhunk://#diff-4691286119508929523e2ed132862962c9271f31595390b8473a84dcb1f0c4c3R44-R49)
* [`plugin-copilot/src/main/java/appland/copilotChat/copilot/UpdatingCopilotToken.java`](diffhunk://#diff-7b24c3bc78f357518e6395df47fa7d4bc1f6015667f701add0589a25253ceb09L19-R19): Updated the token request URL to use the new `INTERNAL_API_URL` constant.