### PR TITLE
CI: cache IntelliJ IDEs, simplify the platform matrix, re-enable the Gradle cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,13 @@ jobs:
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v5
               with:
-                  cache-disabled: true
+                  # Exclude the IntelliJ Platform IDE distributions from the Gradle cache. They are
+                  # cached separately (intellijPlatform.caching.ides -> .intellijPlatform/ides, via the
+                  # actions/cache steps below). On a warm IDE cache the ZIP is never downloaded; this
+                  # also keeps a cold run's ~1 GB ZIP out of the Gradle cache, deterministically,
+                  # rather than relying on cache-cleanup to prune it on a subsequent run. Covers both
+                  # ideaIC (Community/251) and ideaIU (Ultimate/262).
+                  gradle-home-cache-excludes: caches/modules-2/files-2.1/com.jetbrains.intellij.idea
 
             # Restore cached AppMap/Scanner test binaries from previous runs using restore-keys.
             # We explicitly use actions/cache/restore (instead of actions/cache) to decouple

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,7 @@ jobs:
                 platform_version: [ "251" ]
                 os: [ ubuntu, windows, macos ]
                 include:
-                    - platform_version: "261"  # latest released version
-                      os: ubuntu
-                    - platform_version: "262"  # latest EAP version
+                    - platform_version: "262"  # latest released version
                       os: ubuntu
 
         name: Test ${{ matrix.platform_version }} on ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,13 @@ jobs:
                   distribution: jetbrains
                   java-version: ${{ env.JAVA_VERSION }}
 
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v5
+              with:
+                  # Same IDE-artifact exclusion as the test job: IDEs are cached separately
+                  # (.intellijPlatform/ides), so keep them out of the Gradle dependency cache.
+                  gradle-home-cache-excludes: caches/modules-2/files-2.1/com.jetbrains.intellij.idea
+
             - name: Set development version
               shell: bash
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,10 +146,9 @@ jobs:
         needs: [test]
         timeout-minutes: 45
         steps:
-            - name: Free Disk Space
-              uses: insightsengineering/disk-space-reclaimer@dae9fabcb8febe09f6585471948acf9dc9a57489 # v1.1.2
-              with:
-                  swap-storage: false
+            - name: Show Available Disk Space
+              shell: bash
+              run: df -h
 
             - name: Fetch Sources
               uses: actions/checkout@v6
@@ -198,3 +197,8 @@ jobs:
                   name: plugin-distribution
                   path: build/distributions/intellij-appmap-*.zip
                   archive: false
+
+            - name: Show Available Disk Space
+              if: always()
+              shell: bash
+              run: df -h

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,17 @@ jobs:
                   key: appmap-test-binaries-${{ runner.os }}-initial
                   restore-keys: appmap-test-binaries-${{ runner.os }}-
 
+            # Restore the IntelliJ Platform IDE. It is resolved as an OS-agnostic cross-platform
+            # ZIP (useInstaller = false) and cached in .intellijPlatform/ides, so a single entry
+            # per version is shared across all OS runners -- the key intentionally omits runner.os.
+            # Decoupled restore/save (like the AppMap binaries cache) lets us save only on a miss.
+            - name: Restore IntelliJ IDE cache
+              id: restore-ide-cache
+              uses: actions/cache/restore@v5
+              with:
+                  path: .intellijPlatform/ides
+                  key: intellij-ide-${{ matrix.platform_version }}-${{ hashFiles(format('gradle-{0}.properties', matrix.platform_version)) }}
+
             # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
             - name: Show GitHub Actions rate limit
               shell: bash
@@ -96,6 +107,21 @@ jobs:
                   path: ~/.cache/appmap-test
                   key: appmap-test-binaries-${{ runner.os }}-${{ steps.clean-cache.outputs.cache_hash }}
 
