### PR TITLE
Update build setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.intellij.platform") version "2.2.2-SNAPSHOT"
+    id("org.jetbrains.intellij.platform") version "2.3.1-SNAPSHOT"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"

--- a/gradle-241.properties
+++ b/gradle-241.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.1
-copilotPluginVersion=1.5.35-241
+copilotPluginVersion=1.5.38-241

--- a/gradle-242.properties
+++ b/gradle-242.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.2
-copilotPluginVersion=1.5.35-242
+copilotPluginVersion=1.5.38-241

--- a/gradle-243.properties
+++ b/gradle-243.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.3.1
-copilotPluginVersion=1.5.35-242
+copilotPluginVersion=1.5.38-243

--- a/gradle-251.properties
+++ b/gradle-251.properties
@@ -1,2 +1,2 @@
 ideVersion=251.22821.72
-copilotPluginVersion=1.5.35-242
+copilotPluginVersion=1.5.38-243


### PR DESCRIPTION
- Use the latest version of Copilot for local testing and development.
- Use the current snapshot of the intellij-platform Gradle plugin because it has important performance optimizations. Without it, local builds can be very slow.