### PR TITLE
Verify against latest 2025.1, update build setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.intellij.platform") version "2.3.1-SNAPSHOT"
+    id("org.jetbrains.intellij.platform") version "2.3.0"
     id("org.jetbrains.changelog") version "1.3.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"

--- a/gradle-241.properties
+++ b/gradle-241.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.1
-copilotPluginVersion=1.5.38-241
+copilotPluginVersion=1.5.40-241

--- a/gradle-242.properties
+++ b/gradle-242.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.2
-copilotPluginVersion=1.5.38-241
+copilotPluginVersion=1.5.40-241

--- a/gradle-243.properties
+++ b/gradle-243.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.3.1
-copilotPluginVersion=1.5.38-243
+copilotPluginVersion=1.5.40-243

--- a/gradle-251.properties
+++ b/gradle-251.properties
@@ -1,2 +1,2 @@
-ideVersion=251.22821.72
-copilotPluginVersion=1.5.38-243
+ideVersion=251.23774.200
+copilotPluginVersion=1.5.40-243

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ untilBuild=251.*
 # fixme add 2025.1 as soon as this is solved: https://platform.jetbrains.com/t/plugin-verifier-fails-with-plugin-com-intellij-modules-json-not-declared-as-a-plugin-dependency/580/12
 ideVersionVerifier=IC-2024.1.7,IC-2024.3.3
 
+# https://mvnrepository.com/artifact/org.projectlombok/lombok
 lombokVersion=1.18.36
 
 kotlin.stdlib.default.dependency=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
Updates the build setup to use the latest available versions and to build against the current 2025.1 eap.

Updates
- 2025.1 eap version for the plugin verifier
- Gradle to 8.13
- Copilot plugin to 1.5.40, only used for testing

The intellij-platform Gradle plugin could not be updated due to https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1913