### PR TITLE
Improve compatibility with 2025.1 eap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ jobs:
     test:
         strategy:
             matrix:
-                ide_version: [ "2024.1" ]
+                platform_version: [ "241" ]
                 os: [ ubuntu, windows, macos ]
                 include:
                     # Run tests with latest platform version, but only on Linux
-                    - ide_version: "2024.3"
+                    - platform_version: "243"
                       os: ubuntu
 
-        name: Test ${{ matrix.ide_version }} on ${{ matrix.os }}
+        name: Test ${{ matrix.platform_version }} on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}-latest
         timeout-minutes: 45
         steps:
@@ -47,20 +47,20 @@ jobs:
 
             - name: Run Linters and Test
               shell: bash
-              run: ./gradlew -PideVersion=${{ matrix.ide_version }} check
+              run: ./gradlew -PplatformVersion=${{ matrix.platform_version }} check
 
             - name: Upload Test Reports
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: test-reports-${{ matrix.os }}-${{ matrix.ide_version }}
+                  name: test-reports-${{ matrix.os }}-${{ matrix.platform_version }}
                   path: |
                       build/reports/
                       **/build/reports/
 
             - name: Save AppMaps
               uses: actions/cache/save@v4
-              if: runner.os == 'Linux' && matrix.ide_version == '2024.1'
+              if: runner.os == 'Linux' && matrix.platform_version == '241'
               with:
                   path: ./tmp/appmap
                   key: appmaps-${{ github.sha }}-${{ github.run_attempt }}