+            # Save the IDE cache only when this run downloaded a new IDE (restore missed).
+            # GitHub caches are immutable and the ZIP is large, so re-saving on a hit is pure churn.
+            # The product-info.json guard ensures we only cache a fully-extracted IDE: it is absent
+            # if the build failed before IDE resolution or the download/extract failed, which would
+            # otherwise poison the immutable key with an empty/partial entry. always() (rather than
+            # success()) still caches a valid IDE when tests fail *after* it was resolved.
+            # Parallel matrix jobs sharing a key may race to save first; the loser's 409 is benign.
+            - name: Save IntelliJ IDE cache
+              if: always() && steps.restore-ide-cache.outputs.cache-hit != 'true' && hashFiles('.intellijPlatform/ides/*/product-info.json') != ''
+              continue-on-error: true
+              uses: actions/cache/save@v5
+              with:
+                  path: .intellijPlatform/ides
+                  key: intellij-ide-${{ matrix.platform_version }}-${{ hashFiles(format('gradle-{0}.properties', matrix.platform_version)) }}
+
             - name: Save AppMaps
               uses: actions/cache/save@v5
               if: runner.os == 'Linux' && matrix.platform_version == '251'
@@ -135,6 +161,22 @@ jobs:
               run: |
                   VERSION=$(git describe --tags --always | sed 's/^v//')
                   sed -i "s/^pluginVersion=.*/pluginVersion=$VERSION/" gradle.properties
