### PR TITLE
fix: IDE styling was not always applied to webviews

### DIFF
--- a/appland-findings/index.html
+++ b/appland-findings/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./ide-styles.css" />
+    <link rel="stylesheet" href="../ide-styles.css" />
 
     <title>AppLand Findings</title>
 </head>

--- a/appland-install-guide/index.html
+++ b/appland-install-guide/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AppLand Installation Guide</title>
-    <link rel="stylesheet" href="./ide-styles.css" />
+    <link rel="stylesheet" href="../ide-styles.css" />
     <style>
         .recording-method__ask-navie-button {
             display: none;

--- a/appland-navie/index.html
+++ b/appland-navie/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AppMap AI: Explain</title>
     <link rel="stylesheet" href="./dist/main.css" />
-    <link rel="stylesheet" href="./ide-styles.css" />
+    <link rel="stylesheet" href="../ide-styles.css" />
     <!--suppress CssUnusedSymbol -->
     <style>
         body {

--- a/appland/index.html
+++ b/appland/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="./ide-styles.css" />
+  <link rel="stylesheet" href="../ide-styles.css" />
   <title>AppLand Scenario</title>
 </head>
 <body>

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -179,8 +179,6 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     }
 
     private void setupJCEF() {
-        // provide CSS styles customized to match the current IDE
-        contentPanel.getJBCefClient().addRequestHandler(new IdeStyleResourceHandler(), contentPanel.getCefBrowser());
         // open links to https://appmap.io in the external browser
         contentPanel.getJBCefClient().addRequestHandler(new OpenExternalLinksHandler(), contentPanel.getCefBrowser());
         // open new webview windows, which are opened via <a href="..." target="_blank", in the external browser

--- a/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebviewRequestHandler.java
+++ b/plugin-core/src/main/java/appland/webviews/webserver/AppMapWebviewRequestHandler.java
@@ -1,22 +1,26 @@
 package appland.webviews.webserver;
 
+import com.intellij.openapi.application.ReadAction;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.EmptyHttpHeaders;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.ide.HttpRequestHandler;
 import org.jetbrains.io.FileResponses;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  * Request handler to server AppMap's webview files through the IDE's built-in webserver.
  */
 public class AppMapWebviewRequestHandler extends HttpRequestHandler {
     static final String APPMAP_SERVER_BASE_PATH = "/_appmap-webviews";
+    static final String APPMAP_IDE_STYLES_PATH = "/_appmap-webviews/ide-styles.css";
 
     @Override
     public boolean process(@NotNull QueryStringDecoder queryStringDecoder,
@@ -34,6 +38,45 @@ public class AppMapWebviewRequestHandler extends HttpRequestHandler {
             return false;
         }
 
+        // The IDE styles are served with path /_appmap-webviews/ide-styles.css,
+        // the styles are computed on demand
+        if (APPMAP_IDE_STYLES_PATH.equals(requestPath)) {
+            return processIdeStyles(fullHttpRequest, channelHandlerContext);
+        }
+
+        return processWebviewResource(fullHttpRequest, channelHandlerContext, requestPath);
+    }
+
+    private boolean processIdeStyles(@NotNull FullHttpRequest fullHttpRequest, @NotNull ChannelHandlerContext channelHandlerContext) {
+        var isHeadRequest = Objects.equals(fullHttpRequest.method(), HttpMethod.HEAD);
+        var channel = channelHandlerContext.channel();
+
+        var response = FileResponses.INSTANCE.prepareSend(fullHttpRequest,
+                channel,
+                System.currentTimeMillis(),
+                "ide-styles.css");
+        if (response == null) {
+            return false;
+        }
+
+        var ideStyles = ReadAction.compute(IdeStyleRequest::createIdeStyles);
+        var ideStylesBytes = ideStyles.getBytes(StandardCharsets.UTF_8);
+
+        if (!isHeadRequest) {
+            HttpUtil.setContentLength(response, ideStylesBytes.length);
+        }
+        channel.write(response);
+
+        if (!isHeadRequest) {
+            channel.write(Unpooled.copiedBuffer(ideStylesBytes));
+        }
+
+        var cf = channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+        cf.addListener(ChannelFutureListener.CLOSE);
+        return true;
+    }
+
+    private boolean processWebviewResource(@NotNull FullHttpRequest fullHttpRequest, @NotNull ChannelHandlerContext channelHandlerContext, String requestPath) {
         var webviewPath = requestPath.substring(APPMAP_SERVER_BASE_PATH.length() + 1);
         var slashIndex = webviewPath.indexOf('/');
         if (slashIndex == -1) {


### PR DESCRIPTION
The styling was not always applied.
This PR changes the way how the `ide-styles.css` file is served to make it more reliable. The file is now served through the built-in webserver and not by the JCEF component.