### PR TITLE
Reposition Marketplace description around runtime data and MCP

### DIFF
--- a/description.md
+++ b/description.md
@@ -10,7 +10,7 @@ People see the map. Agents query the trace. One run, same ground truth.
 
 ## Why developers use it
 
--   **Review behavior, not just diffs.** See what an AI-generated change actually did at runtime before you open the PR.
+-   **A visual check on your AI's work.** On complex changes the diff outgrows what anyone can hold in their head. AppMap shows what the change actually did at runtime, so your approval rests on evidence, not on the AI's own explanation.
 -   **Debug in one query, not fifteen greps.** The request path, the SQL, and the exception are one trace away, for you and your agent.
 -   **Give your agent ground truth.** Answers from real execution over MCP, not guesses from static code.
 

--- a/description.md
+++ b/description.md
@@ -4,9 +4,15 @@
 
 **Live code behavior, for your eyes and your AI tools, in your JetBrains IDE.**
 
-AppMap records how your application actually runs, with zero code changes. It turns every run into interactive sequence diagrams, dependency maps, flame graphs, and trace views you can read, and makes the same runtime data available to any AI coding agent through the Model Context Protocol (MCP). Your agent can query real execution traces instead of guessing from static code.
+AppMap records how your application actually runs, with zero code changes. Every run becomes interactive sequence diagrams, dependency maps, flame graphs, and trace views. The same runtime data is available to any AI coding agent through the Model Context Protocol (MCP). Your agent can query real execution traces instead of guessing from static code.
 
 People see the map. Agents query the trace. One run, same ground truth.
+
+## Why developers use it
+
+-   **Review behavior, not just diffs.** See what an AI-generated change actually did at runtime before you open the PR.
+-   **Debug in one query, not fifteen greps.** The request path, the SQL, and the exception are one trace away, for you and your agent.
+-   **Give your agent ground truth.** Answers from real execution over MCP, not guesses from static code.
 
 ## Works with any AI coding agent via MCP
 
