### PR TITLE
Log requests in copilot proxy and actually send errors back to the client

### DIFF
--- a/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java
+++ b/plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java
@@ -72,6 +72,8 @@ public final class CopilotChatSession {
                         connection.setRequestProperty(GitHubCopilot.HEADER_OPENAI_ORGANIZATION, "github-copilot");
                         connection.setRequestProperty(GitHubCopilot.HEADER_REQUEST_ID, requestId());
                     })
+                    .connectTimeout(10000)
+                    .readTimeout(60000)
                     .connect(httpRequest -> {
                         httpRequest.write(GsonUtils.GSON.toJson(copilotRequest));
 
@@ -87,7 +89,7 @@ public final class CopilotChatSession {
                         readServerEvents(httpRequest.getReader(), responseListener);
                         return null;
                     });
-        } catch (HttpRequests.HttpStatusException e) {
+        } catch (IOException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Failed to send chat request. ", e);
             }

--- a/plugin-core/src/main/java/appland/utils/UserLog.java
+++ b/plugin-core/src/main/java/appland/utils/UserLog.java
@@ -1,0 +1,57 @@
+package appland.utils;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+public class UserLog implements Disposable {
+    private final @Nullable FileOutputStream logFile;
+    private static final Logger LOG = Logger.getInstance(UserLog.class);
+
+    public UserLog(String name) {
+        FileOutputStream logFile = null;
+        try {
+            File logDir = new File(PathManager.getLogPath());
+            if (logDir.exists() || logDir.mkdirs()) {
+                logFile = new FileOutputStream(new File(logDir, name), false);
+            }
+        } catch (FileNotFoundException e) {
+            LOG.error("Failed to open log file", e);
+        }
+        this.logFile = logFile;
+    }
+
+    public void log(@NotNull String message) {
+        if (logFile == null) {
+            return;
+        }
+        try {
+            synchronized (logFile) {
+                logFile.write(message.getBytes());
+                if (!message.endsWith("\n")) {
+                    logFile.write("\n".getBytes());
+                }
+                logFile.flush();
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to write to log file", e);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        try {
+            if (logFile != null) {
+                logFile.close();
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to close log file", e);
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes several improvements and error handling enhancements to the `NavieCopilotChatRequestHandler` and related classes. The key changes involve adding logging functionality, improving request handling, and updating error responses. In particular it fixes a bug where error responses were never actually sent to the client, leading to upstream errors just appearing as hanging to the client.

### Error Handling Enhancements:
* [`plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java`](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309L49-L102): Improved error handling in `process` method by adding specific responses for unauthorized access, token count limits, and internal server errors. Introduced `sendErrorResponse` method for consistent error responses. [[1]](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309L49-L102) [[2]](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309L116-R126) [[3]](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309L289-R298) [[4]](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309L322-R340)

### Logging Enhancements:
* [`plugin-copilot/src/main/java/appland/copilotChat/copilot/CopilotChatSession.java`](diffhunk://#diff-712da6a7c8b148fb7569decfd27b8b2b9594306f540c5b235aa24a80933204f7R4): Added `UserLog` to log significant events such as loading models and sending chat requests. [[1]](diffhunk://#diff-712da6a7c8b148fb7569decfd27b8b2b9594306f540c5b235aa24a80933204f7R4) [[2]](diffhunk://#diff-712da6a7c8b148fb7569decfd27b8b2b9594306f540c5b235aa24a80933204f7R28-R45) [[3]](diffhunk://#diff-712da6a7c8b148fb7569decfd27b8b2b9594306f540c5b235aa24a80933204f7R70) [[4]](diffhunk://#diff-712da6a7c8b148fb7569decfd27b8b2b9594306f540c5b235aa24a80933204f7R81-R90) [[5]](diffhunk://#diff-712da6a7c8b148fb7569decfd27b8b2b9594306f540c5b235aa24a80933204f7L90-R100)
* [`plugin-copilot/src/main/java/appland/copilotChat/copilot/GitHubCopilotService.java`](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR6-R8): Implemented logging for content exclusions download and session creation. [[1]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR6-R8) [[2]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bL31-R33) [[3]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR49-R55) [[4]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR75) [[5]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR86) [[6]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR106) [[7]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bL140-R154) [[8]](diffhunk://#diff-5f5ef13a11b808355167a89e3b25e2600b08bcb61fc5e2217904c463cc7e631bR164)

### Code Refactoring:
* [`plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java`](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309L49-L102): Refactored `handleChatCompletions` to throw exceptions instead of returning responses directly, simplifying the method logic.

### Dependency Updates:
* [`plugin-copilot/src/main/java/appland/copilotChat/NavieCopilotChatRequestHandler.java`](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309R11-R16): Added new imports for `HttpRequests`, `ByteBufAllocator`, `ByteBufUtil`, and others to support the new functionality. [[1]](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309R11-R16) [[2]](diffhunk://#diff-befb6a04a2b70333c0d3a41e05d6eeb3d3a104a458ea79626e5fed8575eaf309R27)

### Additional Logging:
* [`plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java`](diffhunk://#diff-e4f5c05cbb0973f4c76566259c0c2924c79139141d82c069737443891c0eeaf1R10): Introduced `UserLog` for logging JSON-RPC events. [[1]](diffhunk://#diff-e4f5c05cbb0973f4c76566259c0c2924c79139141d82c069737443891c0eeaf1R10) [[2]](diffhunk://#diff-e4f5c05cbb0973f4c76566259c0c2924c79139141d82c069737443891c0eeaf1R93-R94) [[3]](diffhunk://#diff-e4f5c05cbb0973f4c76566259c0c2924c79139141d82c069737443891c0eeaf1R414-R415)