### PR TITLE
build: use full installer IDE for local dev (ZIP stays CI-only); bump 262 → 2026.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,9 @@ val javaTestCompanionPlugins = listOf(
 )
 
 val isCI = System.getenv("CI") == "true"
+// Make the IDE artifact choice explicit in build logs: CI uses the multi-OS ZIP (see the
+// intellijPlatform dependency block), local dev uses the complete OS-specific installer.
+logger.lifecycle("IntelliJ Platform IDE artifact: ${if (isCI) "multi-OS ZIP (CI)" else "installer (local)"}")
 val agentOutputPath = rootProject.layout.buildDirectory.asFile.get()
     .resolve("appmap-java-agent")
     .resolve("appmap-agent.jar")
@@ -89,14 +92,19 @@ allprojects {
     val testOutput = configurations.create("testOutput")
     dependencies {
         intellijPlatform {
-            // Use the cross-platform (multi-OS) ZIP distribution instead of the OS-specific
-            // installer, so the downloaded IDE can be cached once and shared across all OS
-            // runners. The ZIP bundles no JBR; tests run on the environment JDK (setup-java
-            // on CI, system JDK locally).
+            // On CI, resolve the cross-platform (multi-OS) ZIP distribution so the downloaded
+            // IDE can be cached once and shared across all OS runners (see the IDE cache steps
+            // in .github/workflows/build.yml). The ZIP is an incomplete runtime distribution:
+            // it omits the JBR and some native components (JCEF, platform-daemon). That's fine
+            // for headless tests -- the JBR is resolved separately by Gradle (the OS-specific
+            // com.jetbrains:jbr artifact, kept in the Gradle cache, not the IDE cache), and the
+            // missing natives aren't exercised. Locally, use the OS-specific installer, which is
+            // a complete, runnable IDE (bundled JBR + JCEF + platform-daemon natives), so runIde
+            // works on recent (2026+) builds where the ZIP fails to launch.
             when {
                 // 2025.3+ is only available as a unified build
-                platformVersion >= 253 -> intellijIdea(ideVersion) { useInstaller = false }
-                else -> intellijIdeaCommunity(ideVersion) { useInstaller = false }
+                platformVersion >= 253 -> intellijIdea(ideVersion) { useInstaller = !isCI }
+                else -> intellijIdeaCommunity(ideVersion) { useInstaller = !isCI }
             }
 
             // using "Bundled" to gain access to the Java plugin's test classes
@@ -353,10 +361,10 @@ project(":") {
                 // Versions come from gradle-<platform>.properties (single source of truth,
                 // shared with the build platform) via ideVersionFor().
                 create(IntelliJPlatformType.IntellijIdeaCommunity, ideVersionFor(251)) {
-                    useInstaller = false // earliest supported; ZIP to reuse the build's cached IDE
+                    useInstaller = !isCI // earliest supported; match the build's IDE artifact (ZIP on CI)
                 }
                 create(IntelliJPlatformType.IntellijIdea, ideVersionFor(262)) {
-                    useInstaller = false // latest released; ZIP to reuse the build's cached IDE
+                    useInstaller = !isCI // latest released; match the build's IDE artifact (ZIP on CI)
                 }
             }
 

--- a/gradle-262.properties
+++ b/gradle-262.properties
@@ -1,1 +1,1 @@
-ideVersion=2026.2.0.1
+ideVersion=2026.2.1


### PR DESCRIPTION
## Summary

Resolve the IntelliJ Platform IDE per environment: keep the cross-platform (multi-OS) **ZIP** on CI, but use the complete OS-specific **installer** for local development so `runIde` works on recent (2026+) builds. Also bump the 262 target to the released `2026.2.1`.

## Background

The build resolves the IntelliJ Platform as the multi-OS ZIP distribution (`useInstaller = false`), introduced so CI can cache one OS-agnostic IDE and share it across all runners. That's ideal for headless CI tests, but the ZIP is an **incomplete runtime**: it bundles no JBR and omits native components — notably JCEF and the 2026 platform-daemon. On 2026+ builds this breaks local `runIde`:

- JCEF: `SEVERE - #c.i.u.j.StartupTest - Startup JCEF test is failed (because CefApp wasn't initialized)`
- platform-daemon: `NoSuchFileException: .../plugins/platform-daemon-plugin/jetbrainsd_linux_x86_64.tar.gz`

Comparing an installer- vs ZIP-extracted IDE on disk confirmed the root cause: the installer ships a bundled `jbr/` and the `jetbrainsd_*` daemon native; the ZIP ships neither. The JBR is resolved separately by Gradle (the OS-specific `com.jetbrains:jbr` artifact, kept in the Gradle cache, not the IDE cache), so it can't backfill the missing native components — only the installer is whole.

## Changes

- **`useInstaller = !isCI`** for both the build platform and the plugin-verifier IDEs, so they stay consistent within each environment.
- **Log the chosen artifact** at configuration time (`IntelliJ Platform IDE artifact: multi-OS ZIP (CI)` / `installer (local)`), so the selection is visible in build output rather than silent.
- **Bump 262** test/verify target to the released `2026.2.1`.

## Why this is safe on CI

- `isCI` keys on the `CI` environment variable, which GitHub Actions [always sets to `true`](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) and no workflow here overrides. CI continues to resolve the ZIP — no change to the IDE caching setup or the workflows.
- The plugin is compiled against the same platform API in either distribution, so `buildPlugin` / `publishPlugin` are unaffected.

## Testing

- `runIde` verified locally on both 251 and 262 (`2026.2.1`): JCEF and the platform-daemon start correctly with the installer.
- Build script compiles; the config-time log prints once and reads `installer (local)` locally.

## Note for developers

If you previously ran the ZIP locally, remove the stale ZIP-extracted IDE dir once so the installer re-populates (the managed-cache dir name is identical for both artifacts), e.g.:

```
rm -rf .intellijPlatform/ides/IU-2026.2.1
```

Assisted-by: Claude:claude-opus-4-8
