### PR TITLE
Revert "chore: install JetBrains JDK"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Setup Java
               uses: actions/setup-java@v4
               with:
-                  distribution: jetbrains
+                  distribution: temurin
                   java-version: ${{ env.JAVA_VERSION }}
 
             - name: Setup Gradle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Setup Java
               uses: actions/setup-java@v4
               with:
-                  distribution: jetbrains
+                  distribution: temurin
                   java-version: 21
 
             - name: Setup Gradle


### PR DESCRIPTION
This reverts commit b1837960e68114a55ce8aa7c486fc039d9df87dc.

JetBrains JDK doesn't seem to work with setup-java at the moment:
```
Run actions/setup-java@v4
  with:
    distribution: jetbrains
    java-version: 21
    java-package: jdk
    check-latest: false
    server-id: github
    server-username: GITHUB_ACTOR
    server-password: GITHUB_TOKEN
    overwrite-settings: true
    job-status: success
    token: ***
  env:
    GITHUB_TOKEN: ***
    JAVA_VERSION: 21
Installed distributions
  Trying to resolve the latest version from remote
  Error: Could not find satisfied version for SemVer '21'. 
  Available versions: 11_0_10b1145.115 (11.0.10+1145.115)
```