### PR TITLE
Build and verify against the final 2025.1 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                 os: [ ubuntu, windows, macos ]
                 include:
                     # Run tests with latest platform version, but only on Linux
-                    - platform_version: "243"
+                    - platform_version: "251"
                       os: ubuntu
 
         name: Test ${{ matrix.platform_version }} on ${{ matrix.os }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,14 +5,13 @@ import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
 import org.gradle.api.JavaVersion.VERSION_17
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.InstrumentCodeTask
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
 import org.jetbrains.kotlin.konan.properties.loadProperties
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 loadPlatformProperties()
 
@@ -30,7 +29,7 @@ plugins {
     idea
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.intellij.platform") version "2.3.0"
-    id("org.jetbrains.changelog") version "1.3.1"
+    id("org.jetbrains.changelog") version "2.2.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"
 
@@ -275,10 +274,11 @@ project(":") {
             }
 
             changeNotes.set(provider {
-                when {
-                    pluginVersionString.endsWith("-SNAPSHOT") -> changelog.getUnreleased().toHTML()
-                    else -> changelog.get(pluginVersionString).toHTML()
+                val item = when {
+                    pluginVersionString.endsWith("-SNAPSHOT") -> changelog.getUnreleased()
+                    else -> changelog.get(pluginVersionString)
                 }
+                changelog.renderItem(item.withHeader(false), Changelog.OutputType.HTML)
             })
         }
 

--- a/gradle-241.properties
+++ b/gradle-241.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.1
-copilotPluginVersion=1.5.40-241
+copilotPluginVersion=1.5.42-241

--- a/gradle-242.properties
+++ b/gradle-242.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.2
-copilotPluginVersion=1.5.40-241
+copilotPluginVersion=1.5.42-241

--- a/gradle-243.properties
+++ b/gradle-243.properties
@@ -1,2 +1,2 @@
 ideVersion=2024.3.1
-copilotPluginVersion=1.5.40-243
+copilotPluginVersion=1.5.42-243

--- a/gradle-251.properties
+++ b/gradle-251.properties
@@ -1,2 +1,2 @@
-ideVersion=251.23774.200
-copilotPluginVersion=1.5.40-243
+ideVersion=2025.1
+copilotPluginVersion=1.5.42-243

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,7 @@ sinceBuild=241.0
 untilBuild=251.*
 
 # run plugin verifier for the earliest and latest supported versions
-# fixme add 2025.1 as soon as this is solved: https://platform.jetbrains.com/t/plugin-verifier-fails-with-plugin-com-intellij-modules-json-not-declared-as-a-plugin-dependency/580/12
-ideVersionVerifier=IC-2024.1.7,IC-2024.3.3
+ideVersionVerifier=IC-2024.1.7,IC-2025.1
 
 # https://mvnrepository.com/artifact/org.projectlombok/lombok
 lombokVersion=1.18.36


### PR DESCRIPTION
- Update to 2025.1
- Build and verify against 2025.1 on CI
- Update version of the Copilot plugin