+
+            # Restore the OS-agnostic IDE caches populated by the test jobs. This job needs both
+            # the 251 and 262 IDEs (to build the distribution and run the verifier against each).
+            # Restore-only: the test jobs own the save. Both restore into the same managed cache
+            # directory; each IDE lives in its own <type>-<version> subdir, so they coexist.
+            - name: Restore IntelliJ IDE cache (251)
+              uses: actions/cache/restore@v5
+              with:
+                  path: .intellijPlatform/ides
+                  key: intellij-ide-251-${{ hashFiles('gradle-251.properties') }}
+
+            - name: Restore IntelliJ IDE cache (262)
+              uses: actions/cache/restore@v5
+              with:
+                  path: .intellijPlatform/ides
+                  key: intellij-ide-262-${{ hashFiles('gradle-262.properties') }}
 
             - name: Verify Plugin Structure
               shell: bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,10 +89,14 @@ allprojects {
     val testOutput = configurations.create("testOutput")
     dependencies {
         intellijPlatform {
-            // 2025.3 is only available as a unified build
+            // Use the cross-platform (multi-OS) ZIP distribution instead of the OS-specific
+            // installer, so the downloaded IDE can be cached once and shared across all OS
+            // runners. The ZIP bundles no JBR; tests run on the environment JDK (setup-java
+            // on CI, system JDK locally).
             when {
-                platformVersion >= 253 -> intellijIdea(ideVersion)
-                else -> intellijIdeaCommunity(ideVersion)
+                // 2025.3+ is only available as a unified build
+                platformVersion >= 253 -> intellijIdea(ideVersion) { useInstaller = false }
+                else -> intellijIdeaCommunity(ideVersion) { useInstaller = false }
             }
 
             // using "Bundled" to gain access to the Java plugin's test classes
@@ -337,8 +341,12 @@ project(":") {
                 // verifier reuses the same cached IDEs instead of resolving "latest in range".
                 // Versions come from gradle-<platform>.properties (single source of truth,
                 // shared with the build platform) via ideVersionFor().
-                create(IntelliJPlatformType.IntellijIdeaCommunity, ideVersionFor(251)) // earliest supported
-                create(IntelliJPlatformType.IntellijIdea, ideVersionFor(262))          // latest released
+                create(IntelliJPlatformType.IntellijIdeaCommunity, ideVersionFor(251)) {
+                    useInstaller = false // earliest supported; ZIP to reuse the build's cached IDE
+                }
+                create(IntelliJPlatformType.IntellijIdea, ideVersionFor(262)) {
+                    useInstaller = false // latest released; ZIP to reuse the build's cached IDE
+                }
             }
 
             failureLevel.set(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,6 +152,17 @@ allprojects {
 
     intellijPlatform {
         instrumentCode = false
+
+        // Cache extracted IDE distributions in a stable, OS-agnostic directory
+        // (.intellijPlatform/ides/<type>-<version>) instead of relying solely on
+        // Gradle's transform cache. This lets CI restore the IDE across runs and
+        // share a single cache entry across OS runners for a given version (the ZIP
+        // is OS-agnostic). See the IDE cache steps in .github/workflows/build.yml.
+        caching {
+            ides {
+                enabled = true
+            }
+        }
     }
 
     val jvmVersion = when {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -333,18 +333,12 @@ project(":") {
 
         pluginVerification {
             ides {
-                // earliest supported major version
-                select {
-                    sinceBuild = "251"
-                    untilBuild = "251.*"
-                    types.set(listOf(IntelliJPlatformType.IntellijIdeaCommunity))
-                }
-
-                select {
-                    sinceBuild = "262"
-                    untilBuild = "262.*"
-                    types.set(listOf(IntelliJPlatformType.IntellijIdea))
-                }
+                // Verify against the exact IDE builds used for compilation and tests, so the
+                // verifier reuses the same cached IDEs instead of resolving "latest in range".
+                // Versions come from gradle-<platform>.properties (single source of truth,
+                // shared with the build platform) via ideVersionFor().
+                create(IntelliJPlatformType.IntellijIdeaCommunity, ideVersionFor(251)) // earliest supported
+                create(IntelliJPlatformType.IntellijIdea, ideVersionFor(262))          // latest released
             }
 
             failureLevel.set(
@@ -546,6 +540,14 @@ fun String.renderMarkdown(): String {
 fun prop(name: String): String {
     return extra.properties[name] as? String ?: error("Property `$name` is not defined in gradle.properties")
 }
+
+// Reads the `ideVersion` for a specific platform from its gradle-<platform>.properties file.
+// This is the single source of truth shared between the build platform (loadPlatformProperties)
+// and the plugin verifier, so the verifier reuses the exact same cached IDE builds.
+fun ideVersionFor(platform: Int): String =
+    loadProperties(rootDir.resolve("gradle-$platform.properties").toString())
+        .getProperty("ideVersion")
+        ?: error("`ideVersion` is not defined in gradle-$platform.properties")
 
 fun loadPlatformProperties() {
     val platformVersion = prop("platformVersion").toInt()

--- a/gradle-261.properties
+++ b/gradle-261.properties
@@ -1,1 +1,0 @@
-ideVersion=2026.1.3

--- a/gradle-262.properties
+++ b/gradle-262.properties
@@ -1,1 +1,1 @@
-ideVersion=262.8377.35
+ideVersion=2026.2.0.1


### PR DESCRIPTION
## Summary

Speeds up CI by caching the IntelliJ Platform IDE distributions across runs and
runners, and re-enables the Gradle dependency cache that was previously disabled
to save disk. Along the way the platform matrix is trimmed and the plugin
verifier is pinned to the exact IDE builds we compile/test against.

Net effect: the large IDE distributions are downloaded once per version and
reused everywhere (test matrix + verifier), instead of every job re-downloading
a full IDE on every run.

## Background

The Gradle cache was disabled (`cache-disabled: true`, commit 35e3f950) because
CI ran out of disk: the OS-specific IDE **installer** was extracted into Gradle's
cached `transforms/` directory and bloated the Gradle User Home cache. This PR
removes the root cause and then re-enables the cache.

## Changes (one concern per commit)

1. **Drop the 261 test target, bump 262 to the released build.**
   261 is no longer a needed compatibility target. 262 has graduated from EAP,
   so it is pinned to the released `2026.2.0.1` (build `262.8665.337`) instead of
   an EAP snapshot build number — a stable, immutable artifact.

2. **Pin the plugin verifier IDEs to the build platform versions.**
   Replaces the verifier's "latest build in `251.*`/`262.*`" range selection with
   exact version pins read from `gradle-<platform>.properties` via a new
   `ideVersionFor()` helper. Those files are now the single source of truth for
   both the build platform and the verifier, so they cannot desync. This makes
   verification deterministic (verify exactly what we built) and lets the verifier
   reuse the same cached IDEs as the test matrix.

3. **Resolve IDEs as the cross-platform ZIP instead of the OS-specific installer.**
   Sets `useInstaller = false` for both the build/test platform and the verifier.
   The multi-OS ZIP is OS-agnostic, so a single extracted IDE can be cached once
   and shared across the Linux/Windows/macOS runners. The ZIP bundles no JetBrains
   Runtime; tests run on the JDK provided by the environment (`setup-java` on CI),
   matching how the 262 EAP leg already resolved a ZIP.

4. **Cache the IDE distributions across runs and runners.**
   Enables the plugin's managed IDE cache (`intellijPlatform.caching.ides`) so
   extracted IDEs live in `.intellijPlatform/ides/<type>-<version>`, and adds
   `actions/cache` steps to persist that directory. Because the IDE is now an
   OS-agnostic ZIP, the cache key is keyed on the platform version alone (hash of
   `gradle-<version>.properties`), **not** `runner.os` — so one entry per version
   is shared across all runners. Restore/save are decoupled (like the AppMap
   binaries cache): test jobs save only on a miss, and the verify job restores
   both the 251 and 262 entries read-only, reusing what the test jobs produced
   instead of re-downloading IDEs on the disk-constrained verifier runner.

5. **Re-enable the Gradle dependency cache.**
   Removes `cache-disabled: true`. The original disk-bloat cause is gone: IDEs are
   unpacked into the separately-cached managed directory, not Gradle's transforms
   cache. To keep the ~1 GB IDE ZIP out of the Gradle cache entirely, the IntelliJ
   Platform artifacts (`com.jetbrains.intellij.idea`) are excluded from it via
   `gradle-home-cache-excludes` — they are cached separately as the unpacked
   managed IDE directory. On a warm IDE cache the ZIP is never downloaded; on a
   cold run (version bump or eviction) it is downloaded but not saved into the
   Gradle cache. So the Gradle cache deterministically holds only dependency jars,
   rather than depending on `cache-cleanup` to prune the ZIP on a later run.

6. **Drop the disk-space reclaimer from the verify job.**
   Removes the `insightsengineering/disk-space-reclaimer` step, which aggressively
   deleted preinstalled runner tooling to free space. It is no longer needed: the
   runners are larger now, and the verify job restores IDEs from cache (unpacked
   ZIPs in the managed directory) instead of re-downloading full installers, so
   peak disk usage is much lower. Adds `df -h` steps at the start and end of the
   job (mirroring the test job) so disk headroom stays visible without the
   reclaimer as a safety net.

7. **Cache Gradle dependencies in the verify job.**
   The verify job invoked `./gradlew` directly without the `setup-gradle` action,
   so it re-downloaded all dependencies on every run. Adds `setup-gradle` (with the
   same IDE-artifact exclusion) so it reuses the Gradle dependency cache like the
   test job.

## Local validation

Verified on Linux with the 251 leg (probes against fresh Gradle homes, so results
generalize to a cold CI runner):

- ZIP + system JDK runs the platform test framework headless — no
  `jetbrainsRuntime()` dependency required and no JBR downloaded.
- The unpacked IDE lands **only** in the managed `.intellijPlatform/ides`
  directory; the Gradle `transforms/` cache contains no IDE.
- A warm managed IDE cache fully obviates the source ZIP download — Gradle never
  resolves it (confirmed: `compileTestJava` on a fresh Gradle home + warm managed
  cache downloaded 0 IDE zips).
- Cache size is modest: the unpacked IC-2025.1 tree compresses to ~0.87 GB with
  zstd (what `actions/cache` stores), smaller than the 0.95 GB source ZIP — both
  IDE cache entries together are ~2 GB, well within the 10 GB repository quota.

## To confirm in CI (not reproducible in the local sandbox)

- Windows/macOS 251 legs on ZIP + system JDK (only Linux validated locally).
- 262 on the released build (needs JDK 25 tooling; local sandbox is JDK 21).
- Cross-OS `actions/cache` restore of the OS-agnostic IDE entry on Windows/macOS.
  A bad restore degrades to a re-download, not a failure; the `df -h` steps report
  actual disk and cache sizes.
- Verify-job disk headroom without the reclaimer — the new `df -h` steps confirm
  it; re-add the reclaimer if it turns out to be tight.