--- a/.run/Run tests (2024.3).run.xml
+++ b/.run/Run tests (2024.3).run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run tests (2024.3)" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PplatformVersion=243" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run tests.run.xml
+++ b/.run/Run tests.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="intellij-plugin [test]" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Run tests" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/runIDE 2025.1.run.xml
+++ b/.run/runIDE 2025.1.run.xml
@@ -1,10 +1,10 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="intellij-plugin [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="runIDE 2025.1" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PideVersion=2024.3.1 -PcopilotPluginVersion=1.5.30-242" />
+      <option name="scriptParameters" value="-PplatformVersion=251" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/runIde 2024.3.run.xml
+++ b/.run/runIde 2024.3.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runIde 2024.3" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PplatformVersion=243" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/runIde.run.xml
+++ b/.run/runIde.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runIde" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,11 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.InstrumentCodeTask
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
+import org.jetbrains.kotlin.konan.properties.loadProperties
+import kotlin.collections.component1
+import kotlin.collections.component2
+
+loadPlatformProperties()
 
 buildscript {
     dependencies {
@@ -474,4 +479,16 @@ fun String.renderMarkdown(): String {
 
 fun prop(name: String): String {
     return extra.properties[name] as? String ?: error("Property `$name` is not defined in gradle.properties")
+}
+
+fun loadPlatformProperties() {
+    val platformVersion = prop("platformVersion").toInt()
+    val platformFilePath = rootDir.resolve("gradle-$platformVersion.properties")
+    loadProperties(platformFilePath.toString()).forEach { (key, value) ->
+        val name = key.toString()
+        // don't override properties which were overridden on the Gradle commandline with '-Pname=value"
+        if (!rootProject.extra.has(name)) {
+            rootProject.extra.set(name, value)
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.intellij.platform") version "2.2.1"
+    id("org.jetbrains.intellij.platform") version "2.2.2-SNAPSHOT"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"
@@ -44,12 +44,7 @@ val ideVersion = prop("ideVersion")
 group = "appland.appmap"
 version = pluginVersionString
 
-val platformVersion = when {
-    // e.g. '2024.1'
-    ideVersion.length == 6 -> ideVersion.replace(".", "").substring(2).toInt()
-    // e.g. '243.16718.32'
-    else -> ideVersion.substringBefore(".").toInt()
-}
+val platformVersion = prop("platformVersion").toInt()
 
 val isCI = System.getenv("CI") == "true"
 val agentOutputPath = rootProject.layout.buildDirectory.asFile.get()

--- a/development.md
+++ b/development.md
@@ -1,5 +1,16 @@
 ## Indexing of AppMap Data
 
+### Developing or Testing For A Different Major Version
+
+Release builds must be created with the earliest support version.
+But testing or fixing API compatibility can be done for a different major version.
+
+Property `platformVersion` in file `gradle.properties` defines which IDE platform to use.
+File `gradle-$platformVersion.properties` contains the properties for the configured versin.
+
+Use `./gradlew -PplatformVersion=...` to override the version on the command line.
+For example, use `./gradlew -PplatformVersion=251` to run a sandbox IDE for 2025.1.
+
 ### Indexed `appmap.yml` Files
 
 `appmap.yml` files, which are located in a project, are indexed.

--- a/gradle-241.properties
+++ b/gradle-241.properties
@@ -1,0 +1,2 @@
+ideVersion=2024.1
+copilotPluginVersion=1.5.35-241

--- a/gradle-242.properties
+++ b/gradle-242.properties
@@ -1,0 +1,2 @@
+ideVersion=2024.2
+copilotPluginVersion=1.5.35-242

--- a/gradle-243.properties
+++ b/gradle-243.properties
@@ -1,0 +1,2 @@
+ideVersion=2024.3.1
+copilotPluginVersion=1.5.35-242

--- a/gradle-251.properties
+++ b/gradle-251.properties
@@ -1,0 +1,2 @@
+ideVersion=251.22821.72
+copilotPluginVersion=1.5.35-242

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,8 @@ sinceBuild=241.0
 untilBuild=251.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2024.1,IC-2024.3,IC-251.22821.72
+# fixme add 2025.1 as soon as this is solved: https://platform.jetbrains.com/t/plugin-verifier-fails-with-plugin-com-intellij-modules-json-not-declared-as-a-plugin-dependency/580/12
+ideVersionVerifier=IC-2024.1.7,IC-2024.3.3
 
 lombokVersion=1.18.36
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,14 @@
 pluginVersion=0.67.0
 
+# defines which gradle-$v.properties file is loaded with the versions of IDE and plugins
+platformVersion=241
 sinceBuild=241.0
 untilBuild=251.*
 
 # run plugin verifier for the earliest and latest supported versions
-ideVersionVerifier=IC-2024.1,IC-2024.3,IC-251.20015.29
+ideVersionVerifier=IC-2024.1,IC-2024.3,IC-251.22821.72
 
 lombokVersion=1.18.36
-
-# alternative versions to simplify development and testing
-ideVersion=2024.1
-#ideVersion=2024.2
-#ideVersion=2024.3.1
-#ideVersion=251.20015.29
-
-# Copilot versions for <=2024.1 and >=2024.2
-copilotPluginVersion=1.5.33-231
-#copilotPluginVersion=1.5.33-242
 
 kotlin.stdlib.default.dependency=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,8 @@ ideVersion=2024.1
 #ideVersion=251.20015.29
 
 # Copilot versions for <=2024.1 and >=2024.2
-copilotPluginVersion=1.5.32-231
-#copilotPluginVersion=1.5.32-242
-#copilotPluginVersion=
+copilotPluginVersion=1.5.33-231
+#copilotPluginVersion=1.5.33-242
 
 kotlin.stdlib.default.dependency=false
 

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -142,7 +142,7 @@ public class AppMapApplicationSettings {
         this.enableScanner = enableScanner;
 
         if (changed) {
-            settingsPublisher().scannedEnabledChanged();
+            settingsPublisher().scannerEnabledChanged();
         }
     }
 

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -36,7 +36,7 @@ public interface AppMapSettingsListener {
     default void copilotModelChanged() {
     }
 
-    default void scannedEnabledChanged() {
+    default void scannerEnabledChanged() {
     }
 
     default void cliEnvironmentChanged(@NotNull Set<String> modifiedKeys) {

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsReloadProjectListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsReloadProjectListener.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.util.Alarm;
+import com.intellij.util.LazyInitializer;
 import com.intellij.util.SingleAlarm;
 import org.apache.commons.collections.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
@@ -18,53 +19,61 @@ import java.util.Set;
  * which require a project reload to activate.
  */
 public class AppMapSettingsReloadProjectListener implements AppMapSettingsListener {
-    // debounce the notification, because several separate settings may be changed at once
-    private final SingleAlarm showReloadNotificationAlarm = new SingleAlarm(
-            this::showReloadNotificationInAllProjects,
-            1_000,
-            AppLandLifecycleService.getInstance(),
-            Alarm.ThreadToUse.SWING_THREAD,
-            ModalityState.defaultModalityState());
+    // Debounce the notification, because several separate settings may be changed at once.
+    // Initialized lazily, because init references a service and other services
+    // must not be accessed during initialization in 2025.1+.
+    private final LazyInitializer.LazyValue<SingleAlarm> showReloadNotificationAlarm = LazyInitializer.create(() -> {
+        return new SingleAlarm(
+                this::showReloadNotificationInAllProjects,
+                1_000,
+                AppLandLifecycleService.getInstance(),
+                Alarm.ThreadToUse.SWING_THREAD,
+                ModalityState.defaultModalityState());
+    });
 
-    // debounce the notification, because several separate settings may be changed at once
-    private final SingleAlarm reloadJsonRpcServerAlarm = new SingleAlarm(
-            this::restartJsonRpcServerInAllProjects,
-            1_000,
-            AppLandLifecycleService.getInstance(),
-            Alarm.ThreadToUse.POOLED_THREAD,
-            ModalityState.defaultModalityState());
+    // Debounce the notification, because several separate settings may be changed at once.
+    // Initialized lazily, because init references a service and other services
+    // must not be accessed during initialization in 2025.1+.
+    private final LazyInitializer.LazyValue<SingleAlarm> reloadJsonRpcServerAlarm = LazyInitializer.create(() -> {
+        return new SingleAlarm(
+                this::restartJsonRpcServerInAllProjects,
+                1_000,
+                AppLandLifecycleService.getInstance(),
+                Alarm.ThreadToUse.POOLED_THREAD,
+                ModalityState.defaultModalityState());
+    });
 
 
     @Override
     public void cliEnvironmentChanged(@NotNull Set<String> modifiedKeys) {
         if (CollectionUtils.containsAny(modifiedKeys, AppLandJsonRpcService.LLM_ENV_VARIABLES)) {
-            reloadJsonRpcServerAlarm.cancelAndRequest();
+            reloadJsonRpcServerAlarm.get().cancelAndRequest();
         }
     }
 
     @Override
     public void openAIKeyChange() {
-        reloadJsonRpcServerAlarm.cancelAndRequest();
+        reloadJsonRpcServerAlarm.get().cancelAndRequest();
     }
 
     @Override
     public void apiKeyChanged() {
-        reloadJsonRpcServerAlarm.cancelAndRequest();
+        reloadJsonRpcServerAlarm.get().cancelAndRequest();
     }
 
     @Override
     public void copilotIntegrationDisabledChanged() {
-        reloadJsonRpcServerAlarm.cancelAndRequest();
+        reloadJsonRpcServerAlarm.get().cancelAndRequest();
     }
 
     @Override
     public void copilotModelChanged() {
-        reloadJsonRpcServerAlarm.cancelAndRequest();
+        reloadJsonRpcServerAlarm.get().cancelAndRequest();
     }
 
     @Override
-    public void scannedEnabledChanged() {
-        showReloadNotificationAlarm.cancelAndRequest();
+    public void scannerEnabledChanged() {
+        showReloadNotificationAlarm.get().cancelAndRequest();
     }
 
     private void showReloadNotificationInAllProjects() {

--- a/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapPatcherUtil.java
@@ -36,9 +36,8 @@ final class AppMapPatcherUtil {
     public static @NotNull List<String> prepareJavaParameters(@NotNull Project project,
                                                               @NotNull RunProfile configuration,
                                                               @NotNull SimpleJavaParameters javaParameters) throws Exception {
-        if (!ApplicationManager.getApplication().isDispatchThread()) {
-            ApplicationManager.getApplication().assertReadAccessNotAllowed();
-        }
+        // < 2025.1 either execute this on the EDT or in a background thread without read access
+        // 2025.1 seems to execute this with read access if in a background thread, at least in test mode.
 
         var task = new Task.WithResult<List<String>, Exception>(project, AppMapBundle.get("appMapConfig.creatingConfig"), true) {
             @Override

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,10 +4,10 @@ pluginManagement {
         gradlePluginPortal()
     }
 
-    val platformVersion = extra["ideVersion"] as String
+    val platformVersion = (extra["platformVersion"] as String).toInt()
     plugins {
         val kotlinVersion = when {
-            platformVersion.startsWith("251.") || platformVersion.startsWith("2025.1") -> "2.1.0"
+            platformVersion == 251 -> "2.1.0"
             else -> "1.9.24"
         }
         kotlin("jvm") version kotlinVersion


### PR DESCRIPTION
With this PR, `gradle runIde` is working with 2025.1 eap4 and an error raised by the IDE about service initialization is fixed.