### PR TITLE
Update Gradle build setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -245,11 +245,11 @@ project(":") {
 
     dependencies {
         intellijPlatform {
-            pluginModule(implementation(project(":plugin-core")))
-            pluginModule(implementation(project(":plugin-gradle")))
-            pluginModule(implementation(project(":plugin-java")))
-            pluginModule(implementation(project(":plugin-maven")))
-            pluginModule(implementation(project(":plugin-copilot")))
+            pluginComposedModule(implementation(project(":plugin-core")))
+            pluginComposedModule(implementation(project(":plugin-gradle")))
+            pluginComposedModule(implementation(project(":plugin-java")))
+            pluginComposedModule(implementation(project(":plugin-maven")))
+            pluginComposedModule(implementation(project(":plugin-copilot")))
 
             // adding this for runIde support
             val copilotPluginVersion = prop("copilotPluginVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.InstrumentCodeTask
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
@@ -252,12 +251,9 @@ project(":") {
             pluginComposedModule(implementation(project(":plugin-copilot")))
 
             // adding this for runIde support
-            val copilotPluginVersion = prop("copilotPluginVersion")
-            if (copilotPluginVersion.isNotEmpty()) {
-                plugin("com.github.copilot", copilotPluginVersion)
-            }
+            compatiblePlugin("com.github.copilot")
 
-            pluginVerifier("1.384")
+            pluginVerifier()
             zipSigner()
         }
     }
@@ -428,10 +424,11 @@ project(":plugin-copilot") {
         implementation(project(":plugin-core"))
         implementation("com.knuddels:jtokkit:1.1.0")
 
-        // Unfortunately, we can't use the Copilot plugin in test mode. In test mode with version 1.5.30-231, it throws:
+        // Unfortunately, we can't use the Copilot plugin in test mode. In test mode with version 1.5.30-231,
+        // it throws an exception because the test service implementations are not included:
         //  java.lang.ClassNotFoundException: com.github.copilot.lang.agent.CopilotAgentProcessTestService
         /*intellijPlatform {
-            plugin("com.github.copilot", prop("copilotPluginVersion"))
+            compatiblePlugin("com.github.copilot")
         }*/
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,11 +244,17 @@ project(":") {
 
     dependencies {
         intellijPlatform {
-            pluginComposedModule(implementation(project(":plugin-core")))
+            // use pluginComposedModule when https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1971 is fixed
+            implementation(project(":plugin-core"))
+            implementation(project(":plugin-gradle"))
+            implementation(project(":plugin-java"))
+            implementation(project(":plugin-maven"))
+            implementation(project(":plugin-copilot"))
+            /*pluginComposedModule(implementation(project(":plugin-core")))
             pluginComposedModule(implementation(project(":plugin-gradle")))
             pluginComposedModule(implementation(project(":plugin-java")))
             pluginComposedModule(implementation(project(":plugin-maven")))
-            pluginComposedModule(implementation(project(":plugin-copilot")))
+            pluginComposedModule(implementation(project(":plugin-copilot")))*/
 
             // adding this for runIde support
             compatiblePlugin("com.github.copilot")

--- a/gradle-241.properties
+++ b/gradle-241.properties
@@ -1,2 +1,1 @@
 ideVersion=2024.1
-copilotPluginVersion=1.5.47-241

--- a/gradle-242.properties
+++ b/gradle-242.properties
@@ -1,2 +1,1 @@
 ideVersion=2024.2
-copilotPluginVersion=1.5.47-241

--- a/gradle-243.properties
+++ b/gradle-243.properties
@@ -1,2 +1,1 @@
 ideVersion=2024.3.1
-copilotPluginVersion=1.5.47-243

--- a/gradle-251.properties
+++ b/gradle-251.properties
@@ -1,2 +1,1 @@
 ideVersion=2025.1
-copilotPluginVersion=1.5.47-243

--- a/gradle-252.properties
+++ b/gradle-252.properties
@@ -1,2 +1,1 @@
-ideVersion=252.23309.22
-copilotPluginVersion=1.5.47-243
+ideVersion=252.23591.19


### PR DESCRIPTION
Unfortunately, we have to use the current snapshot of gradle-intellij-platform-plugin until it has a new stable release. The plugin introduced a breaking change and we have to adapt to fix our build setup.

Also, this PR is adding a workaround for https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1971

It removes the fixed version of the plugin verifier, because the latest available version is now showing the bugs we experienced anymore.

The change to automatically fetch the latest Copilot plugin is unrelated, but helpful.