@@ -47,4 +53,4 @@ Get started:
 
 Open source | [Terms and conditions](https://appmap.io/community/terms-and-conditions.html) | [Security disclosure](https://appmap.io/security)
 
-AppMap is free for every developer and for organizations under 250 employees. Larger organizations standardizing on AppMap are supported with a [support contract](https://appmap.io/pricing).
+This extension is for individual developers working in the code editor. Check out the [pricing page](https://appmap.io/pricing).

--- a/description.md
+++ b/description.md
@@ -30,15 +30,15 @@ Get started:
 
 ## Ways to use AppMap with your AI
 
--   **Explain unfamiliar code.** Ask your agent how a feature actually works. It answers from recorded requests, SQL, and call trees instead of guessing from file names.
--   **Diagnose bugs in one query.** A single call tree query returns the diagnosis-bearing frames, with captured parameters and return values, that a static agent reconstructs with about fifteen grep-and-read calls.
--   **Review changes against reality.** Record the same flows on your base branch and your PR branch, then compare: sequence diagram diffs and compare reports show what the change actually did, including side effects the code diff never showed.
--   **Scan for behavioral defects.** AppMap's built-in code scanners are a behavioral check for structural code quality defects, the kind static analysis misses and AIs reading source cannot see: N+1 queries, missing authentication, secrets in logs, slow queries. Findings appear right in the IDE.
--   **Document APIs from behavior.** Generate OpenAPI definitions from observed HTTP traffic instead of hand-written annotations.
+-   **Explain unfamiliar code.** Ask your agent how a feature works. It answers from recorded requests, SQL queries, and call trees.
+-   **Diagnose bugs.** A call tree query returns the executed frames for the flow under investigation, with captured parameters and return values.
+-   **Compare before and after.** Record the same flows on your base branch and your PR branch; sequence diagram diffs and compare reports show extra calls, changed SQL, and new downstream dependencies.
+-   **Scan for behavioral defects.** The built-in code scanners check recorded behavior for structural code quality defects, as distinct from static defects: N+1 queries, missing authentication, secrets in logs, slow queries. Findings appear in the IDE.
+-   **Generate OpenAPI definitions** from observed HTTP traffic.
 
-### What runtime context is worth
+### The cost, measured
 
-In a controlled AppMap study (June 2026), an agent with trace access held 100% diagnostic accuracy under a tight tool-call budget, while the static-context agent fell from 91% to 28% as the budget tightened. Pairing a compact model with trace data delivered near-frontier accuracy at about half the cost. And recording costs zero model tokens: the running application produces the data.
+A controlled AppMap study (June 2026) compared trace-augmented and static agents on the same bugs and the same models. The trace-augmented agent held 100% diagnostic accuracy as the tool-call budget tightened to three calls; the static agent fell from 91% to 28%. One call tree query returned the frames that the static agent reconstructed with about fifteen file-reading calls. A compact model paired with trace data reached 88% verified fixes at $0.57 per fix; a frontier model without traces reached 95% at $1.16. Recording a trace consumes no model tokens; the running application produces it.
 
 ## See what your code actually does
 

--- a/description.md
+++ b/description.md
@@ -1,188 +1,50 @@
-# Runtime-aware AI starts here
+# AppMap for JetBrains
 
-### Live code behavior, surfaced to your AI tools in your JetBrains IDE
+## Runtime-aware AI starts here
 
-AppMap Navie for JetBrains brings the power of real-time execution data and AI-driven insights right to your code editor. No more guessing what your code does under the hood. Navie watches your application run and uses that live context to provide **smarter suggestions**, **faster debugging**, and **runtime-aware code reviews**.
+**Live code behavior, for your eyes and your AI tools, in your JetBrains IDE.**
 
-## Key Benefits
+AppMap records how your application actually runs, with zero code changes. It turns every run into interactive sequence diagrams, dependency maps, flame graphs, and trace views you can read, and makes the same runtime data available to any AI coding agent through the Model Context Protocol (MCP). Your agent can query real execution traces instead of guessing from static code.
 
-### Smarter AI assistance
+People see the map. Agents query the trace. One run, same ground truth.
 
-Navie combines static analysis with live AppMap traces, so you can ask things like _"What just happened?"_ and get answers based on the actual runtime flow, HTTP calls, SQL queries, exceptions, I/O, and more.
+## Works with any AI coding agent via MCP
 
-### Faster debugging & fewer defects
+AppMap includes an MCP server that exposes your recorded runtime data as read-only query tools. Any MCP-capable coding agent can connect and ask how your application actually ran. Which endpoints are slow. Where time is spent. What SQL was issued. What exceptions occurred. How a single request executed end to end.
 
-Pinpoint performance bottlenecks and logic errors through automatically generated sequence diagrams, flame graphs, dependency maps, and trace views.
+The plugin keeps the query index up to date automatically as you record. Point your agent at the server and start asking questions.
 
-### Context-aware code reviews
+Agents can rank function and SQL hotspots, inspect call trees with captured parameters and return values, find related recordings, and compare per-route latency between git branches.
 
-From security checks to maintainability recommendations, Navie’s `@review` mode analyzes your current branch changes against your base branch with runtime insights.
+Get started:
 
-### Zero fine-tuning required
+-   [Configure the AppMap MCP server for any AI coding agent](https://appmap.io/docs/reference/appmap-mcp.html)
+-   [AppMap for JetBrains reference](https://appmap.io/docs/reference/jetbrains.html)
+-   [Record AppMap Data](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html)
 
-Works out-of-the-box with enterprise-ready LLMs—simply plug in your API key or let Navie default to GitHub Copilot or AppMap’s built-in endpoint.
+## See what your code actually does
 
-## What AppMap Does
+-   **Sequence diagrams** show the full request path, from HTTP to database, from one recording.
+-   **Dependency maps** reveal the running architecture: services, code, SQL, and how they connect.
+-   **Flame graphs and trace views** pinpoint performance bottlenecks and logic errors.
+-   **Zero effort capture.** AppMap records code execution, data flow, HTTP, SQL, and exceptions automatically as your tests or your app run. No code changes.
+
+## What AppMap does
 
 -   Captures real-time snapshots of code execution, data flow, and behavior with zero effort and no code changes.
+-   Renders that behavior as interactive diagrams people can inspect in the IDE.
+-   Feeds the same runtime context to any MCP-capable AI assistant, hosted or local.
+-   Grounds explanations, reviews, and fixes in what your application just did, not in guesses from static code.
 
--   Feeds runtime context to AI assistants like Navie, GitHub Copilot, Anthropic Claude, Google Gemini, OpenAI, and your own local LLMs.
+## Get started
 
--   Delivers deep code explanations, diagrams, implementation plans, tests, and patch-ready code snippets, all grounded in what your application just did.
-
-## Requirements and Use
-
-**2023.1** and newer JetBrains IDEs are required to use this plugin.
-
-AppMap works best\* with the following:
-
--   **Languages:** Java, Kotlin, Python, Ruby, and Node.js (TypeScript and JavaScript).
--   **Frameworks:** Spring, Django, Flask, Ruby on Rails, Nest.js, Next.js, and Express.
-
-Refer to AppMap documentation for the latest information on supported languages, frameworks, and versions.
-
-[*] AppMap Navie is designed to work with a wide range of languages and frameworks, but AppMap trace recording requires a language-specific library.
-
-## Get Started
-
-1. **Install [the AppMap Plugin](https://plugins.jetbrains.com/plugin/16701-appmap)** from within the code editor or
-   from the marketplace.
-
-2. **Sign in** using an email address to obtain a license key and activate AppMap. It's best to use your work email, so
-   that your license can be easily associated with your organization subscription.
-
-3. **Ask Navie** for assistance with the project you're working on. Use the `@help` command to get help with AppMap and
-   Navie itself.
-
-## Examples
-
-[Here are some examples](https://appmap.io/product/examples/navie) of Navie providing code explanations, diagrams,
-specifications, documentation,
-and reasoning about a broad context of mature application code.
-
-## Command Modes
-
-Navie provides different command modes to assist you with your code and project. Here's a quick overview:
-
--   **`@explain` (default)**: Provides context-aware suggestions, specific solutions, and reasons about the
-    larger context of the specific code being worked on.
-
--   **`@diagram`**: Creates and renders Mermaid compatible diagrams within the Navie UI. You can open
-    a diagram in the [Mermaid Live Editor](https://mermaid.live), copy the Mermaid Definitions to your clipboard, save
-    to disk, or expand a full window view.
-
--   **`@plan`**: Builds a detailed implementation plan for an issue or task. This will focus Navie on only understanding
-    the problem and the application to generate a step-by-step plan.
-
--   **`@generate`**: In this mode, responses are optimized to include code snippets and patches that you can apply
-    directly to the files you're working on.
-
--   **`@test`**: Provides output optimized for creating and updating test cases. Supports both unit tests and integration
-    tests. Test updates will confirm to the existing structure and patterns of your test cases, and will provide updated
-    tests based on features or code that is provided.
-
--   **`@search`**: Leverages smart search capabilities to locate specific functions, files, modules, and examples.
-
--   **`@review`**: Performs a review of the code changes on your current branch against the base branch. Provides
-    actionable insights on important aspects of the code, ensuring alignment with best practices in areas such as code
-    quality, security, and maintainability.
-
--   **`@help`**: Offers assistance with using AppMap and Navie, including guidance for generating and leveraging AppMap
-    data effectively.
-
-## Activating Navie
-
-**Activate Navie from the Tools menu**  
-Select 'Explain with AppMap Navie AI' from the Tools/AppMap dropdown
-
-![Open Navie from Tools](https://appmap.io/assets/img/product/tools-appmap-vscode.png)
-
-**Activate Navie from the AppMap sidebar**  
-Click the 'New Navie Chat' button
-
-![New Navie Chat](https://appmap.io/assets/img/product/new-navie-chat.png)
-
-## Add Files to a Navie chat
-
-You can add specific files to your conversation with Navie. This feature is referred to
-as "pinning". Some types of files you may want to pin include:
-
--   Issue description
--   Custom prompts
--   Code files
--   Navie chat responses from previous conversations
-
-**Pin files from the file list**  
-Right-click on a file to select 'AppMap: Add Files to Navie Context'
-
-![Add context from file](https://appmap.io/assets/img/product/add-context-from-file.png)
-
-**Pin files from a Navie response**  
-Click the pin icon in the header of a Navie response
-
-![Pin from Response](https://appmap.io/assets/img/pin-from-response.png)
-
-**Pin files from the Navie's Context Sources Pane**  
-Click the 'Add Context' button
-
-![Add context from the context window](https://appmap.io/assets/img/product/add-context-in-context-window.png)
-
-## Choosing your LLM for Navie
-
-By default, if you have the GitHub Copilot plugin installed, and you have an active Copilot subscription, Navie will use
-the GitHub Copilot LLM. Otherwise, Navie will default to an OpenAI LLM endpoint provided by AppMap.
-
-You can also configure Navie to use your own LLM API key, or to use a local model. Refer to
-the [AppMap Navie documentation](https://appmap.io/docs/navie/bring-your-own-model.html) for details on how to do that.
-
-## Recording AppMap Data
-
-AppMap data brings two benefits to your development workflow:
-
-1. **Runtime diagrams:** You can directly use the AppMap diagrams to understand the runtime behavior of your
-   application.
-2. **Improved context for Navie AI:** Navie will leverage available AppMap data to provide more accurate and relevant
-   answers.
-
-You record AppMap data by running your app — either
-by [running test cases](https://appmap.io/docs/recording-methods.html#recording-test-cases), or
-by [recording a short interaction with your app](https://appmap.io/docs/recording-methods.html#remote-recording).
-
-Navie can assistance with making AppMap data. Use the `@help` command for this.
-
-In IntelliJ, you can record AppMap data using the "Start with AppMap" menu item. [Visit the documentation](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html) for other languages or more details.
-
-![Start with AppMap](https://appmap.io/assets/img/product/start-with-appmap.png)
-
-#### Requirements for Making AppMap Data
-
-Supported programming languages: Node.js, Java (+ Kotlin), Ruby, and Python.
-AppMap works particularly well with web application frameworks such as: Nest.js, Next.js, Spring, Ruby on Rails, Django,
-and Flask.
-
-## Using AppMap Data
-
-AppMap diagrams include:
-
--   **Sequence Diagram** to follow the runtime flow of calls made by your application.
--   **Dependency Map** to see which libraries and frameworks were used at runtime.
--   **Flame Graph** to spot performance issues and bottlenecks.
--   **Trace View** to perform detailed function call and data flow tracing.
-
-Using AppMap data, Navie gains deeper knowledge of runtime aspects of code behavior, such as:
-
--   HTTP requests and responses
--   SQL queries
--   Timing data
--   Exceptions
--   I/O operations
+1. **Install the AppMap plugin** from the JetBrains Marketplace.
+2. **Sign in with an email address, or with GitHub or GitLab.** Guided setup configures the recording agent for your project (Java, Python, Ruby, Node.js).
+3. **Run your tests or exercise your app.** AppMap Data is recorded automatically, diagrams appear in the IDE, and the query index stays fresh for your AI agent.
+4. **Connect your agent** using the [MCP configuration guide](https://appmap.io/docs/reference/appmap-mcp.html).
 
 ## Licensing and Security
 
-[Open source MIT license](https://github.com/getappmap/appmap-intellij-plugin/blob/develop/LICENSE) | [Terms and conditions](https://appmap.io/community/terms-and-conditions.html)
+Open source | [Terms and conditions](https://appmap.io/community/terms-and-conditions.html) | [Security disclosure](https://appmap.io/security)
 
-To learn more about security of AppMap, or the use of data with AI when using Navie, see the
-AppMap [security disclosure](https://appmap.io/security) for more detailed information and discussion.
-
-There is [no fee](https://appmap.io/pricing) for personal use of AppMap for graphing and limited Navie use. Pricing for
-premium features and integrations are listed on [AppMap’s Pricing Page](https://appmap.io/pricing).
+AppMap is free for every developer and for organizations under 250 employees. Larger organizations standardizing on AppMap are supported with a [support contract](https://appmap.io/pricing).

--- a/description.md
+++ b/description.md
@@ -28,6 +28,18 @@ Get started:
 -   [AppMap for JetBrains reference](https://appmap.io/docs/reference/jetbrains.html)
 -   [Record AppMap Data](https://appmap.io/docs/get-started-with-appmap/making-appmap-data.html)
 
+## Ways to use AppMap with your AI
+
+-   **Explain unfamiliar code.** Ask your agent how a feature actually works. It answers from recorded requests, SQL, and call trees instead of guessing from file names.
+-   **Diagnose bugs in one query.** A single call tree query returns the diagnosis-bearing frames, with captured parameters and return values, that a static agent reconstructs with about fifteen grep-and-read calls.
+-   **Review changes against reality.** Record the same flows on your base branch and your PR branch, then compare: sequence diagram diffs and compare reports show what the change actually did, including side effects the code diff never showed.
+-   **Scan for behavioral defects.** AppMap's built-in code scanners are a behavioral check for structural code quality defects, the kind static analysis misses and AIs reading source cannot see: N+1 queries, missing authentication, secrets in logs, slow queries. Findings appear right in the IDE.
+-   **Document APIs from behavior.** Generate OpenAPI definitions from observed HTTP traffic instead of hand-written annotations.
+
+### What runtime context is worth
+
+In a controlled AppMap study (June 2026), an agent with trace access held 100% diagnostic accuracy under a tight tool-call budget, while the static-context agent fell from 91% to 28% as the budget tightened. Pairing a compact model with trace data delivered near-frontier accuracy at about half the cost. And recording costs zero model tokens: the running application produces the data.
+
 ## See what your code actually does
 
 -   **Sequence diagrams** show the full request path, from HTTP to database, from one recording.


### PR DESCRIPTION
Rewrites `description.md`, the source of the JetBrains Marketplace listing, to the new positioning: recorded runtime behavior serving both interactive diagrams (for people) and MCP query tools (for AI coding agents).

**Rendered preview:** [description.md on this branch](https://github.com/getappmap/appmap-intellij-plugin/blob/claude/appmap-extension-descriptions-qj4u4t/description.md)

## What changed

- Keeps the "Runtime-aware AI starts here" opening; adds the "Why developers use it", "Works with any AI coding agent via MCP", and "Ways to use AppMap with your AI" sections (usage patterns, behavioral code scanners, OpenAPI generation) plus "The cost, measured" (June 2026 controlled-study results); promotes the visual identity into its own "See what your code actually does" section; removes retired assistant branding and the command-modes catalog (docs remain the home for those commands); replaces the pricing block with the individual-developer scope statement and a pricing page link. No em-dashes in user-facing copy.
- Interop name-checks are reduced to "any MCP-capable agent" phrasing in this listing, per the rewrite doc; the VS Code listing keeps the agent names where they carry search weight.
- The plugin display name is unchanged, and `<change-notes>` is untouched — the changelog entry is gated on release timing and the title rename is a separate decision.
- The listing's screenshots of the retired chat interface were dropped with their sections. A new capture of an MCP agent calling `get_call_tree` is assigned separately and lands in a follow-up PR; this PR ships text-first.

## Notes on mechanism and risk

- No plugin.xml/CDATA editing was needed: the Gradle build renders `description.md` to HTML at build time (`build.gradle.kts` `patchPluginXml`), so the malformed-CDATA risk called out in the rewrite doc does not apply. The Verify Plugin CI job (which exercises that rendering) passed on the initial copy commit.
- The stale "2023.1 and newer" requirement is gone with the old copy (current builds target 2025.1+ / sinceBuild 251).
- Bundled-CLI verification passed: `appmap query mcp` shipped in `@appland/appmap` v3.200.0, which the `release-manifests` manifest currently serves; the plugin downloads the CLI from that manifest, so MCP is already available to existing installs.

## CI status

Per team guidance, CI is not required for extension doc-only changes. All test jobs and Verify Plugin passed on the substantive copy; later commits are wording-only.

## Before merging

- Confirm the docs URLs are live: `/docs/reference/appmap-mcp.html`, `/docs/reference/jetbrains.html`, and `/docs/get-started-with-appmap/making-appmap-data.html`.
- **This listing and the VS Code listing (getappmap/vscode-appland#1113) must be updated in tandem going forward.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ABtRpfafUxEJemZN5wUbN